### PR TITLE
Prepare input for OPA

### DIFF
--- a/pkg/tools/opautils/opainput.go
+++ b/pkg/tools/opautils/opainput.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/tools/opautils/opainput.go
+++ b/pkg/tools/opautils/opainput.go
@@ -17,8 +17,8 @@
 // Now we can consider the OPA input as a map with the keys:
 //    1) "connection" -- we can use all information about connection in OPA (e.g. input.connection.path.path_segments[0].token)
 //    2) "auth_info" with sub keys:
-//          -"certificate" -- is a pem encoded x509cert (access: input.auth_info.certificate)
-//			-"spiffe_id" -- is a spiffeID from SVIDX509Certificate (access: input.auth_info.spiffe_id)
+//          i) "certificate" -- is a pem encoded x509cert (access: input.auth_info.certificate)
+//			ii) "spiffe_id" -- is a spiffeID from SVIDX509Certificate (access: input.auth_info.spiffe_id)
 //    3) "operation" -- one of request/close (access: input.operation)
 //    4) "role" -- one of client/endpoint (access: input.role)
 
@@ -73,7 +73,7 @@ const (
 func PreparedOpaInput(connection *networkservice.Connection, authInfo credentials.AuthInfo, operation operation, role role) (map[string]interface{}, error) {
 	connectionAsMap, err := convertConnectionToMap(connection)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Cannot marshal the connection %v", connection)
+		return nil, errors.Wrapf(err, "Cannot convert connection %v to map", connection)
 	}
 
 	cert := parseX509Cert(authInfo)

--- a/pkg/tools/opautils/opainput.go
+++ b/pkg/tools/opautils/opainput.go
@@ -17,10 +17,10 @@
 // Now we can consider the OPA input as a map with the keys:
 //    1) "connection" -- we can use all information about connection in OPA (e.g. input.connection.path.path_segments[0].token)
 //    2) "auth_info" with sub keys:
-//          i) "certificate" -- is a pem encoded x509cert (access: input.auth_info.certificate)
-//			ii) "spiffe_id" -- is a spiffeID from SVIDX509Certificate (access: input.auth_info.spiffe_id)
-//    3) "operation" -- one of request/close (access: input.operation)
-//    4) "role" -- one of client/endpoint (access: input.role)
+//          i) "certificate" -- is a pem encoded x509cert (usage: input.auth_info.certificate)
+//			ii) "spiffe_id" -- is a spiffeID from SVIDX509Certificate (usage: input.auth_info.spiffe_id)
+//    3) "operation" -- one of request/close (usage: input.operation)
+//    4) "role" -- one of client/endpoint (usage: input.role)
 
 // An example of using OPA input for the case of token signature verification:
 //

--- a/pkg/tools/opautils/opainput.go
+++ b/pkg/tools/opautils/opainput.go
@@ -36,7 +36,6 @@
 //
 
 // Package opautils provides of utilities for using OPA
-
 package opautils
 
 import (
@@ -53,15 +52,21 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-
 type role string
 type operation string
 
 const (
-	Client   role      = "client"
-	Endpoint role      = "endpoint"
-	Request  operation = "request"
-	Close    operation = "close"
+	// Client is a client role
+	Client role = "client"
+
+	// Endpoint is an endpoint role
+	Endpoint role = "endpoint"
+
+	// Request is a request operation
+	Request operation = "request"
+
+	// Close is a close operation
+	Close operation = "close"
 )
 
 // PreparedOpaInput - returns a prepared input for using in OPA
@@ -84,15 +89,15 @@ func PreparedOpaInput(connection *networkservice.Connection, authInfo credential
 		"connection": connectionAsMap,
 		"auth_info": map[string]interface{}{
 			"certificate": pemcert,
-			"spiffe_id": spiffeID,
+			"spiffe_id":   spiffeID,
 		},
 		"operation": operation,
-		"role": role,
+		"role":      role,
 	}
 	return rv, nil
 }
 
-func pemEncodingX509Cert (cert *x509.Certificate) string {
+func pemEncodingX509Cert(cert *x509.Certificate) string {
 	certpem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 	return string(certpem)
 }
@@ -113,9 +118,8 @@ func convertConnectionToMap(connection *networkservice.Connection) (map[string]i
 		return nil, err
 	}
 	rv := make(map[string]interface{})
-	if err = json.Unmarshal(jsonConn, &rv); err != nil {
+	if err := json.Unmarshal(jsonConn, &rv); err != nil {
 		return nil, err
 	}
 	return rv, nil
 }
-

--- a/pkg/tools/opautils/opainput.go
+++ b/pkg/tools/opautils/opainput.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Now we can consider the OPA input as a map with the keys:
+//    1) "connection" -- we can use all information about connection in OPA (e.g. input.connection.path.path_segments[0].token)
+//    2) "auth_info" with sub keys:
+//          -"certificate" -- is a pem encoded x509cert (access: input.auth_info.certificate)
+//			-"spiffe_id" -- is a spiffeID from SVIDX509Certificate (access: input.auth_info.spiffe_id)
+//    3) "operation" -- one of request/close (access: input.operation)
+//    4) "role" -- one of client/endpoint (access: input.role)
+
+// An example of using OPA input for the case of token signature verification:
+//
+//		package test
+//
+//		default allow = false
+//
+//		allow {
+//			token := input.connection.path.path_segments[0].token
+//			cert := input.auth_info.certificate
+//			io.jwt.verify_es256(token, cert) # signature verification
+//		}
+//
+
+// Package opautils provides of utilities for using OPA
+
+package opautils
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/spiffeutils"
+
+	"github.com/pkg/errors"
+
+	"google.golang.org/grpc/credentials"
+)
+
+
+type role string
+type operation string
+
+const (
+	Client   role      = "client"
+	Endpoint role      = "endpoint"
+	Request  operation = "request"
+	Close    operation = "close"
+)
+
+// PreparedOpaInput - returns a prepared input for using in OPA
+func PreparedOpaInput(connection *networkservice.Connection, authInfo credentials.AuthInfo, operation operation, role role) (map[string]interface{}, error) {
+	connectionAsMap, err := convertConnectionToMap(connection)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Cannot marshal the connection %v", connection)
+	}
+
+	cert := parseX509Cert(authInfo)
+
+	spiffeID, err := spiffeutils.SpiffeIDFromX509(cert)
+	if err != nil {
+		return nil, err
+	}
+
+	pemcert := pemEncodingX509Cert(cert)
+
+	rv := map[string]interface{}{
+		"connection": connectionAsMap,
+		"auth_info": map[string]interface{}{
+			"certificate": pemcert,
+			"spiffe_id": spiffeID,
+		},
+		"operation": operation,
+		"role": role,
+	}
+	return rv, nil
+}
+
+func pemEncodingX509Cert (cert *x509.Certificate) string {
+	certpem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	return string(certpem)
+}
+
+func parseX509Cert(authInfo credentials.AuthInfo) *x509.Certificate {
+	var peerCert *x509.Certificate
+	if tlsInfo, ok := authInfo.(credentials.TLSInfo); ok {
+		if len(tlsInfo.State.PeerCertificates) > 0 {
+			peerCert = tlsInfo.State.PeerCertificates[0]
+		}
+	}
+	return peerCert
+}
+
+func convertConnectionToMap(connection *networkservice.Connection) (map[string]interface{}, error) {
+	jsonConn, err := json.Marshal(connection)
+	if err != nil {
+		return nil, err
+	}
+	rv := make(map[string]interface{})
+	if err = json.Unmarshal(jsonConn, &rv); err != nil {
+		return nil, err
+	}
+	return rv, nil
+}
+

