### PR TITLE
Minor fix to logging to make us take global logrus defaults.

### DIFF
--- a/pkg/networkservice/core/trace/context.go
+++ b/pkg/networkservice/core/trace/context.go
@@ -40,8 +40,16 @@ func withLog(parent context.Context, log logrus.FieldLogger) context.Context {
 
 // Log - return FieldLogger from context
 func Log(ctx context.Context) logrus.FieldLogger {
-	if rv, ok := ctx.Value(logKey).(logrus.FieldLogger); ok {
-		return rv
+	rv, ok := ctx.Value(logKey).(logrus.FieldLogger)
+	if !ok {
+		rv = &logrus.Logger{
+			Out:          logrus.StandardLogger().Out,
+			Formatter:    logrus.StandardLogger().Formatter,
+			Hooks:        logrus.StandardLogger().Hooks,
+			Level:        logrus.StandardLogger().Level,
+			ExitFunc:     logrus.StandardLogger().ExitFunc,
+			ReportCaller: logrus.StandardLogger().ReportCaller,
+		}
 	}
-	return logrus.New()
+	return rv
 }

--- a/pkg/tools/spanhelper/span_helper.go
+++ b/pkg/tools/spanhelper/span_helper.go
@@ -53,12 +53,20 @@ func traceDepth(ctx context.Context) int {
 
 // LogFromSpan - return a logger that has a TraceHook to also log messages to the span
 func LogFromSpan(span opentracing.Span) logrus.FieldLogger {
+	logger := logrus.Logger{
+		Out:          logrus.StandardLogger().Out,
+		Formatter:    logrus.StandardLogger().Formatter,
+		Hooks:        logrus.StandardLogger().Hooks,
+		Level:        logrus.StandardLogger().Level,
+		ExitFunc:     logrus.StandardLogger().ExitFunc,
+		ReportCaller: logrus.StandardLogger().ReportCaller,
+	}
 	if span != nil {
-		logger := logrus.New().WithField("span", span)
+		logger := logger.WithField("span", span)
 		logger.Logger.AddHook(NewTraceHook(span))
 		return logger
 	}
-	return logrus.New()
+	return &logger
 }
 
 type traceHook struct {


### PR DESCRIPTION
Turns out that logrus.New() pegs us to things like stderr for output.

Since by default for testing we want to use:

logrus.SetOutput(ioutil.Discard)

to suppress logs, its important to take defaults from the global logrus settings.