### PR TITLE
clientInfo NetworkServiceRegistryClient

### DIFF
--- a/pkg/registry/common/clientinfo/client.go
+++ b/pkg/registry/common/clientinfo/client.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clientinfo provides a registry client that adds pod, node and cluster names to registration
+package clientinfo
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/clientinfoutils"
+)
+
+type clientInfoRegistry struct{}
+
+// NewRegistryClient - creates a new registry.NetworkServiceRegistryClient that adds pod, node and cluster names
+// to registration from corresponding environment variables
+func NewRegistryClient() registry.NetworkServiceRegistryClient {
+	return &clientInfoRegistry{}
+}
+
+func (a *clientInfoRegistry) RegisterNSE(ctx context.Context, in *registry.NSERegistration, opts ...grpc.CallOption) (*registry.NSERegistration, error) {
+	nse := in.NetworkServiceEndpoint
+	if nse.Labels == nil {
+		nse.Labels = make(map[string]string)
+	}
+	clientinfoutils.AddClientInfo(nse.Labels)
+	return next.RegistryClient(ctx).RegisterNSE(ctx, in, opts...)
+}
+
+func (a *clientInfoRegistry) BulkRegisterNSE(ctx context.Context, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_BulkRegisterNSEClient, error) {
+	return next.RegistryClient(ctx).BulkRegisterNSE(ctx, opts...)
+}
+
+func (a *clientInfoRegistry) RemoveNSE(ctx context.Context, in *registry.RemoveNSERequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.RegistryClient(ctx).RemoveNSE(ctx, in, opts...)
+}

--- a/pkg/registry/common/clientinfo/client.go
+++ b/pkg/registry/common/clientinfo/client.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/clientinfoutils"
+	"github.com/networkservicemesh/sdk/pkg/tools/clientinfo"
 )
 
 type clientInfoRegistry struct{}
@@ -41,7 +41,7 @@ func (a *clientInfoRegistry) RegisterNSE(ctx context.Context, in *registry.NSERe
 	if nse.Labels == nil {
 		nse.Labels = make(map[string]string)
 	}
-	clientinfoutils.AddClientInfo(nse.Labels)
+	clientinfo.AddClientInfo(ctx, nse.Labels)
 	return next.RegistryClient(ctx).RegisterNSE(ctx, in, opts...)
 }
 

--- a/pkg/registry/common/clientinfo/client_test.go
+++ b/pkg/registry/common/clientinfo/client_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clientinfo_test provides a tests for clientinfo
+package clientinfo_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/common/clientinfo"
+)
+
+var testData = []struct {
+	name string
+	envs map[string]string
+	in   *registry.NSERegistration
+	want *registry.NSERegistration
+}{
+	{
+		"labels map is not present",
+		map[string]string{
+			"NODE_NAME":    "AAA",
+			"POD_NAME":     "BBB",
+			"CLUSTER_NAME": "CCC",
+		},
+		&registry.NSERegistration{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{},
+		},
+		&registry.NSERegistration{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+				Labels: map[string]string{
+					"NodeNameKey":    "AAA",
+					"PodNameKey":     "BBB",
+					"ClusterNameKey": "CCC",
+				},
+			},
+		},
+	},
+	{
+		"labels are overwritten",
+		map[string]string{
+			"NODE_NAME":    "A1",
+			"POD_NAME":     "B2",
+			"CLUSTER_NAME": "C3",
+		},
+		&registry.NSERegistration{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+				Labels: map[string]string{
+					"NodeNameKey":     "OLD_VAL1",
+					"PodNameKey":      "OLD_VAL2",
+					"ClusterNameKey":  "OLD_VAL3",
+					"SomeOtherLabel1": "DDD",
+					"SomeOtherLabel2": "EEE",
+				},
+			},
+		},
+		&registry.NSERegistration{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+				Labels: map[string]string{
+					"NodeNameKey":     "A1",
+					"PodNameKey":      "B2",
+					"ClusterNameKey":  "C3",
+					"SomeOtherLabel1": "DDD",
+					"SomeOtherLabel2": "EEE",
+				},
+			},
+		},
+	},
+	{
+		"some of the envs are not present",
+		map[string]string{
+			"CLUSTER_NAME": "ABC",
+		},
+		&registry.NSERegistration{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+				Labels: map[string]string{
+					"NodeNameKey":     "OLD_VAL1",
+					"ClusterNameKey":  "OLD_VAL2",
+					"SomeOtherLabel1": "DDD",
+					"SomeOtherLabel2": "EEE",
+				},
+			},
+		},
+		&registry.NSERegistration{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+				Labels: map[string]string{
+					"NodeNameKey":     "OLD_VAL1",
+					"ClusterNameKey":  "ABC",
+					"SomeOtherLabel1": "DDD",
+					"SomeOtherLabel2": "EEE",
+				},
+			},
+		},
+	},
+}
+
+func Test_clientInfoRegistry_RegisterNSE(t *testing.T) {
+	for _, data := range testData {
+		test := data
+		t.Run(test.name, func(t *testing.T) {
+			testRequest(t, test.envs, test.in, test.want)
+		})
+	}
+}
+
+func testRequest(t *testing.T, envs map[string]string, registration, want *registry.NSERegistration) {
+	for name, value := range envs {
+		if err := os.Setenv(name, value); err != nil {
+			t.Errorf("clientInfoRegistry.RegisterNSE() unable to set up environment variable: %v", err)
+		}
+	}
+
+	client := next.NewRegistryClient([]registry.NetworkServiceRegistryClient{clientinfo.NewRegistryClient()})
+	got, _ := client.RegisterNSE(context.Background(), registration)
+	assert.Equal(t, got, want)
+
+	for name := range envs {
+		if err := os.Unsetenv(name); err != nil {
+			t.Errorf("clientInfoRegistry.RegisterNSE() unable to unset environment variable: %v", err)
+		}
+	}
+}

