### PR TITLE
WIP: Add join registry chain elements

### DIFF
--- a/pkg/registry/join/context.go
+++ b/pkg/registry/join/context.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"context"
+	"time"
+)
+
+type joinedContext struct {
+	contexts []context.Context
+}
+
+func (j joinedContext) Deadline() (deadline time.Time, ok bool) {
+	var result time.Time
+	for _, c := range j.contexts {
+		d, o := c.Deadline()
+		if !o {
+			return d, o
+		}
+		if result.After(deadline) {
+			result = deadline
+		}
+	}
+	return result, true
+}
+
+func (j joinedContext) Done() <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		for _, ctx := range j.contexts {
+			<-ctx.Done()
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+func (j joinedContext) Err() error {
+	for _, c := range j.contexts {
+		if err := c.Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j joinedContext) Value(key interface{}) interface{} {
+	for _, c := range j.contexts {
+		if v := c.Value(key); v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+func Context(ctx ...context.Context) context.Context {
+	return &joinedContext{
+		contexts: ctx,
+	}
+}

--- a/pkg/registry/join/discovery_client.go
+++ b/pkg/registry/join/discovery_client.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"context"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"google.golang.org/grpc"
+)
+
+type discoveryRegistryClient struct {
+	clients []registry.NetworkServiceDiscoveryClient
+}
+
+func (d *discoveryRegistryClient) FindNetworkService(ctx context.Context, in *registry.FindNetworkServiceRequest, opts ...grpc.CallOption) (*registry.FindNetworkServiceResponse, error) {
+	var result = &registry.FindNetworkServiceResponse{
+		NetworkServiceManagers: map[string]*registry.NetworkServiceManager{},
+	}
+	var set = map[string]*registry.NetworkServiceEndpoint{}
+	for _, c := range d.clients {
+		resp, err := c.FindNetworkService(ctx, in, opts...)
+		if err != nil {
+			return nil, err
+		}
+		if result.NetworkService == nil {
+			result.NetworkService = resp.NetworkService
+		}
+		if result.Payload == "" {
+			result.Payload = resp.Payload
+		}
+		for _, nse := range resp.NetworkServiceEndpoints {
+			if _, ok := set[nse.Name]; ok {
+				continue
+			}
+			set[nse.Name] = nse
+			result.NetworkServiceEndpoints = append(result.NetworkServiceEndpoints, nse)
+		}
+		for _, nsm := range resp.NetworkServiceManagers {
+			result.NetworkServiceManagers[nsm.Name] = nsm
+		}
+	}
+	return result, nil
+}
+
+func NewDiscoveryClient(clients ...registry.NetworkServiceDiscoveryClient) registry.NetworkServiceDiscoveryClient {
+	return &discoveryRegistryClient{clients: clients}
+}
+
+var _ registry.NetworkServiceDiscoveryClient = &discoveryRegistryClient{}

--- a/pkg/registry/join/network_service_registry_client.go
+++ b/pkg/registry/join/network_service_registry_client.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"context"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"google.golang.org/grpc"
+)
+
+type networkServiceRegistryClient struct {
+	clients []registry.NetworkServiceRegistryClient
+}
+
+func (n *networkServiceRegistryClient) RegisterNSE(ctx context.Context, in *registry.NSERegistration, opts ...grpc.CallOption) (*registry.NSERegistration, error) {
+	var result *registry.NSERegistration
+
+	for _, c := range n.clients {
+		r, err := c.RegisterNSE(ctx, in, opts...)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			result = r
+		}
+	}
+
+	return result, nil
+}
+
+type joinedServiceRegistryBulkNSEClient struct {
+	clients []registry.NetworkServiceRegistry_BulkRegisterNSEClient
+}
+
+func (j *joinedServiceRegistryBulkNSEClient) Send(r *registry.NSERegistration) error {
+	for _, c := range j.clients {
+		if err := c.Send(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *joinedServiceRegistryBulkNSEClient) Recv() (*registry.NSERegistration, error) {
+	var r *registry.NSERegistration
+	for _, c := range j.clients {
+		if msg, err := c.Recv(); err != nil {
+			return nil, err
+		} else if r == nil {
+			r = msg
+		}
+	}
+	return r, nil
+}
+
+func (j *joinedServiceRegistryBulkNSEClient) Header() (metadata.MD, error) {
+	if len(j.clients) > 0 {
+		return j.clients[0].Header()
+	}
+	return j.clients[0].Header()
+}
+
+func (j *joinedServiceRegistryBulkNSEClient) Trailer() metadata.MD {
+	if len(j.clients) > 0 {
+		return j.clients[0].Trailer()
+	}
+	return nil
+}
+
+func (j *joinedServiceRegistryBulkNSEClient) CloseSend() error {
+	for _, c := range j.clients {
+		if err := c.CloseSend(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *joinedServiceRegistryBulkNSEClient) Context() context.Context {
+	var contexts []context.Context
+	for _, c := range j.clients {
+		contexts = append(contexts, c.Context())
+	}
+	return Context(contexts...)
+}
+
+func (j *joinedServiceRegistryBulkNSEClient) SendMsg(m interface{}) error {
+	for _, c := range j.clients {
+		if err := c.SendMsg(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *joinedServiceRegistryBulkNSEClient) RecvMsg(m interface{}) error {
+	for _, c := range j.clients {
+		if err := c.RecvMsg(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (n *networkServiceRegistryClient) BulkRegisterNSE(ctx context.Context, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_BulkRegisterNSEClient, error) {
+	var clients []registry.NetworkServiceRegistry_BulkRegisterNSEClient
+	for _, c := range n.clients {
+		r, err := c.BulkRegisterNSE(ctx, opts...)
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, r)
+	}
+	return &joinedServiceRegistryBulkNSEClient{clients: clients}, nil
+}
+
+func (n *networkServiceRegistryClient) RemoveNSE(ctx context.Context, in *registry.RemoveNSERequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	for _, c := range n.clients {
+		_, err := c.RemoveNSE(ctx, in, opts...)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return new(empty.Empty), nil
+}
+
+func NewNetworkServiceRegistryClient(clients ...registry.NetworkServiceRegistryClient) registry.NetworkServiceRegistryClient {
+	return &networkServiceRegistryClient{clients: clients}
+}
+
+var _ registry.NetworkServiceRegistryClient = &networkServiceRegistryClient{}

--- a/pkg/registry/join/nsm_registry_client.go
+++ b/pkg/registry/join/nsm_registry_client.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package join
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"google.golang.org/grpc"
+)
+
+type nsmRegistryClient struct {
+	clients []registry.NsmRegistryClient
+}
+
+func (n *nsmRegistryClient) RegisterNSM(ctx context.Context, in *registry.NetworkServiceManager, opts ...grpc.CallOption) (*registry.NetworkServiceManager, error) {
+	for _, c := range n.clients {
+		_, _ = c.RegisterNSM(ctx, in, opts...)
+	}
+	return next.NSMRegistryClient(ctx).RegisterNSM(ctx, in, opts...)
+}
+
+func (n *nsmRegistryClient) GetEndpoints(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*registry.NetworkServiceEndpointList, error) {
+	var result = new(registry.NetworkServiceEndpointList)
+	var set = map[string]*registry.NetworkServiceEndpoint{}
+	for _, c := range n.clients {
+		list, err := c.GetEndpoints(ctx, in, opts...)
+		if err != nil {
+			return nil, err
+		}
+		for _, nse := range list.NetworkServiceEndpoints {
+			if _, ok := set[nse.Name]; ok {
+				continue
+			}
+			set[nse.Name] = nse
+			result.NetworkServiceEndpoints = append(result.NetworkServiceEndpoints, nse)
+		}
+	}
+	return result, nil
+}
+
+func NewNsmRegistryClient(clients ...registry.NsmRegistryClient) registry.NsmRegistryClient {
+	return &nsmRegistryClient{clients: clients}
+}
+
+var _ registry.NsmRegistryClient = &nsmRegistryClient{}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

Registry `join` chain elements add a possible to aggregate a few registry clients to one. It could be useful for `cmd-nsmgr`.

Depends on https://github.com/networkservicemesh/sdk/pull/241