### PR TITLE
Fix npe and add tests to cover for core/next pkg

### DIFF
--- a/pkg/networkservice/common/authorize/server_test.go
+++ b/pkg/networkservice/common/authorize/server_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"

--- a/pkg/networkservice/core/next/client.go
+++ b/pkg/networkservice/core/next/client.go
@@ -50,7 +50,7 @@ func NewWrappedNetworkServiceClient(wrapper ClientWrapper, clients ...networkser
 
 // NewNetworkServiceClient - chains together clients into a single networkservice.NetworkServiceClient
 func NewNetworkServiceClient(clients ...networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
-	return NewWrappedNetworkServiceClient(notWrap, clients...)
+	return NewWrappedNetworkServiceClient(notWrapClient, clients...)
 }
 
 func (n *nextClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*connection.Connection, error) {
@@ -67,6 +67,6 @@ func (n *nextClient) Close(ctx context.Context, conn *connection.Connection, opt
 	return n.clients[n.index].Close(withNextClient(ctx, newTailClient()), conn, opts...)
 }
 
-func notWrap(c networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
+func notWrapClient(c networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
 	return c
 }

--- a/pkg/networkservice/core/next/server.go
+++ b/pkg/networkservice/core/next/server.go
@@ -50,7 +50,7 @@ func NewWrappedNetworkServiceServer(wrapper ServerWrapper, servers ...networkser
 // NewNetworkServiceServer - chains together servers while providing them with the correct next.Server(ctx) to call to
 // invoke the next element in the chain.
 func NewNetworkServiceServer(servers ...networkservice.NetworkServiceServer) networkservice.NetworkServiceServer {
-	return NewWrappedNetworkServiceServer(nil, servers...)
+	return NewWrappedNetworkServiceServer(notWrapServer, servers...)
 }
 
 func (n *nextServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
@@ -65,4 +65,8 @@ func (n *nextServer) Close(ctx context.Context, conn *connection.Connection) (*e
 		return n.servers[n.index].Close(withNextServer(ctx, &nextServer{servers: n.servers, index: n.index + 1}), conn)
 	}
 	return n.servers[n.index].Close(withNextServer(ctx, newTailServer()), conn)
+}
+
+func notWrapServer(server networkservice.NetworkServiceServer) networkservice.NetworkServiceServer {
+	return server
 }


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

NPE:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x9817b7]

goroutine 50 [running]:
testing.tRunner.func1(0xc00022c100)
	/usr/local/go/src/testing/testing.go:874 +0x3a3
panic(0xa1eba0, 0x1002630)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress.(*setVppMacServer).Request(0x10349d8, 0xbc1900, 0xc00014e7b0, 0xc0001f27c0, 0xa24460, 0x10349d8, 0xbc1900)
	/home/user/go/src/github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/server.go:65 +0xd7
github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextServer).Request(0xc0001542e0, 0xbc1900, 0xc00014e780, 0xc0001f27c0, 0xbb76a0, 0xc0001542e0, 0x349)
	/home/user/go/src/github.com/networkservicemesh/sdk/pkg/networkservice/core/next/server.go:60 +0xd6
github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress.TestServerBasic(0xc00022c100)
	/home/user/go/src/github.com/networkservicemesh/sdk-vppagent/pkg/networkservice/connectioncontextkernel/ethernetcontext/macaddress/server_test.go:43 +0x352
testing.tRunner(0xc00022c100, 0xb15060)
	/usr/local/go/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:960 +0x350

```

Code coverage:
![Screenshot from 2020-01-23 15-18-52](https://user-images.githubusercontent.com/49399980/72967720-8ae80f00-3df4-11ea-8340-e75db2e6fff0.png)
