### PR TITLE
Change from go version 1.13 -> 1.13.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
       - run: |
           go build -race  ./...
   test:
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
       - name: Install gotestsum
         run: go get gotest.tools/gotestsum@v0.4.0
       - name: Run tests
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
       - run: go mod tidy
       - name: Check for changes in go.mod or go.sum
         run: |
@@ -101,7 +101,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
       - name: Install go-header
         run: 'go get github.com/denis-tingajkin/go-header@v0.2.1'
       - name: Run go-header

--- a/.github/workflows/update-sdk-kernel.yaml
+++ b/.github/workflows/update-sdk-kernel.yaml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
       - name: Update sdk locally
         run: |
           go get -u github.com/networkservicemesh/sdk

--- a/.github/workflows/update-sdk-vppagent.yaml
+++ b/.github/workflows/update-sdk-vppagent.yaml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.13.4
       - name: Update sdk locally
         run: |
           go get -u github.com/networkservicemesh/sdk


### PR DESCRIPTION
This is because it looks like go 1.13 doesn't properly
handle

go get -u

when updating modules (should also update dependencies)

where as go 1.13.4 (tested locally) does.