### PR TITLE
Temporary fix for nextwrap

### DIFF
--- a/pkg/registry/core/nextwrap/ns_registry_client.go
+++ b/pkg/registry/core/nextwrap/ns_registry_client.go
@@ -19,6 +19,7 @@ package nextwrap
 
 import (
 	"context"
+	"io"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -40,9 +41,12 @@ func (r *nextNetworkServiceWrappedClient) Register(ctx context.Context, in *regi
 }
 
 func (r *nextNetworkServiceWrappedClient) Find(ctx context.Context, in *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
-	_, err := r.client.Find(ctx, in, opts...)
-	if err != nil {
+	client, err := r.client.Find(ctx, in, opts...)
+	if err != nil && err != io.EOF {
 		return nil, err
+	}
+	if client != nil {
+		return client, nil
 	}
 	return next.NetworkServiceRegistryClient(ctx).Find(ctx, in, opts...)
 }

--- a/pkg/registry/core/nextwrap/nse_registry_client.go
+++ b/pkg/registry/core/nextwrap/nse_registry_client.go
@@ -19,6 +19,7 @@ package nextwrap
 
 import (
 	"context"
+	"io"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -40,9 +41,12 @@ func (r *nextNetworkServiceEndpointWrappedClient) Register(ctx context.Context, 
 }
 
 func (r *nextNetworkServiceEndpointWrappedClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
-	_, err := r.client.Find(ctx, in, opts...)
-	if err != nil {
+	client, err := r.client.Find(ctx, in, opts...)
+	if err != nil && err != io.EOF {
 		return nil, err
+	}
+	if client != nil {
+		return client, nil
 	}
 	return next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, in, opts...)
 }


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation
Problem: In master branch nextwrap ignores inner client find stream result. This problem is blocking testing for nsmgr.

And we already have the fix for nextwrap https://github.com/networkservicemesh/sdk/pull/320, but @edwarnicke not sure in this patch because it adds some complexity for the registry chains. 

So we can just use some small temporary fix for this issue at this moment to do not block nsmgr stream.