### PR TITLE
Fix data races in RefreshClient

### DIFF
--- a/pkg/networkservice/common/refresh/client.go
+++ b/pkg/networkservice/common/refresh/client.go
@@ -35,16 +35,18 @@ import (
 )
 
 type refreshClient struct {
-	connectionTimers map[string]*time.Timer
-	executor         serialize.Executor
+	connectionTimers       map[string]*time.Timer
+	timerContextCancellers map[string]func()
+	executor               serialize.Executor
 }
 
 // NewClient - creates new NetworkServiceClient chain element for refreshing connections before they timeout at the
 // endpoint
 func NewClient() networkservice.NetworkServiceClient {
 	rv := &refreshClient{
-		connectionTimers: make(map[string]*time.Timer),
-		executor:         serialize.Executor{},
+		connectionTimers:       make(map[string]*time.Timer),
+		timerContextCancellers: make(map[string]func()),
+		executor:               serialize.Executor{},
 	}
 	return rv
 }
@@ -59,15 +61,24 @@ func (t *refreshClient) Request(ctx context.Context, request *networkservice.Net
 	// Set its connection to the returned connection we received
 	req.Connection = rv
 	// Setup the timer with the req containing the returned connection
-	ct, err := t.createTimer(ctx, req, opts...)
+
+	expire, err := t.getExpireDuration(request)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error creating timer from Request.Connection.Path.PathSegment[%d].ExpireTime", request.GetConnection().GetPath().GetIndex())
 	}
 	t.executor.AsyncExec(func() {
+		if ctx.Err() != nil {
+			return
+		}
 		if timer, ok := t.connectionTimers[req.GetConnection().GetId()]; ok {
 			timer.Stop()
 		}
-		t.connectionTimers[req.GetConnection().GetId()] = ct
+		if canceller, ok := t.timerContextCancellers[req.GetConnection().GetId()]; ok {
+			canceller()
+		}
+		timer, cancelFunc := t.createTimer(ctx, req, expire, opts...)
+		t.connectionTimers[req.GetConnection().GetId()] = timer
+		t.timerContextCancellers[req.GetConnection().GetId()] = cancelFunc
 	})
 	return rv, nil
 }
@@ -78,23 +89,31 @@ func (t *refreshClient) Close(ctx context.Context, conn *networkservice.Connecti
 			timer.Stop()
 			delete(t.connectionTimers, conn.GetId())
 		}
+		if canceller, ok := t.timerContextCancellers[conn.GetId()]; ok {
+			canceller()
+			delete(t.timerContextCancellers, conn.GetId())
+		}
 	})
 	return next.Client(ctx).Close(ctx, conn)
 }
 