--- a/pkg/registry/common/clientinfo/client_test.go
+++ b/pkg/registry/common/clientinfo/client_test.go
@@ -131,7 +131,7 @@ func testRequest(t *testing.T, envs map[string]string, registration, want *regis
 		}
 	}
 
-	client := next.NewRegistryClient([]registry.NetworkServiceRegistryClient{clientinfo.NewRegistryClient()})
+	client := next.NewRegistryClient(clientinfo.NewRegistryClient())
 	got, _ := client.RegisterNSE(context.Background(), registration)
 	assert.Equal(t, got, want)
 

--- a/pkg/registry/utils/checks/checkregistration/client.go
+++ b/pkg/registry/utils/checks/checkregistration/client.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package checkregistration - provides registry chain elements to check the registration received from the
+// previous element in the chain
+package checkregistration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+)
+
+type checkRegistrationRegistryClient struct {
+	*testing.T
+	check func(*testing.T, *registry.NSERegistration)
+}
+
+// NewRegistryClient - returns registry.NetworkServiceRegistryClient chain elements to check the registration
+// received from the previous element in the chain
+//             t - *testing.T for checks
+//             check - function to check the registry.NSERegistration
+func NewRegistryClient(t *testing.T, check func(*testing.T, *registry.NSERegistration)) registry.NetworkServiceRegistryClient {
+	return &checkRegistrationRegistryClient{t, check}
+}
+
+func (c *checkRegistrationRegistryClient) RegisterNSE(ctx context.Context, registration *registry.NSERegistration, opts ...grpc.CallOption) (*registry.NSERegistration, error) {
+	c.check(c.T, registration)
+	return next.RegistryClient(ctx).RegisterNSE(ctx, registration, opts...)
+}
+
+func (c *checkRegistrationRegistryClient) BulkRegisterNSE(ctx context.Context, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_BulkRegisterNSEClient, error) {
+	return next.RegistryClient(ctx).BulkRegisterNSE(ctx, opts...)
+}
+
+func (c *checkRegistrationRegistryClient) RemoveNSE(ctx context.Context, request *registry.RemoveNSERequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.RegistryClient(ctx).RemoveNSE(ctx, request, opts...)
+}


### PR DESCRIPTION
Implementation of #44 
Created clientInfoRegistry NetworkServiceRegistryClient that takes podName/nodeName/clusterName from environment variables and adds corresponding labels to registration
Also added tailRegistryClient to be able to run tests