### PR TITLE
Metrics monitor

### DIFF
--- a/pkg/networkservice/common/metrics/context.go
+++ b/pkg/networkservice/common/metrics/context.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+)
+
+const (
+	metricsMonitorKey contextKeyType = "MetricsMonitor"
+)
+
+type contextKeyType string
+
+// WithServer -
+//    Wraps 'parent' in a new Context that has the metrics monitor
+func WithServer(parent context.Context, monitor MetricsMonitor) context.Context {
+	if parent == nil {
+		parent = context.TODO()
+	}
+	return context.WithValue(parent, metricsMonitorKey, monitor)
+}
+
+// Server -
+//   Returns the MetricsMonitor
+func Server(ctx context.Context) MetricsMonitor {
+	if rv, ok := ctx.Value(metricsMonitorKey).(MetricsMonitor); ok {
+		return rv
+	}
+	return nil
+}

--- a/pkg/networkservice/common/metrics/metrics_monitor.go
+++ b/pkg/networkservice/common/metrics/metrics_monitor.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+// MetricsMonitor - extension to monitor service to pass metrics into MonitorServer recipients.
+// monitor will send events with configured with connection interval, often updates will wait for
+// next interval approaching before will be sended.
+type MetricsMonitor interface {
+	// HandleMetrics - send update to current segment metrics
+	HandleMetrics(metrics map[string]string)
+}

