### PR TITLE
Do not return io.EOF for tail server registry chain elements

### DIFF
--- a/pkg/registry/core/adapters/nse_registry.go
+++ b/pkg/registry/core/adapters/nse_registry.go
@@ -19,7 +19,6 @@ package adapters
 
 import (
 	"context"
-	"io"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -76,20 +75,18 @@ func (n *networkServiceEndpointRegistryClient) Register(ctx context.Context, in 
 	return n.server.Register(ctx, in)
 }
 
-func (n networkServiceEndpointRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+func (n *networkServiceEndpointRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
 	ch := make(chan *registry.NetworkServiceEndpoint, channelSize)
 	s := streamchannel.NewNetworkServiceEndpointFindServer(ctx, ch)
-	if err := n.server.Find(in, s); err != nil {
-		if err == io.EOF {
-			close(ch)
-		} else {
-			return nil, err
-		}
+	err := n.server.Find(in, s)
+	close(ch)
+	if err != nil {
+		return nil, err
 	}
 	return streamchannel.NewNetworkServiceEndpointFindClient(s.Context(), ch), nil
 }
 
-func (n networkServiceEndpointRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+func (n *networkServiceEndpointRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
 	return n.server.Unregister(ctx, in)
 }
 

--- a/pkg/registry/core/next/tail_nse_registry.go
+++ b/pkg/registry/core/next/tail_nse_registry.go
@@ -30,33 +30,48 @@ import (
 // of a chain to ensure that we never call a method on a nil object
 type tailNetworkServiceEndpointRegistryServer struct{}
 
-func (t tailNetworkServiceEndpointRegistryServer) Register(_ context.Context, r *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+func (t *tailNetworkServiceEndpointRegistryServer) Register(_ context.Context, r *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
 	return r, nil
 }
 
-func (t tailNetworkServiceEndpointRegistryServer) Find(*registry.NetworkServiceEndpointQuery, registry.NetworkServiceEndpointRegistry_FindServer) error {
-	return io.EOF
+func (t *tailNetworkServiceEndpointRegistryServer) Find(_ *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
+	return nil
 }
 
-func (t tailNetworkServiceEndpointRegistryServer) Unregister(context.Context, *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+func (t *tailNetworkServiceEndpointRegistryServer) Unregister(context.Context, *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
 	return new(empty.Empty), nil
 }
 
 var _ registry.NetworkServiceEndpointRegistryServer = &tailNetworkServiceEndpointRegistryServer{}
 
-// tailNetworkServiceEndpointRegistryServer is a simple implementation of registry.NetworkServiceEndpointRegistryServer that is called at the end
+// tailNetworkServiceEndpointRegistryClient is a simple implementation of registry.NetworkServiceEndpointRegistryClient that is called at the end
 // of a chain to ensure that we never call a method on a nil object
 type tailNetworkServiceEndpointRegistryClient struct{}
 
-func (t tailNetworkServiceEndpointRegistryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+func (t *tailNetworkServiceEndpointRegistryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
 	return in, nil
 }
 
-func (t tailNetworkServiceEndpointRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+type tailNetworkServiceEndpointRegistryFindClient struct {
+	grpc.ClientStream
+	ctx context.Context
+}
+
+func (t *tailNetworkServiceEndpointRegistryFindClient) Context() context.Context {
+	return t.ctx
+}
+
+func (t *tailNetworkServiceEndpointRegistryFindClient) Recv() (*registry.NetworkServiceEndpoint, error) {
 	return nil, io.EOF
 }
 
-func (t tailNetworkServiceEndpointRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+func (t *tailNetworkServiceEndpointRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+	return &tailNetworkServiceEndpointRegistryFindClient{ctx: ctx}, nil
+}
+
+func (t *tailNetworkServiceEndpointRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
 	return new(empty.Empty), nil
 }
 

--- a/pkg/registry/memory/ns_server_test.go
+++ b/pkg/registry/memory/ns_server_test.go
@@ -1,3 +1,19 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package memory_test
 
 import (
@@ -67,12 +83,14 @@ func TestNetworkServiceRegistryServer_RegisterAndFindWatch(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := make(chan *registry.NetworkService, 1)
-	_ = s.Find(&registry.NetworkServiceQuery{
-		Watch: true,
-		NetworkService: &registry.NetworkService{
-			Name: "a",
-		},
-	}, streamchannel.NewNetworkServiceFindServer(ctx, ch))
+	go func() {
+		_ = s.Find(&registry.NetworkServiceQuery{
+			Watch: true,
+			NetworkService: &registry.NetworkService{
+				Name: "a",
+			},
+		}, streamchannel.NewNetworkServiceFindServer(ctx, ch))
+	}()
 
 	require.Equal(t, &registry.NetworkService{
 		Name: "a",

--- a/pkg/registry/memory/nse_server_test.go
+++ b/pkg/registry/memory/nse_server_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
+	"github.com/networkservicemesh/sdk/pkg/registry/memory"
+)
+
+func TestNetworkServiceEndpointRegistryServer_RegisterAndFind(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	s := next.NewNetworkServiceEndpointRegistryServer(memory.NewNetworkServiceEndpointRegistryServer())
+
+	_, err := s.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "a",
+	})
+	require.NoError(t, err)
+
+	_, err = s.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "b",
+	})
+	require.NoError(t, err)
+
+	_, err = s.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "c",
+	})
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan *registry.NetworkServiceEndpoint, 1)
+	_ = s.Find(&registry.NetworkServiceEndpointQuery{
+		NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+			Name: "a",
+		},
+	}, streamchannel.NewNetworkServiceEndpointFindServer(ctx, ch))
+
+	require.Equal(t, &registry.NetworkServiceEndpoint{
+		Name: "a",
+	}, <-ch)
+	cancel()
+	close(ch)
+}
+
+func TestNetworkServiceEndpointRegistryServer_RegisterAndFindWatch(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	s := next.NewNetworkServiceEndpointRegistryServer(memory.NewNetworkServiceEndpointRegistryServer())
+
+	_, err := s.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "a",
+	})
+	require.NoError(t, err)
+
+	_, err = s.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "b",
+	})
+	require.NoError(t, err)
+
+	_, err = s.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "c",
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan *registry.NetworkServiceEndpoint, 1)
+	go func() {
+		_ = s.Find(&registry.NetworkServiceEndpointQuery{
+			Watch: true,
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+				Name: "a",
+			},
+		}, streamchannel.NewNetworkServiceEndpointFindServer(ctx, ch))
+	}()
+
+	require.Equal(t, &registry.NetworkServiceEndpoint{
+		Name: "a",
+	}, <-ch)
+
+	_, err = s.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "a",
+	})
+	require.NoError(t, err)
+	require.Equal(t, &registry.NetworkServiceEndpoint{
+		Name: "a",
+	}, <-ch)
+
+	cancel()
+	close(ch)
+}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>


## Motivation

@haiodo has found during nsmgr + registry grpc testing that we should get rid of using io.EOF for our adapters and next stream chain elements because it works wrong with grpc.

