### PR TITLE
Add client dial options to `connectServer`

### DIFF
--- a/pkg/networkservice/common/connect/server.go
+++ b/pkg/networkservice/common/connect/server.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
 // Copyright (c) 2020 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -29,7 +31,7 @@ import (
 
 type connectServer struct {
 	ctx                     context.Context
-	dialOptionsSupplier     func() []grpc.DialOption
+	dialOptions             []grpc.DialOption
 	clientFactory           func(ctx context.Context, conn grpc.ClientConnInterface) networkservice.NetworkServiceClient
 	uRLToClientMap          clientMap // key == url as string
 	connectionIDToClientMap clientMap // key == connection.GetId()
@@ -44,18 +46,13 @@ type connectServer struct {
 //                             before returning to the server.
 //             connect presumes depends on some previous chain element having set clienturl.WithClientURL so it can know
 //             which client to address.
-func NewServer(clientFactory func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient) networkservice.NetworkServiceServer {
-	return NewServerWithDialOptions(clientFactory, func() []grpc.DialOption { return nil })
-}
-
-// NewServerWithDialOptions - returns a new connect Server with specific client dial options
-func NewServerWithDialOptions(clientFactory func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient, dialOptionsSupplier func() []grpc.DialOption) networkservice.NetworkServiceServer {
+func NewServer(clientFactory func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient, clientDialOptions ...grpc.DialOption) networkservice.NetworkServiceServer {
 	return &connectServer{
 		ctx:                     nil,
 		clientFactory:           clientFactory,
 		uRLToClientMap:          newClientMap(),
 		connectionIDToClientMap: newClientMap(),
-		dialOptionsSupplier:     dialOptionsSupplier,
+		dialOptions:             clientDialOptions,
 	}
 }
 
@@ -75,7 +72,7 @@ func (c *connectServer) Request(ctx context.Context, request *networkservice.Net
 	// TODO - fix to accept dialOptions from github.com/networkservicemesh/sdk/tools/security - the options should flow in from the top
 	// TODO - fix to accept a mockable interface we can pass in from the top other than DialContext
 	// TODO - fix to be cautious about schemes
-	cc, err := grpc.DialContext(clientCtx, u.String(), c.dialOptionsSupplier()...)
+	cc, err := grpc.DialContext(clientCtx, u.String(), c.dialOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +98,7 @@ func (c *connectServer) Close(ctx context.Context, conn *networkservice.Connecti
 	// TODO - fix to accept dialOptions from github.com/networkservicemesh/sdk/tools/security - the options should flow in from the top
 	// TODO - fix to accept a mockable interface we can pass in from the top other than DialContext
 	// TODO - fix to be cautious about schemes
-	cc, err := grpc.DialContext(clientCtx, u.String(), c.dialOptionsSupplier()...)
+	cc, err := grpc.DialContext(clientCtx, u.String(), c.dialOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

It could help to write tests that depend on `connect` package. 
For example to testing `directmemif` package.