### PR TITLE
Automerge nsmbot update PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,3 +112,13 @@ jobs:
         run: |
           eval $(go env)
           ${GOPATH}/bin/go-header
+  excludereplace:
+    name: Exclude Replace in go.mod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v1
+      - name: Exclude replace in go.mod
+        run: |
+          grep ^replace go.mod || exit 0
+          exit 1

--- a/.github/workflows/nsmbot-automerge.yaml
+++ b/.github/workflows/nsmbot-automerge.yaml
@@ -1,0 +1,29 @@
+---
+name: NSMBot Automerge of go.{mod,sum} updates?
+on:
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+jobs:
+  automerge:
+    name: automerge
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'nsmbot' }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v1
+      - name: Fetch master
+        run: |
+          git remote -v
+          git fetch --depth=1 origin master
+      - name: Only allow go.mod and go.sum changes
+        run: |
+          find . -type f ! -name 'go.mod' ! -name 'go.sum' -exec git diff --exit-code origin/master -- {} +
+      - name: Automerge nsmbot PR
+        uses: ridedott/merge-me-action@master
+        with:
+          GITHUB_LOGIN: nsmbot
+          GITHUB_TOKEN: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
If and only if:

- Checks pass
- They only change go.sum or go.mod
- They do not introduce any new 'replace' directives into go.mod.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>