--- a/pkg/networkservice/common/metrics/server.go
+++ b/pkg/networkservice/common/metrics/server.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2020 Cisco Systems, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package monitor provides a NetworkServiceServer chain element to provide a monitor server that reflects
+// the connections actually in the NetworkServiceServer
+package metrics
+
+import (
+	"context"
+	"errors"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/monitor"
+	"github.com/networkservicemesh/sdk/pkg/tools/serialize"
+	"github.com/sirupsen/logrus"
+	"runtime"
+	"time"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+type metricsServer struct {
+	metrics   map[string]*metricsMonitor
+	executor  serialize.Executor
+	finalized chan struct{}
+}
+
+type metricsMonitor struct {
+	connection *networkservice.Connection
+	index      uint32
+	metrics    *networkservice.Metrics
+	interval   time.Duration
+	enabled    bool
+	server     networkservice.MonitorConnection_MonitorConnectionsServer
+	executor   serialize.Executor
+	networkservice.MonitorConnection_MonitorConnectionsServer
+	lastSend time.Time
+}
+
+// NewServer - creates a NetworkServiceServer chain element that will properly hold and periodically send metrics to passed MonitorServer
+func NewServer() networkservice.NetworkServiceServer {
+	rv := &metricsServer{
+		metrics:   make(map[string]*metricsMonitor),
+		executor:  serialize.NewExecutor(),
+		finalized: make(chan struct{}),
+	}
+	runtime.SetFinalizer(rv, func(server *metricsServer) {
+		close(server.finalized)
+	})
+	return rv
+}
+
+func (m *metricsServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	monitorServer := monitor.Server(ctx)
+	if monitorServer == nil {
+		return nil, errors.New("Metrics chain require monitor.Server to be passed")
+	}
+
+	// Pass metrics monitor, so it could be used later in chain.
+	metricsMonitor := m.newMetricsMonitor(request.GetConnection(), monitorServer)
+	ctx = WithServer(ctx, metricsMonitor)
+
+	// We need to hook for Send() events to process upcoming monitoring events.
+	ctx = monitor.WithServer(ctx, metricsMonitor)
+
+	return next.Server(ctx).Request(ctx, request)
+}
+
+func (m *metricsServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	// Pass metrics monitor, so it could be used later in chain.
+	var metricsMon *metricsMonitor
+	m.executor.SyncExec(func() {
+		metricsMon = m.metrics[conn.GetId()]
+		ctx = WithServer(ctx, metricsMon)
+	})
+	empty, err := next.Server(ctx).Close(ctx, conn)
+	m.executor.AsyncExec(func() {
+		delete(m.metrics, conn.GetId())
+	})
+	return empty, err
+}
+
+/**
+configureMonitor - cancel previous go routine with metrics sending for this connection and trigger new one if required.
+*/
+func (m *metricsMonitor) configureMonitor(conn *networkservice.Connection) {
+	m.interval = time.Second * 5 // Default interval is 5 seconds
+	m.enabled = false
+	// If enabled or not specified
+	if conn.Context.MetricsContext != nil && conn.Context.MetricsContext.Enabled {
+		m.enabled = true
+		intvalue := conn.Context.MetricsContext.Interval
+		if intvalue > 0 {
+			m.interval = time.Duration(intvalue)
+		}
+	}
+	// Build segments
+	m.metrics = &networkservice.Metrics{
+		MetricsSegment: []*networkservice.MetricsSegment{},
+	}
+	m.updateMetricsPath(m.metrics, conn)
+	m.lastSend = time.Now()
+}
+
+func (m *metricsServer) newMetricsMonitor(conn *networkservice.Connection, monitorServer networkservice.MonitorConnection_MonitorConnectionsServer) (result *metricsMonitor) {
+	m.executor.SyncExec(func() {
+		result = m.metrics[conn.GetId()]
+		if result == nil {
+			result = &metricsMonitor{
+				connection: conn,
+				server:     monitorServer,
+				executor:   m.executor,
+				index:      conn.GetPath().GetIndex(),
+			}
+			m.metrics[conn.GetId()] = result
+		}
+		// Re configure monitor
+		result.configureMonitor(conn)
+	})
+	return result
+}
+
+func (m *metricsServer) collectMetrics() map[string]*networkservice.Metrics {
+	result := map[string]*networkservice.Metrics{}
+	for _, m := range m.metrics {
+		result[m.connection.GetId()] = m.metrics
+	}
+	return result
+}
+
+/**
+HandleMetrics - update metrics for current connection and current segment index.
+*/
+func (m *metricsMonitor) HandleMetrics(metrics map[string]string) {
+	m.executor.AsyncExec(func() {
+		// Put curMetrics
+		// We need to construct curMetrics segments to be same as connection ones.
+		m.updateMetricsPath(m.metrics, m.connection)
+		// replace curMetrics segment curMetrics
+		m.metrics.MetricsSegment[m.index].Metrics = metrics
+
+		// Next triggered event will send update and if enabled
+		if m.enabled && time.Now().Sub(m.lastSend) > m.interval {
+			m.lastSend = time.Now()
+			event := &networkservice.ConnectionEvent{
+				Type:    networkservice.ConnectionEventType_UPDATE,
+				Metrics: map[string]*networkservice.Metrics{m.connection.GetId(): m.metrics},
+			}
+			m.server.Send(event)
+		}
+	})
+}
+
+func (m *metricsMonitor) updateMetricsPath(curMetrics *networkservice.Metrics, conn *networkservice.Connection) {
+	for len(curMetrics.MetricsSegment) < len(conn.Path.PathSegments) {
+		newIdx := len(curMetrics.MetricsSegment)
+		curMetrics.MetricsSegment = append(curMetrics.MetricsSegment, &networkservice.MetricsSegment{
+			Id:   conn.Path.PathSegments[newIdx].Id,
+			Name: conn.Path.PathSegments[newIdx].Name,
+		})
+	}
+}
+
+func (m *metricsMonitor) Send(event *networkservice.ConnectionEvent) error {
+	m.executor.AsyncExec(func() {
+		// Update connection object if passed
+		hasConnection := false
+		if conn, ok := event.Connections[m.connection.GetId()]; ok {
+			m.connection = conn
+			hasConnection = true
+		}
+		// If event had metrics, we need to update them and send only of interval is passed.
+		if metricEvt, ok := event.Metrics[m.connection.GetId()]; ok {
+			// We need to be sure we replace current metrics with new ones.
+			m.updateMetricsPath(m.metrics, m.connection)
+			if len(metricEvt.MetricsSegment) >= len(m.metrics.MetricsSegment) {
+				m.metrics.MetricsSegment = append(m.metrics.MetricsSegment[0:m.index], metricEvt.MetricsSegment[m.index:len(metricEvt.MetricsSegment)]...)
+			}
+			// Delete event from metrics
+			delete(event.Metrics, m.connection.GetId())
+		}
+
+		// If connection update is coming, we need to add our collected metrics in any case.
+		// Or we have interval passed so we need to send update
+		if m.enabled && (hasConnection || time.Now().Sub(m.lastSend) > m.interval) {
+			event.Metrics[m.connection.GetId()] = m.metrics
+			m.lastSend = time.Now()
+		}
+
+		// Just pass event to next sender
+		if err := m.server.Send(event); err != nil {
+			logrus.Errorf("Failed to send event to Monitor.Server %v", err)
+		}
+	})
+	return nil
+}

--- a/pkg/networkservice/common/metrics/server.go
+++ b/pkg/networkservice/common/metrics/server.go
@@ -21,15 +21,14 @@ package metrics
 import (
 	"context"
 	"errors"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/monitor"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/serialize"
 	"github.com/sirupsen/logrus"
 	"runtime"
-	"time"
-
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 )
 
 type metricsServer struct {
@@ -41,13 +40,10 @@ type metricsServer struct {
 type metricsMonitor struct {
 	connection *networkservice.Connection
 	index      uint32
-	metrics    *networkservice.Metrics
-	interval   time.Duration
-	enabled    bool
 	server     networkservice.MonitorConnection_MonitorConnectionsServer
 	executor   serialize.Executor
 	networkservice.MonitorConnection_MonitorConnectionsServer
-	lastSend time.Time
+	enabled bool
 }
 
 // NewServer - creates a NetworkServiceServer chain element that will properly hold and periodically send metrics to passed MonitorServer
@@ -73,54 +69,44 @@ func (m *metricsServer) Request(ctx context.Context, request *networkservice.Net
 	metricsMonitor := m.newMetricsMonitor(request.GetConnection(), monitorServer)
 	ctx = WithServer(ctx, metricsMonitor)
 
-	// We need to hook for Send() events to process upcoming monitoring events.
 	ctx = monitor.WithServer(ctx, metricsMonitor)
 
-	return next.Server(ctx).Request(ctx, request)
+	conn, err := next.Server(ctx).Request(ctx, request)
+	if err == nil {
+		m.executor.SyncExec(func() {
+			metricsMonitor.updateConnection(conn)
+		})
+		m.executor.AsyncExec(func() {
+			metricsMonitor.sendCurrentMetricsEvent()
+		})
+	}
+	return conn, err
 }
 
 func (m *metricsServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
 	// Pass metrics monitor, so it could be used later in chain.
-	var metricsMon *metricsMonitor
 	m.executor.SyncExec(func() {
-		metricsMon = m.metrics[conn.GetId()]
-		ctx = WithServer(ctx, metricsMon)
+		metricsMon := m.metrics[conn.GetId()]
+		if metricsMon != nil {
+			ctx = WithServer(ctx, metricsMon)
+		}
 	})
-	empty, err := next.Server(ctx).Close(ctx, conn)
+
+	empt, err := next.Server(ctx).Close(ctx, conn)
+
 	m.executor.AsyncExec(func() {
 		delete(m.metrics, conn.GetId())
 	})
-	return empty, err
-}
 
-/**
-configureMonitor - cancel previous go routine with metrics sending for this connection and trigger new one if required.
-*/
-func (m *metricsMonitor) configureMonitor(conn *networkservice.Connection) {
-	m.interval = time.Second * 5 // Default interval is 5 seconds
-	m.enabled = false
-	// If enabled or not specified
-	if conn.Context.MetricsContext != nil && conn.Context.MetricsContext.Enabled {
-		m.enabled = true
-		intvalue := conn.Context.MetricsContext.Interval
-		if intvalue > 0 {
-			m.interval = time.Duration(intvalue)
-		}
-	}
-	// Build segments
-	m.metrics = &networkservice.Metrics{
-		MetricsSegment: []*networkservice.MetricsSegment{},
-	}
-	m.updateMetricsPath(m.metrics, conn)
-	m.lastSend = time.Now()
+	return empt, err
 }
-
 func (m *metricsServer) newMetricsMonitor(conn *networkservice.Connection, monitorServer networkservice.MonitorConnection_MonitorConnectionsServer) (result *metricsMonitor) {
+	// New metrics lock for writing.
 	m.executor.SyncExec(func() {
 		result = m.metrics[conn.GetId()]
 		if result == nil {
 			result = &metricsMonitor{
-				connection: conn,
+				connection: proto.Clone(conn).(*networkservice.Connection),
 				server:     monitorServer,
 				executor:   m.executor,
 				index:      conn.GetPath().GetIndex(),
@@ -128,16 +114,9 @@ func (m *metricsServer) newMetricsMonitor(conn *networkservice.Connection, monit
 			m.metrics[conn.GetId()] = result
 		}
 		// Re configure monitor
-		result.configureMonitor(conn)
+		result.enabled = conn.Context.MetricsContext != nil && conn.Context.MetricsContext.Enabled
 	})
-	return result
-}
 
-func (m *metricsServer) collectMetrics() map[string]*networkservice.Metrics {
-	result := map[string]*networkservice.Metrics{}
-	for _, m := range m.metrics {
-		result[m.connection.GetId()] = m.metrics
-	}
 	return result
 }
 
@@ -148,62 +127,43 @@ func (m *metricsMonitor) HandleMetrics(metrics map[string]string) {
 	m.executor.AsyncExec(func() {
 		// Put curMetrics
 		// We need to construct curMetrics segments to be same as connection ones.
-		m.updateMetricsPath(m.metrics, m.connection)
 		// replace curMetrics segment curMetrics
-		m.metrics.MetricsSegment[m.index].Metrics = metrics
+		m.connection.Path.PathSegments[m.index].Metrics = metrics
 
-		// Next triggered event will send update and if enabled
-		if m.enabled && time.Now().Sub(m.lastSend) > m.interval {
-			m.lastSend = time.Now()
-			event := &networkservice.ConnectionEvent{
-				Type:    networkservice.ConnectionEventType_UPDATE,
-				Metrics: map[string]*networkservice.Metrics{m.connection.GetId(): m.metrics},
-			}
-			m.server.Send(event)
+		// Send to previous monitor if enabled
+		if m.enabled {
+			m.sendCurrentMetricsEvent()
 		}
 	})
 }
 
-func (m *metricsMonitor) updateMetricsPath(curMetrics *networkservice.Metrics, conn *networkservice.Connection) {
-	for len(curMetrics.MetricsSegment) < len(conn.Path.PathSegments) {
-		newIdx := len(curMetrics.MetricsSegment)
-		curMetrics.MetricsSegment = append(curMetrics.MetricsSegment, &networkservice.MetricsSegment{
-			Id:   conn.Path.PathSegments[newIdx].Id,
-			Name: conn.Path.PathSegments[newIdx].Name,
-		})
+func (m *metricsMonitor) sendCurrentMetricsEvent() {
+	event := &networkservice.ConnectionEvent{
+		Type:        networkservice.ConnectionEventType_UPDATE,
+		Connections: map[string]*networkservice.Connection{m.connection.GetId(): m.connection},
+	}
+	if err := m.server.Send(event); err != nil {
+		logrus.Errorf("Failed to send event to Monitor.Server %v", err)
 	}
 }
 
 func (m *metricsMonitor) Send(event *networkservice.ConnectionEvent) error {
 	m.executor.AsyncExec(func() {
 		// Update connection object if passed
-		hasConnection := false
 		if conn, ok := event.Connections[m.connection.GetId()]; ok {
-			m.connection = conn
-			hasConnection = true
+			m.updateConnection(conn)
 		}
-		// If event had metrics, we need to update them and send only of interval is passed.
-		if metricEvt, ok := event.Metrics[m.connection.GetId()]; ok {
-			// We need to be sure we replace current metrics with new ones.
-			m.updateMetricsPath(m.metrics, m.connection)
-			if len(metricEvt.MetricsSegment) >= len(m.metrics.MetricsSegment) {
-				m.metrics.MetricsSegment = append(m.metrics.MetricsSegment[0:m.index], metricEvt.MetricsSegment[m.index:len(metricEvt.MetricsSegment)]...)
-			}
-			// Delete event from metrics
-			delete(event.Metrics, m.connection.GetId())
-		}
-
-		// If connection update is coming, we need to add our collected metrics in any case.
-		// Or we have interval passed so we need to send update
-		if m.enabled && (hasConnection || time.Now().Sub(m.lastSend) > m.interval) {
-			event.Metrics[m.connection.GetId()] = m.metrics
-			m.lastSend = time.Now()
-		}
-
 		// Just pass event to next sender
 		if err := m.server.Send(event); err != nil {
 			logrus.Errorf("Failed to send event to Monitor.Server %v", err)
 		}
 	})
 	return nil
+}
+
+func (m *metricsMonitor) updateConnection(conn *networkservice.Connection) {
+	// We need to preserve current index metrics, since only we provide it.
+	currentMetrics := m.connection.GetPath().GetPathSegments()[m.index].Metrics
+	conn.GetPath().GetPathSegments()[m.index].Metrics = currentMetrics
+	m.connection = proto.Clone(conn).(*networkservice.Connection)
 }

--- a/pkg/networkservice/common/metrics/server_test.go
+++ b/pkg/networkservice/common/metrics/server_test.go
@@ -1,0 +1,190 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/monitor"
+	"github.com/sirupsen/logrus"
+	"testing"
+	"time"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
+	"github.com/stretchr/testify/require"
+)
+
+type metricMonitorHolder struct {
+	index int
+	networkservice.MonitorConnection_MonitorConnectionsServer
+	events       []*networkservice.ConnectionEvent
+	monitor      MetricsMonitor
+	server       networkservice.MonitorConnection_MonitorConnectionsServer
+	eventChannel chan *networkservice.ConnectionEvent
+}
+
+func (t *metricMonitorHolder) Send(event *networkservice.ConnectionEvent) error {
+	t.events = append(t.events, event)
+	t.eventChannel <- event
+	return nil
+}
+
+func newMetricMonitorHolder() *metricMonitorHolder {
+	return &metricMonitorHolder{
+		index:        0,
+		eventChannel: make(chan *networkservice.ConnectionEvent, 100),
+	}
+}
+
+func (t *metricMonitorHolder) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	t.index += 1
+	t.monitor = Server(ctx)
+	t.server = monitor.Server(ctx)
+
+	request.GetConnection().Labels = make(map[string]string)
+	request.GetConnection().Labels["lastUpdate"] = fmt.Sprintf("%v %v", t.index, time.Now())
+	return request.GetConnection(), nil
+}
+
+func (t *metricMonitorHolder) Close(context.Context, *networkservice.Connection) (*empty.Empty, error) {
+	return &empty.Empty{}, nil
+}
+
+func (t *metricMonitorHolder) WaitEvents(ctx context.Context, count int) {
+	for {
+		if len(t.events) == count {
+			logrus.Infof("Waiting for events %v, but has %v", count, len(t.events))
+			break
+		}
+		// Wait 10ms for listeners to activate
+		select {
+		case <-ctx.Done():
+			// Context is done, we need to exit
+			logrus.Errorf("Failed to wait for events count %v current value is: %v", count, len(t.events))
+			return
+		case <-t.eventChannel:
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+func TestSendMetrics(t *testing.T) {
+	ctx := context.Background()
+
+	timeoutCtx, _ := context.WithTimeout(context.Background(), time.Second*5)
+
+	ms := NewServer()
+	mons, ok := ms.(*metricsServer)
+	require.Equal(t, true, ok)
+
+	holder := newMetricMonitorHolder()
+
+	srv := next.NewWrappedNetworkServiceServer(trace.NewNetworkServiceServer, ms, holder)
+
+	// Add first connection and check right listener has event
+	// After it will think connection is established.
+	nsr := &networkservice.NetworkServiceRequest{
+		Connection: createConnection("id0", 1, []string{"local-nsm", "remote-nsm"}, int64(1 * time.Millisecond)),
+	}
+
+	ctx = monitor.WithServer(ctx, holder)
+	_, _ = srv.Request(ctx, nsr)
+	// Now we could check monitoring routine's are working fine.
+	require.Equal(t, len(mons.metrics), 1)
+
+	<-time.After(1 * time.Millisecond)
+	holder.monitor.HandleMetrics(map[string]string{
+		"rx": "100",
+		"wx": "100",
+	})
+
+	holder.WaitEvents(timeoutCtx, 1)
+	require.Equal(t, len(holder.events), 1)
+
+	require.NotNil(t, holder.events[0].Metrics)
+
+	m := holder.events[0].Metrics["id0"]
+	require.Equal(t, m.MetricsSegment[0].Name, "local-nsm")
+	require.Nil(t, m.MetricsSegment[0].Metrics)
+
+	require.Equal(t, m.MetricsSegment[1].Name, "remote-nsm")
+	require.NotNil(t, m.MetricsSegment[1].Metrics)
+	require.Equal(t, len(m.MetricsSegment[1].Metrics), 2)
+}
+
+func TestIntervalSendMetrics(t *testing.T) {
+	ctx := context.Background()
+
+	//timeoutCtx, _ := context.WithTimeout(context.Background(), time.Second*5)
+
+	ms := NewServer()
+	mons, ok := ms.(*metricsServer)
+	require.Equal(t, true, ok)
+
+	holder := newMetricMonitorHolder()
+
+	srv := next.NewWrappedNetworkServiceServer(trace.NewNetworkServiceServer, ms, holder)
+
+	// Add first connection and check right listener has event
+	// After it will think connection is established.
+	nsr := &networkservice.NetworkServiceRequest{
+		Connection: createConnection("id0", 1, []string{"local-nsm", "remote-nsm"}, int64(5 * time.Hour)),
+	}
+
+	ctx = monitor.WithServer(ctx, holder)
+	_, _ = srv.Request(ctx, nsr)
+	// Now we could check monitoring routine's are working fine.
+	require.Equal(t, len(mons.metrics), 1)
+
+	<-time.After(1 * time.Millisecond)
+	holder.monitor.HandleMetrics(map[string]string{
+		"rx": "100",
+		"wx": "100",
+	})
+
+	// There is no event yet
+	require.Equal(t, len(holder.events), 0)
+
+	// but if we reqest again, we will have event send.
+	_, _ = srv.Request(ctx, nsr)
+	<- time.After(60 * time.Second)
+	require.NotNil(t, holder.events[0].Metrics)
+
+	m := holder.events[0].Metrics["id0"]
+	require.Equal(t, m.MetricsSegment[0].Name, "local-nsm")
+	require.Nil(t, m.MetricsSegment[0].Metrics)
+
+	require.Equal(t, m.MetricsSegment[1].Name, "remote-nsm")
+	require.NotNil(t, m.MetricsSegment[1].Metrics)
+	require.Equal(t, len(m.MetricsSegment[1].Metrics), 2)
+}
+
+
+func createConnection(id string, index uint32, segments []string, interval int64) *networkservice.Connection {
+	result := &networkservice.Connection{
+		Id: id,
+		Path: &networkservice.Path{
+			Index: index,
+			PathSegments: []*networkservice.PathSegment{
+			},
+		},
+		Context: &networkservice.ConnectionContext{
+			IpContext: &networkservice.IPContext{
+				SrcIpRequired: true,
+				DstIpRequired: true,
+			},
+			MetricsContext: &networkservice.MetricsContext{
+				Enabled:  true,
+				Interval: interval, // Make it really/ really small
+			},
+		},
+	}
+	for _, s := range segments {
+		result.Path.PathSegments = append(result.Path.PathSegments, &networkservice.PathSegment{
+			Id:   s,
+			Name: s,
+		})
+	}
+	return result
+}

--- a/pkg/networkservice/common/monitor/context.go
+++ b/pkg/networkservice/common/monitor/context.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"context"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+)
+
+const (
+	monitorServerKey contextKeyType = "Server"
+)
+
+type contextKeyType string
+
+// WithServer -
+//    Wraps 'parent' in a new Context that has the monitor server
+func WithServer(parent context.Context, monitor networkservice.MonitorConnection_MonitorConnectionsServer) context.Context {
+	if parent == nil {
+		parent = context.TODO()
+	}
+	return context.WithValue(parent, monitorServerKey, monitor)
+}
+
+// Server -
+//   Returns the Monitor Server
+func Server(ctx context.Context) networkservice.MonitorConnection_MonitorConnectionsServer {
+	if rv, ok := ctx.Value(monitorServerKey).(networkservice.MonitorConnection_MonitorConnectionsServer); ok {
+		return rv
+	}
+	return nil
+}

--- a/pkg/networkservice/common/monitor/filter.go
+++ b/pkg/networkservice/common/monitor/filter.go
@@ -32,27 +32,14 @@ func newMonitorFilter(selector *networkservice.MonitorScopeSelector, srv network
 	}
 }
 
-func (m *monitorFilter) Send(event *networkservice.ConnectionEvent, current map[string]*networkservice.Connection) error {
+func (m *monitorFilter) Send(event *networkservice.ConnectionEvent) error {
 	// Filter connections based on event passed and selector for this filter
 	rv := &networkservice.ConnectionEvent{
 		Type:        event.Type,
 		Connections: networkservice.FilterMapOnManagerScopeSelector(event.GetConnections(), m.selector),
-		Metrics:     filteredMetrics(event, networkservice.FilterMapOnManagerScopeSelector(current, m.selector)),
 	}
-	if rv.Type == networkservice.ConnectionEventType_INITIAL_STATE_TRANSFER || len(rv.GetConnections()) > 0 || len(rv.GetMetrics()) > 0 {
+	if rv.Type == networkservice.ConnectionEventType_INITIAL_STATE_TRANSFER || len(rv.GetConnections()) > 0  {
 		return m.srv.Send(rv)
 	}
 	return nil
-}
-
-func filteredMetrics(event *networkservice.ConnectionEvent, matchedConnections map[string]*networkservice.Connection) map[string]*networkservice.Metrics {
-	filteredMetrics := map[string]*networkservice.Metrics{}
-
-	// Put only relevant metrics
-	for k, v := range event.Metrics {
-		if _, ok := matchedConnections[k]; ok {
-			filteredMetrics[k] = v
-		}
-	}
-	return filteredMetrics
 }

--- a/pkg/networkservice/common/monitor/filter.go
+++ b/pkg/networkservice/common/monitor/filter.go
@@ -32,8 +32,9 @@ func newMonitorFilter(selector *networkservice.MonitorScopeSelector, srv network
 	}
 }
 
+// Send - Filter connections based on event passed and selector for this filter
 func (m *monitorFilter) Send(event *networkservice.ConnectionEvent) error {
-	// Filter connections based on event passed and selector for this filter
+
 	rv := &networkservice.ConnectionEvent{
 		Type:        event.Type,
 		Connections: networkservice.FilterMapOnManagerScopeSelector(event.GetConnections(), m.selector),

--- a/pkg/networkservice/common/monitor/server_test.go
+++ b/pkg/networkservice/common/monitor/server_test.go
@@ -3,108 +3,36 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/sdk/pkg/test/monitor"
 	"testing"
 	"time"
 
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/metadata"
-
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
 )
-
-type testMonitorServer struct {
-	events       []*networkservice.ConnectionEvent
-	eventChannel chan *networkservice.ConnectionEvent
-	ctx          context.Context
-	cancel       context.CancelFunc
-}
-
-func newTestMonitorServer() *testMonitorServer {
-	ctx, cancel := context.WithCancel(context.Background())
-	return &testMonitorServer{
-		eventChannel: make(chan *networkservice.ConnectionEvent, 10),
-		ctx:          ctx,
-		cancel:       cancel,
-	}
-}
-
-func (t *testMonitorServer) Send(evt *networkservice.ConnectionEvent) error {
-	t.events = append(t.events, evt)
-	t.eventChannel <- evt
-	return nil
-}
-
-func (t *testMonitorServer) SetHeader(metadata.MD) error {
-	return nil
-}
-
-func (t *testMonitorServer) SendHeader(metadata.MD) error {
-	return nil
-}
-
-func (t *testMonitorServer) SetTrailer(metadata.MD) {
-}
-
-func (t *testMonitorServer) Context() context.Context {
-	return t.ctx
-}
-
-func (t *testMonitorServer) SendMsg(m interface{}) error {
-	return nil
-}
-
-func (t *testMonitorServer) RecvMsg(m interface{}) error {
-	return nil
-}
-
-func (t *testMonitorServer) BeginMonitoring(server networkservice.MonitorConnectionServer, segmentName string) {
-	go func() {
-		_ = server.MonitorConnections(
-			&networkservice.MonitorScopeSelector{
-				PathSegments: []*networkservice.PathSegment{{Name: segmentName}},
-			}, t)
-	}()
-}
-
-func (t *testMonitorServer) WaitEvents(ctx context.Context, count int) {
-	for {
-		if len(t.events) == count {
-			logrus.Infof("Waiting for events %v, but has %v", count, len(t.events))
-			break
-		}
-		// Wait 10ms for listeners to activate
-		select {
-		case <-ctx.Done():
-			// Context is done, we need to exit
-			logrus.Errorf("Failed to wait for events count %v current value is: %v", count, len(t.events))
-			return
-		case <-t.eventChannel:
-		case <-time.After(1 * time.Second):
-		}
-	}
-}
 
 type myServer struct {
 	networkservice.MonitorConnectionServer
 }
 
 type updateConnServer struct {
-	requestFunc func(request *networkservice.NetworkServiceRequest) *networkservice.Connection
+	requestFunc func(ctx context.Context, request *networkservice.NetworkServiceRequest) *networkservice.Connection
 }
 
-func newUpdateConnServer(requestFunc func(request *networkservice.NetworkServiceRequest) *networkservice.Connection) *updateConnServer {
+func newUpdateConnServer(requestFunc func(ctx context.Context, request *networkservice.NetworkServiceRequest) *networkservice.Connection) *updateConnServer {
 	return &updateConnServer{
 		requestFunc: requestFunc,
 	}
 }
 
-func (t *updateConnServer) Request(_ context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	return t.requestFunc(request), nil
+func (t *updateConnServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	return t.requestFunc(ctx, request), nil
 }
 
 func (t *updateConnServer) Close(context.Context, *networkservice.Connection) (*empty.Empty, error) {
@@ -124,11 +52,11 @@ func TestMonitorSendToRightClient(t *testing.T) {
 
 	srv := next.NewWrappedNetworkServiceServer(trace.NewNetworkServiceServer, ms, updateEnv)
 
-	localMonitor := newTestMonitorServer()
-	remoteMonitor := newTestMonitorServer()
+	localMonitor := monitor.NewTestMonitorClient()
+	remoteMonitor := monitor.NewTestMonitorClient()
 	localMonitor.BeginMonitoring(myServer, "local-nsm")
 	remoteMonitor.BeginMonitoring(myServer, "remote-nsm")
-	// We need to be sure we have 2 clients waiting for events, we could check to have initial transfers for this.
+	// We need to be sure we have 2 clients waiting for Events, we could check to have initial transfers for this.
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*6000)
 	defer cancel()
 	// Wait for init messages in both monitors
@@ -136,8 +64,8 @@ func TestMonitorSendToRightClient(t *testing.T) {
 	remoteMonitor.WaitEvents(timeoutCtx, 1)
 	// Check we have 2 monitors
 	require.Equal(t, len(mons.monitors), 2)
-	require.Equal(t, 1, len(localMonitor.events))
-	require.Equal(t, 1, len(remoteMonitor.events))
+	require.Equal(t, 1, len(localMonitor.Events))
+	require.Equal(t, 1, len(remoteMonitor.Events))
 
 	// Add first connection and check right listener has event
 	// After it will think connection is established.
@@ -148,34 +76,36 @@ func TestMonitorSendToRightClient(t *testing.T) {
 	// Now we could check monitoring routine's are working fine.
 	// Wait for update message for first monitor
 	localMonitor.WaitEvents(timeoutCtx, 2)
-	require.Equal(t, 2, len(localMonitor.events))
-	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.events[1].Type)
+	require.Equal(t, 2, len(localMonitor.Events))
+	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.Events[1].Type)
 	// Check we have connection already
 	require.Equal(t, len(mons.connections), 1)
 	// Just dummy update
 	nsr.Connection.Context.IpContext.ExtraPrefixes = append(nsr.Connection.Context.IpContext.ExtraPrefixes, "10.2.3.1")
 	_, _ = srv.Request(ctx, nsr)
 	localMonitor.WaitEvents(timeoutCtx, 3)
-	require.Equal(t, 3, len(localMonitor.events))
-	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.events[2].Type)
+	require.Equal(t, 3, len(localMonitor.Events))
+	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.Events[2].Type)
 	// check delete event is working fine.
 	_, closeErr := srv.Close(ctx, nsr.Connection)
 	require.Nil(t, closeErr)
 	localMonitor.WaitEvents(timeoutCtx, 4)
 	// Last event should be delete
-	require.Equal(t, 4, len(localMonitor.events))
-	require.Equal(t, networkservice.ConnectionEventType_DELETE, localMonitor.events[3].Type)
+	require.Equal(t, 4, len(localMonitor.Events))
+	require.Equal(t, networkservice.ConnectionEventType_DELETE, localMonitor.Events[3].Type)
 	// Check connection is not longer inside map
 	require.Equal(t, len(mons.connections), 0)
 }
 
 func newUpdateTailServer(updateCounter int) *updateConnServer {
-	updateEnv := newUpdateConnServer(func(request *networkservice.NetworkServiceRequest) *networkservice.Connection {
+	updateEnv := newUpdateConnServer(func(ctx context.Context, request *networkservice.NetworkServiceRequest) *networkservice.Connection {
 		updateCounter++
-		if request.GetConnection().Labels == nil {
-			request.GetConnection().Labels = make(map[string]string)
+		connection := request.GetConnection()
+		if connection.Labels == nil {
+			connection.Labels = make(map[string]string)
 		}
-		request.GetConnection().Labels["lastOp"] = fmt.Sprintf("updates: %v time: %v", updateCounter, time.Now())
+		connection.Labels["lastOp"] = fmt.Sprintf("updates: %v time: %v", updateCounter, time.Now())
+
 		return request.GetConnection()
 	})
 	return updateEnv
@@ -194,18 +124,18 @@ func TestMonitorIsClosedProperly(t *testing.T) {
 
 	srv := next.NewWrappedNetworkServiceServer(trace.NewNetworkServiceServer, ms, updateEnv)
 
-	localMonitor := newTestMonitorServer()
+	localMonitor := monitor.NewTestMonitorClient()
 
 	localMonitor.BeginMonitoring(myServer, "local-nsm")
 
-	// We need to be sure we have 2 clients waiting for events, we could check to have initial transfers for this.
+	// We need to be sure we have 2 clients waiting for Events, we could check to have initial transfers for this.
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*6000)
 	defer cancel()
 
 	// Wait for init messages in both monitors
 	localMonitor.WaitEvents(timeoutCtx, 1)
-	require.Equal(t, 1, len(localMonitor.events))
+	require.Equal(t, 1, len(localMonitor.Events))
 
 	// Add first connection and check right listener has event
 	// After it will think connection is established.
@@ -218,14 +148,14 @@ func TestMonitorIsClosedProperly(t *testing.T) {
 	// Wait for update message for first monitor
 	localMonitor.WaitEvents(timeoutCtx, 2)
 
-	require.Equal(t, 2, len(localMonitor.events))
-	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.events[1].Type)
+	require.Equal(t, 2, len(localMonitor.Events))
+	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.Events[1].Type)
 
 	// Check we have connection already
 	require.Equal(t, len(mons.connections), 1)
 
 	// Cancel context for monitor
-	localMonitor.cancel()
+	localMonitor.Cancel()
 	// Just dummy update
 	nsr.Connection.Context.IpContext.ExtraPrefixes = append(nsr.Connection.Context.IpContext.ExtraPrefixes, "10.2.3.1")
 	_, _ = srv.Request(ctx, nsr)
@@ -247,6 +177,88 @@ func TestMonitorIsClosedProperly(t *testing.T) {
 	require.Equal(t, len(mons.monitors), 0)
 }
 
+func TestChainedIntervalSend(t *testing.T) {
+	myServer := &myServer{}
+
+	ctx := context.Background()
+	ms := NewServer(&myServer.MonitorConnectionServer)
+	mons, ok := ms.(*monitorServer)
+	require.Equal(t, true, ok)
+
+	updateCounter := 0
+	updateEnv := newUpdateTailServer(updateCounter)
+
+	srv := next.NewWrappedNetworkServiceServer(trace.NewNetworkServiceServer, ms, updateEnv)
+
+	localMonitor := monitor.NewTestMonitorClient()
+	localMonitor.BeginMonitoring(myServer, "local-nsm")
+	// We need to be sure we have 2 clients waiting for Events, we could check to have initial transfers for this.
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*6000)
+	defer cancel()
+	// Wait for init messages in both monitors
+	localMonitor.WaitEvents(timeoutCtx, 1)
+	// Check we have 2 monitors
+	require.Equal(t, len(mons.monitors), 1)
+	require.Equal(t, 1, len(localMonitor.Events))
+
+	// Add first connection and check right listener has event
+	// After it will think connection is established.
+	nsr := &networkservice.NetworkServiceRequest{
+		Connection: createConnection("id0", "local-nsm"),
+	}
+
+	conn, _ := srv.Request(ctx, nsr)
+	// Now we could check monitoring routine's are working fine.
+	// Wait for update message for first monitor
+	localMonitor.WaitEvents(timeoutCtx, 2)
+
+	mons.Send(&networkservice.ConnectionEvent{
+		Type: networkservice.ConnectionEventType_UPDATE,
+		Connections: map[string]*networkservice.Connection{
+			conn.GetId(): createMetrics(conn, "mx1"),
+		},
+	})
+	mons.Send(&networkservice.ConnectionEvent{
+		Type: networkservice.ConnectionEventType_UPDATE,
+		Connections: map[string]*networkservice.Connection{
+			conn.GetId(): createMetrics(conn, "mx2"),
+		},
+	})
+	mons.Send(&networkservice.ConnectionEvent{
+		Type: networkservice.ConnectionEventType_UPDATE,
+		Connections: map[string]*networkservice.Connection{
+			conn.GetId(): createMetrics(conn, "mx3"),
+		},
+	})
+	mons.executor.SyncExec(func() { /* Dummy */ })
+
+	localMonitor.WaitEvents(timeoutCtx, 3)
+	// Check we still have 3 Events, first since never send, and 2 metrics updates are in pending state.
+	require.Equal(t, 3, len(localMonitor.Events))
+
+	require.Equal(t, "mx1", localMonitor.Events[2].Connections[conn.GetId()].GetPath().GetPathSegments()[0].Metrics["mx:"])
+
+	// Check pending update is mx3
+	require.Equal(t, "mx3", mons.connections[conn.GetId()].connection.GetPath().GetPathSegments()[0].Metrics["mx:"])
+	require.Equal(t, 2, mons.connections[conn.GetId()].pendingUpdates)
+
+	conn, _ = srv.Request(ctx, nsr)
+	localMonitor.WaitEvents(timeoutCtx, 4)
+	require.Equal(t, "mx3", localMonitor.Events[3].Connections[conn.GetId()].GetPath().GetPathSegments()[0].Metrics["mx:"])
+}
+
+func createMetrics(conn *networkservice.Connection, mx string) *networkservice.Connection {
+	cpy := proto.Clone(conn).(*networkservice.Connection)
+	for pos, s := range cpy.GetPath().GetPathSegments() {
+		s.Metrics = map[string]string{
+			"mx:": mx,
+			"pos": fmt.Sprintf("%v", pos),
+			"dt":  fmt.Sprintf("%v %v", conn.GetPath().GetIndex(), time.Now()),
+		}
+	}
+	return cpy
+}
+
 func createConnection(id, server string) *networkservice.Connection {
 	return &networkservice.Connection{
 		Id: id,
@@ -262,6 +274,10 @@ func createConnection(id, server string) *networkservice.Connection {
 			IpContext: &networkservice.IPContext{
 				SrcIpRequired: true,
 				DstIpRequired: true,
+			},
+			MetricsContext: &networkservice.MetricsContext{
+				Enabled:  true,
+				Interval: int64(1 * time.Hour),
 			},
 		},
 	}

--- a/pkg/networkservice/common/monitor/server_test.go
+++ b/pkg/networkservice/common/monitor/server_test.go
@@ -1,0 +1,268 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"github.com/golang/protobuf/ptypes/empty"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
+)
+
+type testMonitorServer struct {
+	events       []*networkservice.ConnectionEvent
+	eventChannel chan *networkservice.ConnectionEvent
+	ctx          context.Context
+	cancel       context.CancelFunc
+}
+
+func newTestMonitorServer() *testMonitorServer {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &testMonitorServer{
+		eventChannel: make(chan *networkservice.ConnectionEvent, 10),
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+}
+
+func (t *testMonitorServer) Send(evt *networkservice.ConnectionEvent) error {
+	t.events = append(t.events, evt)
+	t.eventChannel <- evt
+	return nil
+}
+
+func (t *testMonitorServer) SetHeader(metadata.MD) error {
+	return nil
+}
+
+func (t *testMonitorServer) SendHeader(metadata.MD) error {
+	return nil
+}
+
+func (t *testMonitorServer) SetTrailer(metadata.MD) {
+}
+
+func (t *testMonitorServer) Context() context.Context {
+	return t.ctx
+}
+
+func (t *testMonitorServer) SendMsg(m interface{}) error {
+	return nil
+}
+
+func (t *testMonitorServer) RecvMsg(m interface{}) error {
+	return nil
+}
+
+func (t *testMonitorServer) BeginMonitoring(server networkservice.MonitorConnectionServer, segmentName string) {
+	go func() {
+		_ = server.MonitorConnections(
+			&networkservice.MonitorScopeSelector{
+				PathSegments: []*networkservice.PathSegment{{Name: segmentName}},
+			}, t)
+	}()
+}
+
+func (t *testMonitorServer) WaitEvents(ctx context.Context, count int) {
+	for {
+		if len(t.events) == count {
+			logrus.Infof("Waiting for events %v, but has %v", count, len(t.events))
+			break
+		}
+		// Wait 10ms for listeners to activate
+		select {
+		case <-ctx.Done():
+			// Context is done, we need to exit
+			logrus.Errorf("Failed to wait for events count %v current value is: %v", count, len(t.events))
+			return
+		case <-t.eventChannel:
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+type myServer struct {
+	networkservice.MonitorConnectionServer
+}
+
+type updateConnServer struct {
+	requestFunc func(request *networkservice.NetworkServiceRequest) *networkservice.Connection
+}
+
+func newUpdateConnServer(requestFunc func(request *networkservice.NetworkServiceRequest) *networkservice.Connection) *updateConnServer {
+	return &updateConnServer{
+		requestFunc: requestFunc,
+	}
+}
+
+func (t *updateConnServer) Request(_ context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	return t.requestFunc(request), nil
+}
+
+func (t *updateConnServer) Close(context.Context, *networkservice.Connection) (*empty.Empty, error) {
+	return &empty.Empty{}, nil
+}
+
+func TestMonitorSendToRightClient(t *testing.T) {
+	myServer := &myServer{}
+
+	ctx := context.Background()
+	ms := NewServer(&myServer.MonitorConnectionServer)
+	mons, ok := ms.(*monitorServer)
+	require.Equal(t, true, ok)
+
+	updateCounter := 0
+	updateEnv := newUpdateTailServer(updateCounter)
+
+	srv := next.NewWrappedNetworkServiceServer(trace.NewNetworkServiceServer, ms, updateEnv)
+
+	localMonitor := newTestMonitorServer()
+	remoteMonitor := newTestMonitorServer()
+	localMonitor.BeginMonitoring(myServer, "local-nsm")
+	remoteMonitor.BeginMonitoring(myServer, "remote-nsm")
+	// We need to be sure we have 2 clients waiting for events, we could check to have initial transfers for this.
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*6000)
+	defer cancel()
+	// Wait for init messages in both monitors
+	localMonitor.WaitEvents(timeoutCtx, 1)
+	remoteMonitor.WaitEvents(timeoutCtx, 1)
+	// Check we have 2 monitors
+	require.Equal(t, len(mons.monitors), 2)
+	require.Equal(t, 1, len(localMonitor.events))
+	require.Equal(t, 1, len(remoteMonitor.events))
+
+	// Add first connection and check right listener has event
+	// After it will think connection is established.
+	nsr := &networkservice.NetworkServiceRequest{
+		Connection: createConnection("id0", "local-nsm"),
+	}
+	_, _ = srv.Request(ctx, nsr)
+	// Now we could check monitoring routine's are working fine.
+	// Wait for update message for first monitor
+	localMonitor.WaitEvents(timeoutCtx, 2)
+	require.Equal(t, 2, len(localMonitor.events))
+	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.events[1].Type)
+	// Check we have connection already
+	require.Equal(t, len(mons.connections), 1)
+	// Just dummy update
+	nsr.Connection.Context.IpContext.ExtraPrefixes = append(nsr.Connection.Context.IpContext.ExtraPrefixes, "10.2.3.1")
+	_, _ = srv.Request(ctx, nsr)
+	localMonitor.WaitEvents(timeoutCtx, 3)
+	require.Equal(t, 3, len(localMonitor.events))
+	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.events[2].Type)
+	// check delete event is working fine.
+	_, closeErr := srv.Close(ctx, nsr.Connection)
+	require.Nil(t, closeErr)
+	localMonitor.WaitEvents(timeoutCtx, 4)
+	// Last event should be delete
+	require.Equal(t, 4, len(localMonitor.events))
+	require.Equal(t, networkservice.ConnectionEventType_DELETE, localMonitor.events[3].Type)
+	// Check connection is not longer inside map
+	require.Equal(t, len(mons.connections), 0)
+}
+
+func newUpdateTailServer(updateCounter int) *updateConnServer {
+	updateEnv := newUpdateConnServer(func(request *networkservice.NetworkServiceRequest) *networkservice.Connection {
+		updateCounter++
+		if request.GetConnection().Labels == nil {
+			request.GetConnection().Labels = make(map[string]string)
+		}
+		request.GetConnection().Labels["lastOp"] = fmt.Sprintf("updates: %v time: %v", updateCounter, time.Now())
+		return request.GetConnection()
+	})
+	return updateEnv
+}
+
+func TestMonitorIsClosedProperly(t *testing.T) {
+	myServer := &myServer{}
+
+	ctx := context.Background()
+	ms := NewServer(&myServer.MonitorConnectionServer)
+	mons, ok := ms.(*monitorServer)
+	require.Equal(t, true, ok)
+
+	updateCounter := 0
+	updateEnv := newUpdateTailServer(updateCounter)
+
+	srv := next.NewWrappedNetworkServiceServer(trace.NewNetworkServiceServer, ms, updateEnv)
+
+	localMonitor := newTestMonitorServer()
+
+	localMonitor.BeginMonitoring(myServer, "local-nsm")
+
+	// We need to be sure we have 2 clients waiting for events, we could check to have initial transfers for this.
+
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*6000)
+	defer cancel()
+
+	// Wait for init messages in both monitors
+	localMonitor.WaitEvents(timeoutCtx, 1)
+	require.Equal(t, 1, len(localMonitor.events))
+
+	// Add first connection and check right listener has event
+	// After it will think connection is established.
+	nsr := &networkservice.NetworkServiceRequest{
+		Connection: createConnection("id0", "local-nsm"),
+	}
+	_, _ = srv.Request(ctx, nsr)
+	// Now we could check monitoring routine's are working fine.
+
+	// Wait for update message for first monitor
+	localMonitor.WaitEvents(timeoutCtx, 2)
+
+	require.Equal(t, 2, len(localMonitor.events))
+	require.Equal(t, networkservice.ConnectionEventType_UPDATE, localMonitor.events[1].Type)
+
+	// Check we have connection already
+	require.Equal(t, len(mons.connections), 1)
+
+	// Cancel context for monitor
+	localMonitor.cancel()
+	// Just dummy update
+	nsr.Connection.Context.IpContext.ExtraPrefixes = append(nsr.Connection.Context.IpContext.ExtraPrefixes, "10.2.3.1")
+	_, _ = srv.Request(ctx, nsr)
+
+	for {
+		if len(mons.monitors) == 0 {
+			logrus.Infof("Waiting for monitors %v, but has %v", 0, len(mons.monitors))
+			break
+		}
+		// Wait 10ms for listeners to activate
+		select {
+		case <-ctx.Done():
+			// Context is done, we need to exit
+			require.Fail(t, "Context timeout")
+		case <-time.After(time.Millisecond * 100): // Delay for channel to be activated
+		}
+	}
+	// Check we no have monitors anymore
+	require.Equal(t, len(mons.monitors), 0)
+}
+
+func createConnection(id, server string) *networkservice.Connection {
+	return &networkservice.Connection{
+		Id: id,
+		Path: &networkservice.Path{
+			Index: 0,
+			PathSegments: []*networkservice.PathSegment{
+				{
+					Name: server,
+				},
+			},
+		},
+		Context: &networkservice.ConnectionContext{
+			IpContext: &networkservice.IPContext{
+				SrcIpRequired: true,
+				DstIpRequired: true,
+			},
+		},
+	}
+}

--- a/pkg/test/monitor/test_monitor.go
+++ b/pkg/test/monitor/test_monitor.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package monitor provides a TestMonitorClient test class to perform client monitoring based on MonitorConnection call.
+package monitor
+
+import (
+	"context"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"time"
+)
+
+// TestMonitorClient - implementation of monitor client.
+type TestMonitorClient struct {
+	Events       []*networkservice.ConnectionEvent
+	eventChannel chan *networkservice.ConnectionEvent
+	ctx          context.Context
+	Cancel       context.CancelFunc
+	grpc.ServerStream
+}
+
+// NewTestMonitorClient - construct a new client.
+func NewTestMonitorClient() *TestMonitorClient {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &TestMonitorClient{
+		eventChannel: make(chan *networkservice.ConnectionEvent, 10),
+		ctx:          ctx,
+		Cancel:       cancel,
+	}
+}
+
+// Send - recieve event from server.
+func (t *TestMonitorClient) Send(evt *networkservice.ConnectionEvent) error {
+	t.Events = append(t.Events, evt)
+	t.eventChannel <- evt
+	return nil
+}
+
+// Context - current context to perform checks.
+func (t *TestMonitorClient) Context() context.Context {
+	return t.ctx
+}
+
+// BeginMonitoring - start monitoring inside go routine, use Cancel() to perform stop.
+func (t *TestMonitorClient) BeginMonitoring(server networkservice.MonitorConnectionServer, segmentName string) {
+	go func() {
+		_ = server.MonitorConnections(
+			&networkservice.MonitorScopeSelector{
+				PathSegments: []*networkservice.PathSegment{{Name: segmentName}},
+			}, t)
+	}()
+}
+
+// WaitEvents - wait for a required number of events to be recieved.
+func (t *TestMonitorClient) WaitEvents(ctx context.Context, count int) {
+	for {
+		if len(t.Events) == count {
+			logrus.Infof("Waiting for Events %v, but has %v", count, len(t.Events))
+			break
+		}
+		// Wait 10ms for listeners to activate
+		select {
+		case <-ctx.Done():
+			// Context is done, we need to exit
+			logrus.Errorf("Failed to wait for Events count %v current value is: %v", count, len(t.Events))
+			return
+		case <-t.eventChannel:
+		case <-time.After(1 * time.Second):
+		}
+	}
+}

--- a/pkg/test/test_monitor/test_monitor.go
+++ b/pkg/test/test_monitor/test_monitor.go
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 // Package monitor provides a TestMonitorClient test class to perform client monitoring based on MonitorConnection call.
-package monitor
+package test_monitor
 
 import (
 	"context"


### PR DESCRIPTION
Implementation of Metrics chain element, it exposes 

```go
// MetricsMonitor - extension to monitor service to pass metrics into MonitorServer recipients.
// monitor will send events with configured with connection interval, often updates will wait for
// next interval approaching before will be sended.
type MetricsMonitor interface {
	// HandleMetrics - send update to current segment metrics
	HandleMetrics(metrics map[string]string)
}
```

Interface to all next chain elements, and allow to update current path segment metrics and send updates.

PR is based on: https://github.com/networkservicemesh/sdk/pull/87