### PR TITLE
Make spire go tools path independent

### DIFF
--- a/pkg/tools/spire/agent.conf.go
+++ b/pkg/tools/spire/agent.conf.go
@@ -17,14 +17,14 @@
 package spire
 
 const (
-	spireAgentConfFilename = "/etc/nsm/spire/conf/agent/agent.conf"
-	spireEndpointSocket    = "/tmp/agent.sock"
+	spireAgentConfFilename = "agent/agent.conf"
+	spireEndpointSocket    = "agent.sock"
 	spireAgentConfContents = `agent {
-    data_dir = "./.data"
+    data_dir = "%[1]s/data"
     log_level = "WARN"
     server_address = "127.0.0.1"
     server_port = "8081"
-    socket_path =%q
+    socket_path = "%[1]s/%[2]s"
     insecure_bootstrap = true
     trust_domain = "example.org"
 }
@@ -36,7 +36,7 @@ plugins {
     }
     KeyManager "disk" {
         plugin_data {
-            directory = "./.data"
+            directory = "%[1]s/data"
         }
     }
     WorkloadAttestor "unix" {

--- a/pkg/tools/spire/server.conf.go
+++ b/pkg/tools/spire/server.conf.go
@@ -17,14 +17,14 @@
 package spire
 
 const (
-	spireRunDir             = "/run/spire/"
-	spireServerConfFileName = "/etc/nsm/spire/conf/server/server.conf"
+	spireServerConfFileName = "server/server.conf"
+	spireServerRegSock      = "spire-registration.sock"
 	spireServerConfContents = `server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
+    registration_uds_path = "%[1]s/%[2]s"
     trust_domain = "example.org"
-    data_dir = "./.data"
+    data_dir = "%[1]s/data"
     log_level = "WARN"
     upstream_bundle = true
     default_svid_ttl = "1h"
@@ -39,7 +39,7 @@ plugins {
     DataStore "sql" {
         plugin_data {
             database_type = "sqlite3"
-            connection_string = "./.data/datastore.sqlite3"
+            connection_string = "%[1]s/data/datastore.sqlite3"
         }
     }
 


### PR DESCRIPTION
Make spire go tools path independent and do folder cleanup on exit.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>