### PR TITLE
Fix so we only push downstream on changes to master branch

### DIFF
--- a/.github/workflows/update-sdk-kernel.yaml
+++ b/.github/workflows/update-sdk-kernel.yaml
@@ -1,6 +1,9 @@
 ---
 name: Update sdk-kernel
-on: push
+on:
+  push:
+    branches:
+      - master
 jobs:
   update-sdk-kernel:
     name: Update sdk-kernel

--- a/.github/workflows/update-sdk-vppagent.yaml
+++ b/.github/workflows/update-sdk-vppagent.yaml
@@ -1,6 +1,10 @@
 ---
 name: Update sdk-vppagent
-on: push
+on:
+  push:
+    branches:
+      - master
+
 jobs:
   update-sdk-vppagent:
     name: Update sdk-vppagent


### PR DESCRIPTION
Now that we have update/* branches coming in, need to limit downstream branch to things coming in on master