### PR TITLE
Fix: adapted server should ignore io.eof from client

### DIFF
--- a/pkg/registry/core/adapters/common_test.go
+++ b/pkg/registry/core/adapters/common_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 Doc.ai, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters_test
+
+const adaptCountPerTest = 10

--- a/pkg/registry/core/adapters/ns_registry.go
+++ b/pkg/registry/core/adapters/ns_registry.go
@@ -18,6 +18,8 @@ package adapters
 
 import (
 	"context"
+	"io"
+	"strings"
 
 	"google.golang.org/grpc"
 
@@ -47,6 +49,9 @@ func (n *networkServiceRegistryServer) Find(query *registry.NetworkServiceQuery,
 		}
 		msg, err := client.Recv()
 		if err != nil {
+			if strings.HasSuffix(err.Error(), io.EOF.Error()) {
+				return nil
+			}
 			return err
 		}
 		err = s.Send(msg)

--- a/pkg/registry/core/adapters/ns_registry_test.go
+++ b/pkg/registry/core/adapters/ns_registry_test.go
@@ -1,3 +1,19 @@
+// Copyright (c) 2020 Doc.ai, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package adapters_test
 
 import (
@@ -13,13 +29,13 @@ import (
 	streamchannel "github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
 )
 
-type echoClient struct{}
+type echoNetworkServiceClient struct{}
 
-func (t *echoClient) Register(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*registry.NetworkService, error) {
+func (t *echoNetworkServiceClient) Register(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*registry.NetworkService, error) {
 	return in, nil
 }
 
-func (t *echoClient) Find(ctx context.Context, in *registry.NetworkServiceQuery, _ ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
+func (t *echoNetworkServiceClient) Find(ctx context.Context, in *registry.NetworkServiceQuery, _ ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
 	ch := make(chan *registry.NetworkService)
 	go func() {
 		ch <- in.NetworkService
@@ -28,7 +44,7 @@ func (t *echoClient) Find(ctx context.Context, in *registry.NetworkServiceQuery,
 	return streamchannel.NewNetworkServiceFindClient(ctx, ch), nil
 }
 
-func (t *echoClient) Unregister(_ context.Context, _ *registry.NetworkService, _ ...grpc.CallOption) (*empty.Empty, error) {
+func (t *echoNetworkServiceClient) Unregister(_ context.Context, _ *registry.NetworkService, _ ...grpc.CallOption) (*empty.Empty, error) {
 	return new(empty.Empty), nil
 }
 
@@ -36,19 +52,47 @@ func TestNetworkServiceClientToServer_Register(t *testing.T) {
 	expected := &registry.NetworkService{
 		Name: "echo",
 	}
-	client := &echoClient{}
-	s := adapters.NetworkServiceClientToServer(client)
-	actual, err := s.Register(context.Background(), expected)
-	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	for i := 1; i < adaptCountPerTest; i++ {
+		server := adaptNetworkServiceClientToServerFewTimes(i, &echoNetworkServiceClient{})
+		actual, err := server.Register(context.Background(), expected)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}
 }
 
 func TestNetworkServiceClientToServer_Unregister(t *testing.T) {
 	expected := &registry.NetworkService{
 		Name: "echo",
 	}
-	client := &echoClient{}
+	for i := 1; i < adaptCountPerTest; i++ {
+		server := adaptNetworkServiceClientToServerFewTimes(i, &echoNetworkServiceClient{})
+		_, err := server.Unregister(context.Background(), expected)
+		require.NoError(t, err)
+	}
+}
+
+func TestNetworkServiceFind(t *testing.T) {
+	for i := 1; i < adaptCountPerTest; i++ {
+		server := adaptNetworkServiceClientToServerFewTimes(i, &echoNetworkServiceClient{})
+		ch := make(chan *registry.NetworkService, 1)
+		s := streamchannel.NewNetworkServiceFindServer(context.Background(), ch)
+		err := server.Find(&registry.NetworkServiceQuery{NetworkService: &registry.NetworkService{Name: "test"}}, s)
+		require.Nil(t, err)
+		require.Equal(t, "test", (<-ch).Name)
+		close(ch)
+	}
+}
+
+func adaptNetworkServiceClientToServerFewTimes(n int, client registry.NetworkServiceRegistryClient) registry.NetworkServiceRegistryServer {
+	if n == 0 {
+		panic("n should be more or equal 1")
+	}
 	s := adapters.NetworkServiceClientToServer(client)
-	_, err := s.Unregister(context.Background(), expected)
-	require.NoError(t, err)
+
+	for i := 1; i < n; i++ {
+		client = adapters.NetworkServiceServerToClient(s)
+		s = adapters.NetworkServiceClientToServer(client)
+	}
+
+	return s
 }

--- a/pkg/registry/core/adapters/nse_registry.go
+++ b/pkg/registry/core/adapters/nse_registry.go
@@ -19,6 +19,8 @@ package adapters
 
 import (
 	"context"
+	"io"
+	"strings"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -47,6 +49,9 @@ func (n *networkServiceEndpointRegistryServer) Find(query *registry.NetworkServi
 		}
 		msg, err := client.Recv()
 		if err != nil {
+			if strings.HasSuffix(err.Error(), io.EOF.Error()) {
+				return nil
+			}
 			return err
 		}
 		err = s.Send(msg)

--- a/pkg/registry/core/adapters/nse_registry_test.go
+++ b/pkg/registry/core/adapters/nse_registry_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2020 Doc.ai, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapters_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
+	streamchannel "github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
+)
+
+type echoNetworkServiceEndpointClient struct{}
+
+func (t *echoNetworkServiceEndpointClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	return in, nil
+}
+
+func (t *echoNetworkServiceEndpointClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, _ ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+	ch := make(chan *registry.NetworkServiceEndpoint)
+	go func() {
+		ch <- in.NetworkServiceEndpoint
+		close(ch)
+	}()
+	return streamchannel.NewNetworkServiceEndpointFindClient(ctx, ch), nil
+}
+
+func (t *echoNetworkServiceEndpointClient) Unregister(_ context.Context, _ *registry.NetworkServiceEndpoint, _ ...grpc.CallOption) (*empty.Empty, error) {
+	return new(empty.Empty), nil
+}
+
+func TestNetworkServiceEndpointClientToServer_Register(t *testing.T) {
+	expected := &registry.NetworkServiceEndpoint{
+		Name: "echo",
+	}
+	for i := 1; i < adaptCountPerTest; i++ {
+		server := adaptNetworkServiceEndpointClientToServerFewTimes(i, &echoNetworkServiceEndpointClient{})
+		actual, err := server.Register(context.Background(), expected)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}
+}
+
+func TestNetworkServiceEndpointClientToServer_Unregister(t *testing.T) {
+	expected := &registry.NetworkServiceEndpoint{
+		Name: "echo",
+	}
+	for i := 1; i < adaptCountPerTest; i++ {
+		server := adaptNetworkServiceEndpointClientToServerFewTimes(i, &echoNetworkServiceEndpointClient{})
+		_, err := server.Unregister(context.Background(), expected)
+		require.NoError(t, err)
+	}
+}
+
+func TestNetworkServiceEndpointFind(t *testing.T) {
+	for i := 1; i < adaptCountPerTest; i++ {
+		server := adaptNetworkServiceEndpointClientToServerFewTimes(i, &echoNetworkServiceEndpointClient{})
+		ch := make(chan *registry.NetworkServiceEndpoint, 1)
+		s := streamchannel.NewNetworkServiceEndpointFindServer(context.Background(), ch)
+		err := server.Find(&registry.NetworkServiceEndpointQuery{NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: "test"}}, s)
+		require.Nil(t, err)
+		require.Equal(t, "test", (<-ch).Name)
+		close(ch)
+	}
+}
+
+func adaptNetworkServiceEndpointClientToServerFewTimes(n int, client registry.NetworkServiceEndpointRegistryClient) registry.NetworkServiceEndpointRegistryServer {
+	if n == 0 {
+		panic("n should be more or equal 1")
+	}
+	s := adapters.NetworkServiceEndpointClientToServer(client)
+
+	for i := 1; i < n; i++ {
+		client = adapters.NetworkServiceEndpointServerToClient(s)
+		s = adapters.NetworkServiceEndpointClientToServer(client)
+	}
+
+	return s
+}

--- a/pkg/registry/core/streamchannel/ns_registry_stream_channel.go
+++ b/pkg/registry/core/streamchannel/ns_registry_stream_channel.go
@@ -18,6 +18,7 @@ package streamchannel
 
 import (
 	"context"
+	"io"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/pkg/errors"
@@ -42,7 +43,7 @@ type networkServiceRegistryFindClient struct {
 func (c *networkServiceRegistryFindClient) Recv() (*registry.NetworkService, error) {
 	res, ok := <-c.recvCh
 	if !ok {
-		err := errors.New("recv channel has been closed")
+		err := io.EOF
 		if c.err == nil {
 			return nil, err
 		}

--- a/pkg/registry/core/streamchannel/nse_registry_stream_channel.go
+++ b/pkg/registry/core/streamchannel/nse_registry_stream_channel.go
@@ -19,6 +19,7 @@ package streamchannel
 
 import (
 	"context"
+	"io"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/pkg/errors"
@@ -43,7 +44,7 @@ type networkServiceEndpointRegistryFindClient struct {
 func (c *networkServiceEndpointRegistryFindClient) Recv() (*registry.NetworkServiceEndpoint, error) {
 	res, ok := <-c.recvCh
 	if !ok {
-		err := errors.New("recv channel has been closed")
+		err := io.EOF
 		if c.err == nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

An adapted server should ignore EOF error from the wrapped client