### PR TITLE
Fix logrus usage concurrency

### DIFF
--- a/pkg/networkservice/core/trace/context.go
+++ b/pkg/networkservice/core/trace/context.go
@@ -42,14 +42,18 @@ func withLog(parent context.Context, log logrus.FieldLogger) context.Context {
 func Log(ctx context.Context) logrus.FieldLogger {
 	rv, ok := ctx.Value(logKey).(logrus.FieldLogger)
 	if !ok {
-		rv = &logrus.Logger{
+		logger := &logrus.Logger{
 			Out:          logrus.StandardLogger().Out,
 			Formatter:    logrus.StandardLogger().Formatter,
-			Hooks:        logrus.StandardLogger().Hooks,
+			Hooks:        make(logrus.LevelHooks),
 			Level:        logrus.StandardLogger().Level,
 			ExitFunc:     logrus.StandardLogger().ExitFunc,
 			ReportCaller: logrus.StandardLogger().ReportCaller,
 		}
+		for k, v := range logrus.StandardLogger().Hooks {
+			logger.Hooks[k] = v
+		}
+		rv = logger
 	}
 	return rv
 }

--- a/pkg/tools/spanhelper/span_helper.go
+++ b/pkg/tools/spanhelper/span_helper.go
@@ -61,10 +61,13 @@ func LogFromSpan(span opentracing.Span) logrus.FieldLogger {
 	logger := logrus.Logger{
 		Out:          logrus.StandardLogger().Out,
 		Formatter:    logrus.StandardLogger().Formatter,
-		Hooks:        logrus.StandardLogger().Hooks,
+		Hooks:        make(logrus.LevelHooks),
 		Level:        logrus.StandardLogger().Level,
 		ExitFunc:     logrus.StandardLogger().ExitFunc,
 		ReportCaller: logrus.StandardLogger().ReportCaller,
+	}
+	for k, v := range logrus.StandardLogger().Hooks {
+		logger.Hooks[k] = v
 	}
 	if span != nil {
 		logger := logger.WithField("span", span)


### PR DESCRIPTION
Direct usage of logrus.StandardLogger().Hooks may cause cuncurrent map troubles. So make a copy.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>