### PR TITLE
Small fixes for point2pointipam pkg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters-settings:
     threshold: 150
   funlen:
     Lines: 100
+    Statements: 50
   goconst:
     min-len: 2
     min-occurrences: 2


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

1. Moved tests to separate pkg `point2pointipam_test`
2. Used variadic syntax for point2pointipam.NewServer()
3. Do not use pkg "errors"
4. Added lazy init:
It changed signature from
```go
NewServer(...) (networkservice.NetworkServiceServer, error)
```
to
```go
NewServer(...) networkservice.NetworkServiceServer
```