### PR TITLE
Fix next to *always* work.

### DIFF
--- a/pkg/networkservice/core/next/client.go
+++ b/pkg/networkservice/core/next/client.go
@@ -61,14 +61,14 @@ func (n *nextClient) Request(ctx context.Context, request *networkservice.Networ
 	if n.index+1 < len(n.clients) {
 		return n.clients[n.index].Request(withNextClient(ctx, &nextClient{clients: n.clients, index: n.index + 1}), request, opts...)
 	}
-	return n.clients[n.index].Request(withNextClient(ctx, newTailClient()), request, opts...)
+	return n.clients[n.index].Request(withNextClient(ctx, nil), request, opts...)
 }
 
 func (n *nextClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
 	if n.index+1 < len(n.clients) {
 		return n.clients[n.index].Close(withNextClient(ctx, &nextClient{clients: n.clients, index: n.index + 1}), conn, opts...)
 	}
-	return n.clients[n.index].Close(withNextClient(ctx, newTailClient()), conn, opts...)
+	return n.clients[n.index].Close(withNextClient(ctx, nil), conn, opts...)
 }
 
 func notWrapClient(c networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {

--- a/pkg/networkservice/core/next/server.go
+++ b/pkg/networkservice/core/next/server.go
@@ -61,14 +61,14 @@ func (n *nextServer) Request(ctx context.Context, request *networkservice.Networ
 	if n.index+1 < len(n.servers) {
 		return n.servers[n.index].Request(withNextServer(ctx, &nextServer{servers: n.servers, index: n.index + 1}), request)
 	}
-	return n.servers[n.index].Request(withNextServer(ctx, newTailServer()), request)
+	return n.servers[n.index].Request(withNextServer(ctx, nil), request)
 }
 
 func (n *nextServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
 	if n.index+1 < len(n.servers) {
 		return n.servers[n.index].Close(withNextServer(ctx, &nextServer{servers: n.servers, index: n.index + 1}), conn)
 	}
-	return n.servers[n.index].Close(withNextServer(ctx, newTailServer()), conn)
+	return n.servers[n.index].Close(withNextServer(ctx, nil), conn)
 }
 
 func notWrapServer(server networkservice.NetworkServiceServer) networkservice.NetworkServiceServer {

--- a/pkg/networkservice/core/next/tail_client.go
+++ b/pkg/networkservice/core/next/tail_client.go
@@ -29,10 +29,6 @@ import (
 // to insure that we never call a method on a nil object
 type tailClient struct{}
 
-func newTailClient() *tailClient {
-	return &tailClient{}
-}
-
 func (t *tailClient) Request(_ context.Context, request *networkservice.NetworkServiceRequest, _ ...grpc.CallOption) (*networkservice.Connection, error) {
 	return request.GetConnection(), nil
 }

--- a/pkg/networkservice/core/next/tail_server.go
+++ b/pkg/networkservice/core/next/tail_server.go
@@ -28,10 +28,6 @@ import (
 // to insure that we never call a method on a nil object
 type tailServer struct{}
 
-func newTailServer() *tailServer {
-	return &tailServer{}
-}
-
 func (t *tailServer) Request(_ context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	return request.GetConnection(), nil
 }


### PR DESCRIPTION
Right now in the event where you run a chain element outside of a chain, you will get a panic
on calls to things like:

next.Server(ctx).Request(...)

This fixes that.  Now it never panics.