### PR TITLE
Use GOPROXY=direct for update-*.yaml

### DIFF
--- a/.github/workflows/update-sdk-kernel.yaml
+++ b/.github/workflows/update-sdk-kernel.yaml
@@ -19,7 +19,7 @@ jobs:
           go-version: 1.13.4
       - name: Update sdk locally
         run: |
-          go get -u github.com/networkservicemesh/sdk
+          GOPROXY=direct go get -u github.com/networkservicemesh/sdk
           go mod tidy
           git diff
       - name: Push update to sdk-kernel

--- a/.github/workflows/update-sdk-vppagent.yaml
+++ b/.github/workflows/update-sdk-vppagent.yaml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.13.4
       - name: Update sdk locally
         run: |
-          go get -u github.com/networkservicemesh/sdk
+          GOPROXY=direct go get -u github.com/networkservicemesh/sdk
           go mod tidy
           git diff
       - name: Push update to sdk-vppagent


### PR DESCRIPTION
Turns out that sometimes the google go module proxy isn't
quick about getting updated from github.com. Since obviously
we want to get this right, we use GOPROXY=direct to force
it to go to the direct source.