### PR TITLE
Updated spire to handle entries via options

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -227,4 +227,4 @@ issues:
     - path: pkg/tools/spire/start.go
       linters:
         - funlen
-      text: "Function 'Start' has too many statements"
+        - gocyclo

--- a/pkg/tools/callback/callback.pb.go
+++ b/pkg/tools/callback/callback.pb.go
@@ -6,11 +6,12 @@ package callback
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/pkg/tools/spire/agent.conf.go
+++ b/pkg/tools/spire/agent.conf.go
@@ -41,6 +41,7 @@ plugins {
     }
     WorkloadAttestor "unix" {
         plugin_data {
+            discover_workload_path = true
         }
     }
 }

--- a/pkg/tools/spire/options.go
+++ b/pkg/tools/spire/options.go
@@ -1,0 +1,43 @@
+package spire
+
+import (
+	"context"
+)
+
+type entry struct {
+	spiffeID string
+	selector string
+}
+
+type option struct {
+	ctx     context.Context
+	agentID string
+	entries []*entry
+}
+
+// Option for spire
+type Option func(*option)
+
+// WithContext - use ctx as context for starting spire
+func WithContext(ctx context.Context) Option {
+	return func(o *option) {
+		o.ctx = ctx
+	}
+}
+
+// WithAgentID - agentID for starting spire
+func WithAgentID(agentID string) Option {
+	return func(o *option) {
+		o.agentID = agentID
+	}
+}
+
+// WithEntry - Option to add Entry to spire-server.  May be used multiple times.
+func WithEntry(spiffeID, selector string) Option {
+	return func(o *option) {
+		o.entries = append(o.entries, &entry{
+			spiffeID: spiffeID,
+			selector: selector,
+		})
+	}
+}


### PR DESCRIPTION
Turns out, spire-agent only polls spire-server
every 5 seconds.  This means that if we run spire-server, then
spire-agent, then add entries... it can take up to six seconds
to get our SVID.

By moving to options, we can:
1.  Start spire-server
2.  Create entries
3.  Start spire-agent

And spire-agent *starts* with the entries and can thus issue ids.