### PR TITLE
Fix data race in registry/core/next pkg

### DIFF
--- a/pkg/registry/core/next/ns_registry_client.go
+++ b/pkg/registry/core/next/ns_registry_client.go
@@ -36,40 +36,43 @@ type nextNetworkServiceRegistryClient struct {
 	nextParent registry.NetworkServiceRegistryClient
 }
 
-func (n nextNetworkServiceRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
+func (n *nextNetworkServiceRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceRegistryClient(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextClient := NetworkServiceRegistryClient(ctx); nextClient != nil {
+			nextParent = nextClient
 		}
 	}
 	if n.index+1 < len(n.clients) {
-		return n.clients[n.index].Find(withNextNSRegistryClient(ctx, &nextNetworkServiceRegistryClient{nextParent: n.nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
+		return n.clients[n.index].Find(withNextNSRegistryClient(ctx, &nextNetworkServiceRegistryClient{nextParent: nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
 	}
-	return n.clients[n.index].Find(withNextNSRegistryClient(ctx, n.nextParent), in)
+	return n.clients[n.index].Find(withNextNSRegistryClient(ctx, nextParent), in)
 }
 
-func (n nextNetworkServiceRegistryClient) Register(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*registry.NetworkService, error) {
+func (n *nextNetworkServiceRegistryClient) Register(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*registry.NetworkService, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceRegistryClient(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextClient := NetworkServiceRegistryClient(ctx); nextClient != nil {
+			nextParent = nextClient
 		}
 	}
 	if n.index+1 < len(n.clients) {
-		return n.clients[n.index].Register(withNextNSRegistryClient(ctx, &nextNetworkServiceRegistryClient{nextParent: n.nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
+		return n.clients[n.index].Register(withNextNSRegistryClient(ctx, &nextNetworkServiceRegistryClient{nextParent: nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
 	}
-	return n.clients[n.index].Register(withNextNSRegistryClient(ctx, n.nextParent), in)
+	return n.clients[n.index].Register(withNextNSRegistryClient(ctx, nextParent), in)
 }
 
-func (n nextNetworkServiceRegistryClient) Unregister(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*empty.Empty, error) {
+func (n *nextNetworkServiceRegistryClient) Unregister(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*empty.Empty, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceRegistryClient(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextClient := NetworkServiceRegistryClient(ctx); nextClient != nil {
+			nextParent = nextClient
 		}
 	}
 	if n.index+1 < len(n.clients) {
-		return n.clients[n.index].Unregister(withNextNSRegistryClient(ctx, &nextNetworkServiceRegistryClient{nextParent: n.nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
+		return n.clients[n.index].Unregister(withNextNSRegistryClient(ctx, &nextNetworkServiceRegistryClient{nextParent: nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
 	}
-	return n.clients[n.index].Unregister(withNextNSRegistryClient(ctx, n.nextParent), in)
+	return n.clients[n.index].Unregister(withNextNSRegistryClient(ctx, nextParent), in)
 }
 
 // NewWrappedNetworkServiceRegistryClient - creates a chain of servers with each one wrapped in wrapper

--- a/pkg/registry/core/next/ns_registry_server.go
+++ b/pkg/registry/core/next/ns_registry_server.go
@@ -38,22 +38,24 @@ type nextNetworkServiceRegistryServer struct {
 	nextParent registry.NetworkServiceRegistryServer
 }
 
-func (n nextNetworkServiceRegistryServer) Register(ctx context.Context, request *registry.NetworkService) (*registry.NetworkService, error) {
+func (n *nextNetworkServiceRegistryServer) Register(ctx context.Context, request *registry.NetworkService) (*registry.NetworkService, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceRegistryServer(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextServer := NetworkServiceRegistryServer(ctx); nextServer != nil {
+			nextParent = nextServer
 		}
 	}
 	if n.index+1 < len(n.servers) {
-		return n.servers[n.index].Register(withNextNSRegistryServer(ctx, &nextNetworkServiceRegistryServer{nextParent: n.nextParent, servers: n.servers, index: n.index + 1}), request)
+		return n.servers[n.index].Register(withNextNSRegistryServer(ctx, &nextNetworkServiceRegistryServer{nextParent: nextParent, servers: n.servers, index: n.index + 1}), request)
 	}
-	return n.servers[n.index].Register(withNextNSRegistryServer(ctx, n.nextParent), request)
+	return n.servers[n.index].Register(withNextNSRegistryServer(ctx, nextParent), request)
 }
 
-func (n nextNetworkServiceRegistryServer) Find(query *registry.NetworkServiceQuery, s registry.NetworkServiceRegistry_FindServer) error {
+func (n *nextNetworkServiceRegistryServer) Find(query *registry.NetworkServiceQuery, s registry.NetworkServiceRegistry_FindServer) error {
+	nextParent := n.nextParent
 	if n.index == 0 && s.Context() != nil {
-		if nextParent := NetworkServiceRegistryServer(s.Context()); nextParent != nil {
-			n.nextParent = nextParent
+		if nextServer := NetworkServiceRegistryServer(s.Context()); nextServer != nil {
+			nextParent = nextServer
 		}
 	}
 	if n.index+1 < len(n.servers) {
@@ -61,7 +63,7 @@ func (n nextNetworkServiceRegistryServer) Find(query *registry.NetworkServiceQue
 			streamcontext.NetworkServiceRegistryFindServer(
 				withNextNSRegistryServer(
 					s.Context(),
-					&nextNetworkServiceRegistryServer{nextParent: n.nextParent, servers: n.servers, index: n.index + 1}),
+					&nextNetworkServiceRegistryServer{nextParent: nextParent, servers: n.servers, index: n.index + 1}),
 				s,
 			),
 		)
@@ -70,22 +72,23 @@ func (n nextNetworkServiceRegistryServer) Find(query *registry.NetworkServiceQue
 		streamcontext.NetworkServiceRegistryFindServer(
 			withNextNSRegistryServer(
 				s.Context(),
-				n.nextParent),
+				nextParent),
 			s,
 		),
 	)
 }
 
-func (n nextNetworkServiceRegistryServer) Unregister(ctx context.Context, request *registry.NetworkService) (*empty.Empty, error) {
+func (n *nextNetworkServiceRegistryServer) Unregister(ctx context.Context, request *registry.NetworkService) (*empty.Empty, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceRegistryServer(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextServer := NetworkServiceRegistryServer(ctx); nextServer != nil {
+			nextParent = nextServer
 		}
 	}
 	if n.index+1 < len(n.servers) {
-		return n.servers[n.index].Unregister(withNextNSRegistryServer(ctx, &nextNetworkServiceRegistryServer{nextParent: n.nextParent, servers: n.servers, index: n.index + 1}), request)
+		return n.servers[n.index].Unregister(withNextNSRegistryServer(ctx, &nextNetworkServiceRegistryServer{nextParent: nextParent, servers: n.servers, index: n.index + 1}), request)
 	}
-	return n.servers[n.index].Unregister(withNextNSRegistryServer(ctx, n.nextParent), request)
+	return n.servers[n.index].Unregister(withNextNSRegistryServer(ctx, nextParent), request)
 }
 
 // NewWrappedNetworkServiceRegistryServer - creates a chain of servers with each one wrapped in wrapper

--- a/pkg/registry/core/next/nse_registry_client.go
+++ b/pkg/registry/core/next/nse_registry_client.go
@@ -37,15 +37,16 @@ type nextNetworkServiceEndpointRegistryClient struct {
 }
 
 func (n *nextNetworkServiceEndpointRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceEndpointRegistryClient(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextClient := NetworkServiceEndpointRegistryClient(ctx); nextClient != nil {
+			nextParent = nextClient
 		}
 	}
 	if n.index+1 < len(n.clients) {
-		return n.clients[n.index].Find(withNextNSERegistryClient(ctx, &nextNetworkServiceEndpointRegistryClient{nextParent: n.nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
+		return n.clients[n.index].Find(withNextNSERegistryClient(ctx, &nextNetworkServiceEndpointRegistryClient{nextParent: nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
 	}
-	return n.clients[n.index].Find(withNextNSERegistryClient(ctx, n.nextParent), in)
+	return n.clients[n.index].Find(withNextNSERegistryClient(ctx, nextParent), in)
 }
 
 func (n *nextNetworkServiceEndpointRegistryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {

--- a/pkg/registry/core/next/nse_registry_client.go
+++ b/pkg/registry/core/next/nse_registry_client.go
@@ -36,7 +36,7 @@ type nextNetworkServiceEndpointRegistryClient struct {
 	nextParent registry.NetworkServiceEndpointRegistryClient
 }
 
-func (n nextNetworkServiceEndpointRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+func (n *nextNetworkServiceEndpointRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
 	if n.index == 0 && ctx != nil {
 		if nextParent := NetworkServiceEndpointRegistryClient(ctx); nextParent != nil {
 			n.nextParent = nextParent
@@ -48,28 +48,30 @@ func (n nextNetworkServiceEndpointRegistryClient) Find(ctx context.Context, in *
 	return n.clients[n.index].Find(withNextNSERegistryClient(ctx, n.nextParent), in)
 }
 
-func (n nextNetworkServiceEndpointRegistryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+func (n *nextNetworkServiceEndpointRegistryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceEndpointRegistryClient(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextClient := NetworkServiceEndpointRegistryClient(ctx); nextClient != nil {
+			nextParent = nextClient
 		}
 	}
 	if n.index+1 < len(n.clients) {
-		return n.clients[n.index].Register(withNextNSERegistryClient(ctx, &nextNetworkServiceEndpointRegistryClient{nextParent: n.nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
+		return n.clients[n.index].Register(withNextNSERegistryClient(ctx, &nextNetworkServiceEndpointRegistryClient{nextParent: nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
 	}
-	return n.clients[n.index].Register(withNextNSERegistryClient(ctx, n.nextParent), in)
+	return n.clients[n.index].Register(withNextNSERegistryClient(ctx, nextParent), in)
 }
 
-func (n nextNetworkServiceEndpointRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+func (n *nextNetworkServiceEndpointRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceEndpointRegistryClient(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextClient := NetworkServiceEndpointRegistryClient(ctx); nextClient != nil {
+			nextParent = nextClient
 		}
 	}
 	if n.index+1 < len(n.clients) {
-		return n.clients[n.index].Unregister(withNextNSERegistryClient(ctx, &nextNetworkServiceEndpointRegistryClient{nextParent: n.nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
+		return n.clients[n.index].Unregister(withNextNSERegistryClient(ctx, &nextNetworkServiceEndpointRegistryClient{nextParent: nextParent, clients: n.clients, index: n.index + 1}), in, opts...)
 	}
-	return n.clients[n.index].Unregister(withNextNSERegistryClient(ctx, n.nextParent), in)
+	return n.clients[n.index].Unregister(withNextNSERegistryClient(ctx, nextParent), in)
 }
 
 // NewWrappedNetworkServiceEndpointRegistryClient - creates a chain of servers with each one wrapped in wrapper

--- a/pkg/registry/core/next/nse_registry_server.go
+++ b/pkg/registry/core/next/nse_registry_server.go
@@ -38,22 +38,24 @@ type nextNetworkServiceEndpointRegistryServer struct {
 	nextParent registry.NetworkServiceEndpointRegistryServer
 }
 
-func (n nextNetworkServiceEndpointRegistryServer) Register(ctx context.Context, request *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+func (n *nextNetworkServiceEndpointRegistryServer) Register(ctx context.Context, request *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceEndpointRegistryServer(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextServer := NetworkServiceEndpointRegistryServer(ctx); nextServer != nil {
+			nextParent = nextServer
 		}
 	}
 	if n.index+1 < len(n.servers) {
-		return n.servers[n.index].Register(withNextNSERegistryServer(ctx, &nextNetworkServiceEndpointRegistryServer{nextParent: n.nextParent, servers: n.servers, index: n.index + 1}), request)
+		return n.servers[n.index].Register(withNextNSERegistryServer(ctx, &nextNetworkServiceEndpointRegistryServer{nextParent: nextParent, servers: n.servers, index: n.index + 1}), request)
 	}
-	return n.servers[n.index].Register(withNextNSERegistryServer(ctx, n.nextParent), request)
+	return n.servers[n.index].Register(withNextNSERegistryServer(ctx, nextParent), request)
 }
 
-func (n nextNetworkServiceEndpointRegistryServer) Find(query *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
+func (n *nextNetworkServiceEndpointRegistryServer) Find(query *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
+	nextParent := n.nextParent
 	if n.index == 0 && s.Context() != nil {
-		if nextParent := NetworkServiceEndpointRegistryServer(s.Context()); nextParent != nil {
-			n.nextParent = nextParent
+		if nextServer := NetworkServiceEndpointRegistryServer(s.Context()); nextServer != nil {
+			nextParent = nextServer
 		}
 	}
 	if n.index+1 < len(n.servers) {
@@ -61,7 +63,7 @@ func (n nextNetworkServiceEndpointRegistryServer) Find(query *registry.NetworkSe
 			streamcontext.NetworkServiceEndpointRegistryFindServer(
 				withNextNSERegistryServer(
 					s.Context(),
-					&nextNetworkServiceEndpointRegistryServer{nextParent: n.nextParent, servers: n.servers, index: n.index + 1}),
+					&nextNetworkServiceEndpointRegistryServer{nextParent: nextParent, servers: n.servers, index: n.index + 1}),
 				s,
 			),
 		)
@@ -70,22 +72,23 @@ func (n nextNetworkServiceEndpointRegistryServer) Find(query *registry.NetworkSe
 		streamcontext.NetworkServiceEndpointRegistryFindServer(
 			withNextNSERegistryServer(
 				s.Context(),
-				n.nextParent),
+				nextParent),
 			s,
 		),
 	)
 }
 
-func (n nextNetworkServiceEndpointRegistryServer) Unregister(ctx context.Context, request *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+func (n *nextNetworkServiceEndpointRegistryServer) Unregister(ctx context.Context, request *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	nextParent := n.nextParent
 	if n.index == 0 && ctx != nil {
-		if nextParent := NetworkServiceEndpointRegistryServer(ctx); nextParent != nil {
-			n.nextParent = nextParent
+		if nextServer := NetworkServiceEndpointRegistryServer(ctx); nextServer != nil {
+			nextParent = nextServer
 		}
 	}
 	if n.index+1 < len(n.servers) {
-		return n.servers[n.index].Unregister(withNextNSERegistryServer(ctx, &nextNetworkServiceEndpointRegistryServer{nextParent: n.nextParent, servers: n.servers, index: n.index + 1}), request)
+		return n.servers[n.index].Unregister(withNextNSERegistryServer(ctx, &nextNetworkServiceEndpointRegistryServer{nextParent: nextParent, servers: n.servers, index: n.index + 1}), request)
 	}
-	return n.servers[n.index].Unregister(withNextNSERegistryServer(ctx, n.nextParent), request)
+	return n.servers[n.index].Unregister(withNextNSERegistryServer(ctx, nextParent), request)
 }
 
 // NewWrappedNetworkServiceEndpointRegistryServer - creates a chain of servers with each one wrapped in wrapper


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation


We've fixed a similar problem in `networkservice/core/next` pkg(https://github.com/networkservicemesh/sdk/pull/310)  but did not fix for registry.