--- a/pkg/tools/opautils/opainput_test.go
+++ b/pkg/tools/opautils/opainput_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/tools/opautils/opainput_test.go
+++ b/pkg/tools/opautils/opainput_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opautils_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/opautils"
+
+	"github.com/stretchr/testify/assert"
+
+	"google.golang.org/grpc/credentials"
+)
+
+const (
+	// certPem is a X.509 certificate with spiffeId = "spiffe://test.com/workload"
+	certPem = `-----BEGIN CERTIFICATE-----
+MIIBvjCCAWWgAwIBAgIQbnFakUhzr52nHoLGltZDyDAKBggqhkjOPQQDAjAdMQsw
+CQYDVQQGEwJVUzEOMAwGA1UEChMFU1BJUkUwHhcNMjAwMTAxMDEwMTAxWhcNMzAw
+MTAxMDEwMTAxWjAdMQswCQYDVQQGEwJVUzEOMAwGA1UEChMFU1BJUkUwWTATBgcq
+hkjOPQIBBggqhkjOPQMBBwNCAASlFpbASv+NIyVdFwTp22JR5gx7D6LJ01Z8Wz0S
+ZiBneWRAcYUBBQY6zKwr/RQtCDxUcFfFyq4zEfUD29a5Phnoo4GGMIGDMA4GA1Ud
+DwEB/wQEAwIDqDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0T
+AQH/BAIwADAdBgNVHQ4EFgQUJJpYlJa1eNEcks+zJcwKClopSAowJQYDVR0RBB4w
+HIYac3BpZmZlOi8vdGVzdC5jb20vd29ya2xvYWQwCgYIKoZIzj0EAwIDRwAwRAIg
+Dk6tlURSF8ULhNbnyUxFQ33rDic2dX8jOIstV2dWErwCIDRH2yw0swTcUMQWYgHy
+aMp+T747AZGjOEfwHb9/w+7m
+-----END CERTIFICATE-----
+`
+	spiffeId = "spiffe://test.com/workload"
+)
+
+func getConnectionWithToken(token string) *networkservice.Connection {
+	return &networkservice.Connection{
+		Path: &networkservice.Path{
+			Index: 0,
+			PathSegments: []*networkservice.PathSegment{
+				{
+					Token: token,
+				},
+			},
+		},
+	}
+}
+
+func TestPreparedOpaInput(t *testing.T) {
+	block, _ := pem.Decode([]byte(certPem))
+	x509cert, err := x509.ParseCertificate(block.Bytes)
+	assert.Nil(t, err)
+	authInfo := credentials.TLSInfo{
+		State: tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{
+				x509cert,
+			},
+		},
+	}
+	testToken := "testToken"
+	conn := getConnectionWithToken(testToken)
+
+	expectedInput := map[string]interface{}{
+		"connection": map[string]interface{}{
+			"path": map[string]interface{}{
+				"path_segments": []interface{}{
+					map[string]interface{}{
+						"token": testToken,
+					},
+				},
+			},
+		},
+		"auth_info": map[string]interface{}{
+			"certificate": certPem,
+			"spiffe_id":   spiffeId,
+		},
+		"operation": opautils.Request,
+		"role":      opautils.Client,
+	}
+
+	realInput, err := opautils.PreparedOpaInput(conn, authInfo, opautils.Request, opautils.Client)
+	assert.Nil(t, err)
+
+	assert.Equal(t, expectedInput, realInput)
+}

