### PR TITLE
Add endpoint url for identification

### DIFF
--- a/pkg/networkservice/common/localbypass/server.go
+++ b/pkg/networkservice/common/localbypass/server.go
@@ -40,7 +40,7 @@ type localBypassServer struct {
 }
 
 // NewServer - creates a NetworkServiceServer that tracks locally registered Endpoints substitutes their
-//             unix file socket as the clienturl.ClientURL(ctx) used to connect to them.
+//             passed endpoint_address with clienturl.ClientURL(ctx) used to connect to them.
 //             - server - *registry.NetworkServiceRegistryServer.  Since registry.NetworkServiceRegistryServer is an interface
 //                        (and thus a pointer) *registry.NetworkServiceRegistryServer is a double pointer.  Meaning it
 //                        points to a place that points to a place that implements registry.NetworkServiceRegistryServer

--- a/pkg/networkservice/common/localbypass/server_test.go
+++ b/pkg/networkservice/common/localbypass/server_test.go
@@ -105,17 +105,11 @@ func TestNewServer_UnixAddressRegistered(t *testing.T) {
 		},
 	}
 	_, err := localBypassRegistryServer.RegisterNSE(
-		peer.NewContext(context.Background(),
-			&peer.Peer{
-				Addr: &net.UnixAddr{
-					Name: "/var/run/nse-1.sock",
-					Net:  "unix",
-				},
-				AuthInfo: nil,
-			}),
+		context.Background(),
 		&registry.NSERegistration{
 			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
 				Name: "nse-1",
+				Url:  "unix:///var/run/nse-1.sock",
 			},
 		})
 	assert.Nil(t, err)
@@ -142,16 +136,11 @@ func TestNewServer_NonUnixAddressRegistered(t *testing.T) {
 		},
 	}
 	_, err := localBypassRegistryServer.RegisterNSE(
-		peer.NewContext(context.Background(),
-			&peer.Peer{
-				Addr: &net.IPAddr{
-					IP: net.IP{255, 255, 255, 255},
-				},
-				AuthInfo: nil,
-			}),
+		context.Background(),
 		&registry.NSERegistration{
 			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
 				Name: "nse-1",
+				Url:  "tcp://127.0.0.1:5002",
 			},
 		})
 	assert.Nil(t, err)
@@ -159,12 +148,14 @@ func TestNewServer_NonUnixAddressRegistered(t *testing.T) {
 	ctx := withTestData(context.Background(), &TestData{})
 	_, err = server.Request(ctx, request)
 	assert.Nil(t, err)
-	assert.Nil(t, testData(ctx).clientURL)
+	assert.Nil(t, err)
+	assert.Equal(t, &url.URL{Scheme: "tcp", Host: "127.0.0.1:5002"}, testData(ctx).clientURL)
 
 	ctx = withTestData(context.Background(), &TestData{})
 	_, err = server.Close(ctx, request.GetConnection())
 	assert.Nil(t, err)
-	assert.Nil(t, testData(ctx).clientURL)
+	assert.Nil(t, err)
+	assert.Equal(t, &url.URL{Scheme: "tcp", Host: "127.0.0.1:5002"}, testData(ctx).clientURL)
 }
 
 func TestNewServer_AddsNothingAfterNSERemoval(t *testing.T) {

--- a/pkg/registry/common/localbypass/server.go
+++ b/pkg/registry/common/localbypass/server.go
@@ -25,8 +25,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/localbypass"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"google.golang.org/grpc/peer"
-
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
@@ -44,14 +42,11 @@ func NewNetworkServiceRegistryServer(sockets localbypass.SocketMap) registry.Net
 }
 
 func (n *localBypassRegistry) RegisterNSE(ctx context.Context, request *registry.NSERegistration) (*registry.NSERegistration, error) {
-	p, ok := peer.FromContext(ctx)
-	if ok && p.Addr.Network() == "unix" && n.sockets != nil {
-		u := &url.URL{
-			Scheme: "unix",
-			Path:   p.Addr.String(),
-		}
-		n.sockets.LoadOrStore(request.GetNetworkServiceEndpoint().GetName(), u)
+	u, err := url.Parse(request.GetNetworkServiceEndpoint().GetUrl())
+	if err != nil {
+		return nil, err
 	}
+	n.sockets.LoadOrStore(request.GetNetworkServiceEndpoint().GetName(), u)
 	return next.NetworkServiceRegistryServer(ctx).RegisterNSE(ctx, request)
 }
 


### PR DESCRIPTION
Fix localbypass to use endpoint url for identification.

Depenes on:
https://github.com/networkservicemesh/api/pull/40

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>