### PR TITLE
Fix race condition in MonitorConnectionClient

### DIFF
--- a/pkg/networkservice/common/heal/client_test.go
+++ b/pkg/networkservice/common/heal/client_test.go
@@ -194,6 +194,7 @@ func TestNewClient_MissingConnectionsInInit(t *testing.T) {
 	}
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 	client := chain.NewNetworkServiceClient(
 		heal.NewClient(ctx, eventchannel.NewMonitorConnectionClient(eventCh), addressof.NetworkServiceClient(onHeal)))
 
@@ -241,5 +242,4 @@ func TestNewClient_MissingConnectionsInInit(t *testing.T) {
 	require.Eventually(t, cond, waitForTimeout, tickTimeout)
 	require.Equal(t, 0, healsRemaining[conns[0].GetId()])
 	require.Equal(t, 0, healsRemaining[conns[1].GetId()])
-	cancelFunc()
 }

--- a/pkg/networkservice/common/heal/client_test.go
+++ b/pkg/networkservice/common/heal/client_test.go
@@ -217,16 +217,18 @@ func TestNewClient_MissingConnectionsInInit(t *testing.T) {
 
 	// we emulate situation that server managed to handle only the first connection
 	// second connection should came in the UPDATE event, but we emulate server's falling down
-	cancelFunc()
+	close(eventCh)
 	// at that point we expect that 'healClient' start healing both 'conn-1' and 'conn-2'
 
-	healedIDs := map[string]bool{}
-
+	healsRemaining := map[string]int{
+		conns[0].GetId(): 1,
+		conns[1].GetId(): 2,
+	}
 	cond := func() bool {
 		select {
 		case r := <-requestCh:
-			if _, ok := healedIDs[r.GetConnection().GetId()]; !ok {
-				healedIDs[r.GetConnection().GetId()] = true
+			if val, ok := healsRemaining[r.GetConnection().GetId()]; ok && val != 0 {
+				healsRemaining[r.GetConnection().GetId()]--
 				return true
 			}
 			return false
@@ -234,10 +236,10 @@ func TestNewClient_MissingConnectionsInInit(t *testing.T) {
 			return false
 		}
 	}
-
 	require.Eventually(t, cond, waitForTimeout, tickTimeout)
 	require.Eventually(t, cond, waitForTimeout, tickTimeout)
-
-	require.True(t, healedIDs[conns[0].GetId()])
-	require.True(t, healedIDs[conns[1].GetId()])
+	require.Eventually(t, cond, waitForTimeout, tickTimeout)
+	require.Equal(t, 0, healsRemaining[conns[0].GetId()])
+	require.Equal(t, 0, healsRemaining[conns[1].GetId()])
+	cancelFunc()
 }


### PR DESCRIPTION
**Problem:**
Undefined order of execution between `monitorConnectionClient.eventLoop()` goroutine that passes events to `fanoutEventCh` and goroutine that's waiting `<--context.Done()` and closes `fanoutEventCh` leads to different number of `testOnHeal.Request()` calls in `/pkg/networkservice/common/heal/client_test.go`
`TestNewClient_MissingConnectionsOnInit` test that leads to different number (2 or 3) `testOnHeal.Request()` invocations. [Explanation diagram](https://drive.google.com/file/d/1yDwcyOjTQrcif8B_RvndGDDyxH3qzmN3/view?usp=sharing)

**Solutions i see:**
1) `time.Sleep(100 * time.Millisecond)` after sending `INITIAL_STATE_TRANSFER` event to ensure that this event will be handled earlier than context cancellation.

2) Guarantee that chain context cancellation will be handled after connection event, if it was cancelled after connection event sending. One way to do that i see is to emulate the server falling down by closing `eventCh`, not chain context cancelling. Chain context cancelling is rather about client's intention to shut down and logically may be async, but server's falling down is not.

Tried to implement the second one in this PR :)