### PR TITLE
Network Service Registry adapters

### DIFF
--- a/pkg/registry/core/next/clients/discovery_client.go
+++ b/pkg/registry/core/next/clients/discovery_client.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+)
+
+type discoveryClientToServer struct {
+	client registry.NetworkServiceDiscoveryClient
+}
+
+// NewNextDiscoveryClient - returns a registry.NetworkServiceDiscoveryClient wrapped around the supplied client, and allow to call next on passed context
+func NewNextDiscoveryClient(client registry.NetworkServiceDiscoveryClient) registry.NetworkServiceDiscoveryClient {
+	return &discoveryClientToServer{client: client}
+}
+
+func (c *discoveryClientToServer) FindNetworkService(ctx context.Context, request *registry.FindNetworkServiceRequest, opts ...grpc.CallOption) (*registry.FindNetworkServiceResponse, error) {
+	result, err := c.client.FindNetworkService(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var nextResult *registry.FindNetworkServiceResponse
+	nextResult, err = next.DiscoveryClient(ctx).FindNetworkService(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+	result.NetworkServiceEndpoints = append(result.NetworkServiceEndpoints, nextResult.NetworkServiceEndpoints...)
+	for k, v := range nextResult.NetworkServiceManagers {
+		result.NetworkServiceManagers[k] = v
+	}
+	return result, nil
+}
+
+// Implementation check
+var _ registry.NetworkServiceDiscoveryClient = &discoveryClientToServer{}

--- a/pkg/registry/core/next/clients/nsm_client.go
+++ b/pkg/registry/core/next/clients/nsm_client.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"context"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"google.golang.org/grpc"
+)
+
+type nsmServerToClient struct {
+	client registry.NsmRegistryClient
+}
+
+// NewNextNSMRegistryClient - returns a registry.NsmRegistryClient wrapped around the supplied client
+func NewNextNSMRegistryClient(client registry.NsmRegistryClient) registry.NsmRegistryClient {
+	return &nsmServerToClient{client: client}
+}
+
+func (n *nsmServerToClient) RegisterNSM(ctx context.Context, in *registry.NetworkServiceManager, opts ...grpc.CallOption) (*registry.NetworkServiceManager, error) {
+	result, err := n.client.RegisterNSM(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return next.NSMRegistryClient(ctx).RegisterNSM(ctx, result, opts...)
+}
+
+func (n *nsmServerToClient) GetEndpoints(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*registry.NetworkServiceEndpointList, error) {
+	result, err := n.client.GetEndpoints(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	var nextResult *registry.NetworkServiceEndpointList
+	nextResult, err = next.NSMRegistryClient(ctx).GetEndpoints(ctx, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	result.NetworkServiceEndpoints = append(result.NetworkServiceEndpoints, nextResult.NetworkServiceEndpoints...)
+	return result, nil
+}
+
+// Implementation check
+var _ registry.NsmRegistryClient = &nsmServerToClient{}

--- a/pkg/registry/core/next/clients/registry_client.go
+++ b/pkg/registry/core/next/clients/registry_client.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clients provides adapters to wrap clients with no support to next, to support it.
+package clients
+
+import (
+	"context"
+	"errors"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"google.golang.org/grpc"
+)
+
+type registryServerToClient struct {
+	client registry.NetworkServiceRegistryClient
+}
+
+// NewNextRegistryClient - returns a new registry.NetworkServiceRegistryClient that is a wrapper around client
+func NewNextRegistryClient(client registry.NetworkServiceRegistryClient) registry.NetworkServiceRegistryClient {
+	return &registryServerToClient{client: client}
+}
+
+func (r *registryServerToClient) RegisterNSE(ctx context.Context, registration *registry.NSERegistration, opts ...grpc.CallOption) (*registry.NSERegistration, error) {
+	result, err := r.client.RegisterNSE(ctx, registration)
+	if err != nil {
+		return nil, err
+	}
+	return next.NetworkServiceRegistryClient(ctx).RegisterNSE(ctx, result, opts...)
+}
+
+// BulkRegisterNSE - register in bulk
+func (r *registryServerToClient) BulkRegisterNSE(ctx context.Context, _ ...grpc.CallOption) (registry.NetworkServiceRegistry_BulkRegisterNSEClient, error) {
+	// TODO: will be removed
+	return nil, errors.New("not supported, and will be removed")
+}
+
+func (r *registryServerToClient) RemoveNSE(ctx context.Context, request *registry.RemoveNSERequest, opts ...grpc.CallOption) (*empty.Empty, error) {
+	_, err := r.client.RemoveNSE(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return next.NetworkServiceRegistryClient(ctx).RemoveNSE(ctx, request, opts...)
+}
+
+// Implementation check
+var _ registry.NetworkServiceRegistryClient = &registryServerToClient{}

--- a/pkg/registry/core/next/context.go
+++ b/pkg/registry/core/next/context.go
@@ -126,10 +126,17 @@ func withNextDiscoveryClient(parent context.Context, next registry.NetworkServic
 // DiscoveryClient -
 //   Returns the DiscoveryClient registry.NetworkServiceDiscoveryClient to be called in the chain from the context.Context
 func DiscoveryClient(ctx context.Context) registry.NetworkServiceDiscoveryClient {
-	if rv, ok := ctx.Value(nextDiscoveryClientKey).(registry.NetworkServiceDiscoveryClient); ok {
+	rv, ok := ctx.Value(nextDiscoveryClientKey).(registry.NetworkServiceDiscoveryClient)
+	if !ok {
+		server, ok := ctx.Value(nextDiscoveryServerKey).(registry.NetworkServiceDiscoveryServer)
+		if ok {
+			rv = adapters.NewDiscoveryServerToClient(server)
+		}
+	}
+	if rv != nil {
 		return rv
 	}
-	return nil
+	return &tailDiscoveryClient{}
 }
 
 // NSMRegistryClient -

--- a/pkg/registry/core/next/tail_discovery_client.go
+++ b/pkg/registry/core/next/tail_discovery_client.go
@@ -3,15 +3,21 @@ package next
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/networkservicemesh/api/pkg/api/registry"
-	"github.com/pkg/errors"
 )
 
 type tailDiscoveryClient struct {
 }
 
-func (t tailDiscoveryClient) FindNetworkService(context.Context, *registry.FindNetworkServiceRequest) (*registry.FindNetworkServiceResponse, error) {
-	return nil, errors.New("NetworkService is not found")
+func (t *tailDiscoveryClient) FindNetworkService(_ context.Context, request *registry.FindNetworkServiceRequest, _ ...grpc.CallOption) (*registry.FindNetworkServiceResponse, error) {
+	// Return empty
+	return &registry.FindNetworkServiceResponse{
+		NetworkService: &registry.NetworkService{
+			Name: request.NetworkServiceName,
+		},
+	}, nil
 }
 
-var _ registry.NetworkServiceDiscoveryServer = &tailDiscoveryClient{}
+var _ registry.NetworkServiceDiscoveryClient = &tailDiscoveryClient{}

--- a/pkg/registry/core/next/tail_discovery_server.go
+++ b/pkg/registry/core/next/tail_discovery_server.go
@@ -4,14 +4,18 @@ import (
 	"context"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
-	"github.com/pkg/errors"
 )
 
 type tailDiscoveryServer struct {
 }
 
-func (t tailDiscoveryServer) FindNetworkService(context.Context, *registry.FindNetworkServiceRequest) (*registry.FindNetworkServiceResponse, error) {
-	return nil, errors.New("NetworkService is not found")
+func (t tailDiscoveryServer) FindNetworkService(_ context.Context, request *registry.FindNetworkServiceRequest) (*registry.FindNetworkServiceResponse, error) {
+	// Return empty
+	return &registry.FindNetworkServiceResponse{
+		NetworkService: &registry.NetworkService{
+			Name: request.NetworkServiceName,
+		},
+	}, nil
 }
 
 var _ registry.NetworkServiceDiscoveryServer = &tailDiscoveryServer{}

--- a/pkg/registry/core/next/tail_nsm_registry_client.go
+++ b/pkg/registry/core/next/tail_nsm_registry_client.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
-	"github.com/pkg/errors"
 )
 
 type tailRegistryNSMServer struct{}
@@ -31,7 +30,8 @@ func (t tailRegistryNSMServer) RegisterNSM(_ context.Context, req *registry.Netw
 }
 
 func (t tailRegistryNSMServer) GetEndpoints(context.Context, *empty.Empty) (*registry.NetworkServiceEndpointList, error) {
-	return nil, errors.New("network service endpoints are not found")
+	//  return empty
+	return &registry.NetworkServiceEndpointList{}, nil
 }
 
 var _ registry.NsmRegistryServer = &tailRegistryNSMServer{}

--- a/pkg/registry/core/next/tail_nsm_registry_server.go
+++ b/pkg/registry/core/next/tail_nsm_registry_server.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
@@ -33,7 +32,8 @@ func (t *tailRegistryNSMClient) RegisterNSM(_ context.Context, in *registry.Netw
 }
 
 func (t *tailRegistryNSMClient) GetEndpoints(_ context.Context, _ *empty.Empty, _ ...grpc.CallOption) (*registry.NetworkServiceEndpointList, error) {
-	return nil, errors.New("network service endpoints are not found")
+	//  return empty
+	return &registry.NetworkServiceEndpointList{}, nil
 }
 
 var _ registry.NsmRegistryClient = &tailRegistryNSMClient{}


### PR DESCRIPTION
+ Network Service Registry adapters, to support next, in case of native(grpc, etc) clients.
* Fix for discovery next
* Tail should not return error.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>