### PR TITLE
Introduce simple server.WithCallbackDialer() that does not require arguments

### DIFF
--- a/pkg/tools/callback/readme.md
+++ b/pkg/tools/callback/readme.md
@@ -30,7 +30,7 @@ And then require to call client.
 target := "callback:{client-authority}"
 // If target is not in a list of callback server targets, 
 // it will perform grpc.DialContext to connect to passed target
-nsmClientGRPC, err := grpc.DialContext(context.Background(), target, callback.WithCallbackDialer(server.callbackServer, target), grpc.WithInsecure())
+nsmClientGRPC, err := grpc.DialContext(context.Background(), target, callbackServer.WithCallbackDialer(), grpc.WithInsecure())
 nsmClient := networkservice.NewNetworkServiceClient(nsmClientGRPC)
 
 resp, _ := nsmClient.Request(context.Background(), &networkservice.NetworkServiceRequest{

--- a/pkg/tools/callback/server_test.go
+++ b/pkg/tools/callback/server_test.go
@@ -197,7 +197,7 @@ func TestServerClientInvoke(t *testing.T) {
 	clientID := server.waitClient(server, client, t)
 
 	// Do a normal GRPC stuff inside.
-	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, callback.WithCallbackDialer(server.callbackServer, clientID), grpc.WithInsecure(), grpc.WithBlock())
+	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, server.callbackServer.WithCallbackDialer(), grpc.WithInsecure(), grpc.WithBlock())
 	require.Nil(t, err3)
 	defer func() { _ = nsmClientGRPC.Close() }()
 	nsmClient := networkservice.NewNetworkServiceClient(nsmClientGRPC)
@@ -227,7 +227,7 @@ func TestServerClientInvokeNoSecurity(t *testing.T) {
 	clientID := server.waitClient(server, client, t)
 
 	// Do a normal GRPC stuff inside.
-	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, callback.WithCallbackDialer(server.callbackServer, clientID))
+	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, server.callbackServer.WithCallbackDialer())
 	require.NotNil(t, err3)
 	require.Nil(t, nsmClientGRPC)
 }
@@ -247,7 +247,7 @@ func TestServerClientInvokeClose(t *testing.T) {
 	clientID := server.waitClient(server, client, t)
 
 	// Do a normal GRPC stuff inside.
-	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, callback.WithCallbackDialer(server.callbackServer, clientID), grpc.WithInsecure())
+	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, server.callbackServer.WithCallbackDialer(), grpc.WithInsecure())
 	require.NotNil(t, nsmClientGRPC)
 	require.Nil(t, err3)
 	err4 := nsmClientGRPC.Close()
@@ -317,7 +317,7 @@ func TestServerClientInvokeWithPeerAuth(t *testing.T) {
 	clientID := server.waitClient(server, client, t)
 
 	// Do a normal GRPC stuff inside.
-	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, callback.WithCallbackDialer(server.callbackServer, clientID), grpc.WithInsecure())
+	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, server.callbackServer.WithCallbackDialer(), grpc.WithInsecure())
 	defer func() { _ = nsmClientGRPC.Close() }()
 	require.Nil(t, err3)
 	nsmClient := networkservice.NewNetworkServiceClient(nsmClientGRPC)
@@ -401,7 +401,7 @@ func BenchmarkServerClientInvoke(b *testing.B) {
 	clientID := server.waitClient(server, client, b)
 
 	// Do a normal GRPC stuff inside.
-	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, callback.WithCallbackDialer(server.callbackServer, clientID), grpc.WithInsecure())
+	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, server.callbackServer.WithCallbackDialer(), grpc.WithInsecure())
 	require.Nil(b, err3)
 	nsmClient := networkservice.NewNetworkServiceClient(nsmClientGRPC)
 
@@ -525,7 +525,7 @@ func TestServerClientConnectionMonitor(t *testing.T) {
 	}
 	callbackServer.AddListener(ids)
 	clientID := waitClientConnected(callbackClient, t, ids)
-	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, callback.WithCallbackDialer(callbackServer, clientID), grpc.WithInsecure())
+	nsmClientGRPC, err3 := grpc.DialContext(context.Background(), clientID, callbackServer.WithCallbackDialer(), grpc.WithInsecure())
 	defer func() { _ = nsmClientGRPC.Close() }()
 	require.Nil(t, err3)
 	nsmClient := networkservice.NewMonitorConnectionClient(nsmClientGRPC)


### PR DESCRIPTION
In many places in our code, we need to be able to pass in a simple grpc.DialOption
rather than a function that can be called to return them.  This makes that possible.