### PR TITLE
Fix concurrency in eventchannel tests

### DIFF
--- a/pkg/networkservice/core/eventchannel/monitor_server.go
+++ b/pkg/networkservice/core/eventchannel/monitor_server.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Cisco and/or its affiliates.
 //
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,17 +32,19 @@ type monitorConnectionServer struct {
 	servers   []networkservice.MonitorConnection_MonitorConnectionsServer
 	selectors []*networkservice.MonitorScopeSelector
 	executor  serialize.Executor
-	connectCh chan int
+	connectCh chan<- int
 }
 
 // NewMonitorServer - returns a networkservice.MonitorConnectionServer
 //                    eventCh - when Send() is called on any of the NewMonitorConnection_MonitorConnectionsServers
 //                              returned by a call to MonitorConnections, it is inserted into eventCh
-func NewMonitorServer(eventCh <-chan *networkservice.ConnectionEvent, monitorConnect chan int) networkservice.MonitorConnectionServer {
+func NewMonitorServer(eventCh <-chan *networkservice.ConnectionEvent, options ...MonitorConnectionServerOption) networkservice.MonitorConnectionServer {
 	rv := &monitorConnectionServer{
-		eventCh:   eventCh,
-		closeCh:   make(chan struct{}),
-		connectCh: monitorConnect,
+		eventCh: eventCh,
+		closeCh: make(chan struct{}),
+	}
+	for _, o := range options {
+		o.apply(rv)
 	}
 	rv.eventLoop()
 	return rv
@@ -54,7 +58,9 @@ func (m *monitorConnectionServer) MonitorConnections(selector *networkservice.Mo
 		m.executor.AsyncExec(func() {
 			m.servers = append(m.servers, srv)
 			m.selectors = append(m.selectors, selector)
-			m.connectCh <- len(m.servers)
+			if m.connectCh != nil {
+				m.connectCh <- len(m.servers)
+			}
 		})
 		select {
 		case <-srv.Context().Done():

--- a/pkg/networkservice/core/eventchannel/option.go
+++ b/pkg/networkservice/core/eventchannel/option.go
@@ -13,6 +13,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package eventchannel provides API for creating monitoring components  via golang channels
 package eventchannel
 
 // MonitorConnectionServerOption applies specific parameters for MonitorConnectionServer

--- a/pkg/networkservice/core/eventchannel/option.go
+++ b/pkg/networkservice/core/eventchannel/option.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package eventchannel
+
+// MonitorConnectionServerOption applies specific parameters for MonitorConnectionServer
+type MonitorConnectionServerOption interface {
+	apply(s *monitorConnectionServer)
+}
+
+type monitorConnectionServerOptionFunc func(*monitorConnectionServer)
+
+func (f monitorConnectionServerOptionFunc) apply(s *monitorConnectionServer) {
+	f(s)
+}
+
+// WithConnectChannel adds for MonitorConnectionServer an option for monitoring connection count
+func WithConnectChannel(connectCh chan<- int) MonitorConnectionServerOption {
+	return monitorConnectionServerOptionFunc(func(s *monitorConnectionServer) {
+		s.connectCh = connectCh
+	})
+}


### PR DESCRIPTION
## Motivation

Fixes unstable test `TestMonitorConnectionServer_MonitorConnections` on CI.

For example, Here is CI build from memory registry elements PR: https://github.com/networkservicemesh/sdk/pull/241/checks?check_run_id=655521550


Based on https://github.com/networkservicemesh/sdk/pull/234