-func (t *refreshClient) createTimer(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*time.Timer, error) {
+func (t *refreshClient) getExpireDuration(request *networkservice.NetworkServiceRequest) (time.Duration, error) {
 	expireTime, err := ptypes.Timestamp(request.GetConnection().GetPath().GetPathSegments()[request.GetConnection().GetPath().GetIndex()].GetExpires())
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	duration := time.Until(expireTime)
+	return duration, nil
+}
 
-	return time.AfterFunc(duration, func() {
+func (t *refreshClient) createTimer(ctx context.Context, request *networkservice.NetworkServiceRequest, expires time.Duration, opts ...grpc.CallOption) (timer *time.Timer, cancelFunc func()) {
+	newCtx, cancelFunc := context.WithCancel(extend.WithValuesFromContext(context.Background(), ctx))
+	timer = time.AfterFunc(expires, func() {
 		// TODO what to do about error handling?
 		// TODO what to do about expiration of context
-		newCtx := extend.WithValuesFromContext(context.Background(), ctx)
 		if _, err := t.Request(newCtx, request, opts...); err != nil {
 			trace.Log(newCtx).Errorf("Error while attempting to refresh connection %s: %+v", request.GetConnection().GetId(), err)
 		}
-	}), nil
+	})
+	return timer, cancelFunc
 }

--- a/pkg/networkservice/common/refresh/client.go
+++ b/pkg/networkservice/common/refresh/client.go
@@ -59,25 +59,37 @@ func (t *refreshClient) Request(ctx context.Context, request *networkservice.Net
 	req := request.Clone()
 	// Set its connection to the returned connection we received
 	req.Connection = rv
-	// Setup the timer with the req containing the returned connection
 
 	expire, err := t.getExpireDuration(request)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error creating timer from Request.Connection.Path.PathSegment[%d].ExpireTime", request.GetConnection().GetPath().GetIndex())
 	}
 	t.executor.AsyncExec(func() {
-		if refreshCtx := refreshContext(ctx); refreshCtx != nil && refreshCtx.Err() != nil {
-			return
+		// check if it is refresh request
+		if refreshCtx := refreshContext(ctx); refreshCtx != nil {
+			// refresh was canceled
+			if refreshCtx.Err() != nil {
+				return
+			}
+			// we reuse non-canceled refresh context for the next refresh request
+			timer := t.createTimer(ctx, req, expire, opts...)
+			t.connectionTimers[req.GetConnection().GetId()] = timer
+		} else {
+			// cancel refresh of previous request if any
+			if timer, ok := t.connectionTimers[req.GetConnection().GetId()]; ok {
+				timer.Stop()
+			}
+			if canceller, ok := t.refreshCancellers[req.GetConnection().GetId()]; ok {
+				canceller()
+			}
+			// add refresh context to request context
+			refreshCtx, cancelFunc := context.WithCancel(context.Background())
+			newCtx := withRefreshContext(ctx, refreshCtx)
+
+			timer := t.createTimer(newCtx, req, expire, opts...)
+			t.connectionTimers[req.GetConnection().GetId()] = timer
+			t.refreshCancellers[req.GetConnection().GetId()] = cancelFunc
 		}
-		if timer, ok := t.connectionTimers[req.GetConnection().GetId()]; ok {
-			timer.Stop()
-		}
-		if canceller, ok := t.refreshCancellers[req.GetConnection().GetId()]; ok {
-			canceller()
-		}
-		timer, cancelFunc := t.createTimer(ctx, req, expire, opts...)
-		t.connectionTimers[req.GetConnection().GetId()] = timer
-		t.refreshCancellers[req.GetConnection().GetId()] = cancelFunc
 	})
 	return rv, nil
 }
@@ -105,16 +117,13 @@ func (t *refreshClient) getExpireDuration(request *networkservice.NetworkService
 	return duration, nil
 }
 
-func (t *refreshClient) createTimer(ctx context.Context, request *networkservice.NetworkServiceRequest, expires time.Duration, opts ...grpc.CallOption) (timer *time.Timer, cancelFunc func()) {
-	refreshCtx, cancelFunc := context.WithCancel(context.Background())
-	newCtx := withRefreshContext(extend.WithValuesFromContext(context.Background(), ctx), refreshCtx)
-
-	timer = time.AfterFunc(expires, func() {
+func (t *refreshClient) createTimer(ctx context.Context, request *networkservice.NetworkServiceRequest, expires time.Duration, opts ...grpc.CallOption) *time.Timer {
+	newCtx := extend.WithValuesFromContext(context.Background(), ctx)
+	return time.AfterFunc(expires, func() {
 		// TODO what to do about error handling?
 		// TODO what to do about expiration of context
 		if _, err := t.Request(newCtx, request, opts...); err != nil {
 			trace.Log(newCtx).Errorf("Error while attempting to refresh connection %s: %+v", request.GetConnection().GetId(), err)
 		}
 	})
-	return timer, cancelFunc
 }

--- a/pkg/networkservice/common/refresh/context.go
+++ b/pkg/networkservice/common/refresh/context.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package refresh allows the setting of a refresh context in the context of the request
+package refresh
+
+import (
+	"context"
+)
+
+const (
+	refreshContextKey contextKeyType = "RefreshContext"
+)
+
+type contextKeyType string
+
+// withRefreshContext -
+//    Wraps 'parent' in a new Context that has the RefreshContext
+func withRefreshContext(parent, refreshContext context.Context) context.Context {
+	if parent == nil {
+		parent = context.TODO()
+	}
+	return context.WithValue(parent, refreshContextKey, refreshContext)
+}
+
+// refreshContext -
+//   Returns the RefreshContext
+func refreshContext(ctx context.Context) context.Context {
+	if rv, ok := ctx.Value(refreshContextKey).(context.Context); ok {
+		return rv
+	}
+	return nil
+}

--- a/pkg/networkservice/common/refresh/context.go
+++ b/pkg/networkservice/common/refresh/context.go
@@ -14,7 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package refresh allows the setting of a refresh context in the context of the request
+// Package refresh allows the setting of the refresh context into the context of the request.
+// Refresh context is used to distinguish requests with the same connectionID (repeating refresh requests will have
+// refreshContext while initial request and new requests from healClient will not) and to be able
+// to guarantee refresh canceling by canceling it's refresh context
 package refresh
 
 import (


### PR DESCRIPTION
Implementation of #237 
Fixed data race between refresh goroutines and close calls/new requests from heal. In some situations there wasn't enough to call `timer.Stop()` to really stop refresh goroutine. I've added context for each refresh and moved timer creation to synced block to fix it. 
Also fixed invalid second request initialization in `TestNewClient_StopRefreshAtAnotherRequest`, that also led to data race. 
Harmless refactoring.