--- a/pkg/tools/opautils/opainput_test.go
+++ b/pkg/tools/opautils/opainput_test.go
@@ -46,7 +46,7 @@ Dk6tlURSF8ULhNbnyUxFQ33rDic2dX8jOIstV2dWErwCIDRH2yw0swTcUMQWYgHy
 aMp+T747AZGjOEfwHb9/w+7m
 -----END CERTIFICATE-----
 `
-	spiffeId = "spiffe://test.com/workload"
+	spiffeID = "spiffe://test.com/workload"
 )
 
 func getConnectionWithToken(token string) *networkservice.Connection {
@@ -88,7 +88,7 @@ func TestPreparedOpaInput(t *testing.T) {
 		},
 		"auth_info": map[string]interface{}{
 			"certificate": certPem,
-			"spiffe_id":   spiffeId,
+			"spiffe_id":   spiffeID,
 		},
 		"operation": opautils.Request,
 		"role":      opautils.Client,


### PR DESCRIPTION
Now OPA input provides the following objects:
1. All information about connection (usage: input.connection.[...]. For example, a token from zero path segment we can get as input.connection.path.path_segments[0].token)
2. The TLSInfo (as retrieved by peer.FromContext for Server or grpc.Peer for the Client) which contains the following data: 
	*	"certificate"  --  is  a  pem  encoded  x509cert  (usage:  input.auth_info.certificate)
	*	"spiffe_id"  --  is  a  spiffeID  from  SVIDX509Certificate  (usage:  input.auth_info.spiffe_id)
3. "operation"  --  one  of  request/close  (usage:  input.operation)
4. "role"  --  one  of  client/endpoint  (usage:  input.role)

An example of using OPA input for the case of token signature verification

```
package test 
default allow = false    
allow { 
   token := input.connection.path.path_segments[0].token  
   cert := input.auth_info.certificate  
   io.jwt.verify_es256(token, cert) # signature verification  
}
```

Motivation #200 

Signed-off-by: Dmitry Vlasov <dmitry.vlasov@xored.com>