### PR TITLE
Registry refresh client should be able to set a default expiration time for NSE

### DIFF
--- a/pkg/registry/common/expire/ns_server_test.go
+++ b/pkg/registry/common/expire/ns_server_test.go
@@ -60,13 +60,15 @@ func TestNewNetworkServiceRegistryServer(t *testing.T) {
 	require.Nil(t, err)
 	list := registry.ReadNetworkServiceList(stream)
 	require.NotEmpty(t, list)
-	<-time.After(testPeriod * 4)
-	stream, err = nsClient.Find(context.Background(), &registry.NetworkServiceQuery{
-		NetworkService: &registry.NetworkService{},
-	})
-	require.Nil(t, err)
-	list = registry.ReadNetworkServiceList(stream)
-	require.Empty(t, list)
+
+	require.Eventually(t, func() bool {
+		stream, err = nsClient.Find(context.Background(), &registry.NetworkServiceQuery{
+			NetworkService: &registry.NetworkService{},
+		})
+		require.Nil(t, err)
+		list = registry.ReadNetworkServiceList(stream)
+		return len(list) == 0
+	}, time.Second, time.Millisecond*100)
 }
 
 func TestNewNetworkServiceRegistryServer_NSEUnregister(t *testing.T) {
@@ -103,11 +105,12 @@ func TestNewNetworkServiceRegistryServer_NSEUnregister(t *testing.T) {
 		NetworkServiceNames: []string{"IP terminator"},
 	})
 	require.Nil(t, err)
-	<-time.After(testPeriod * 4)
-	stream, err = nsClient.Find(context.Background(), &registry.NetworkServiceQuery{
-		NetworkService: &registry.NetworkService{},
-	})
-	require.Nil(t, err)
-	list = registry.ReadNetworkServiceList(stream)
-	require.Empty(t, list)
+	require.Eventually(t, func() bool {
+		stream, err = nsClient.Find(context.Background(), &registry.NetworkServiceQuery{
+			NetworkService: &registry.NetworkService{},
+		})
+		require.Nil(t, err)
+		list = registry.ReadNetworkServiceList(stream)
+		return len(list) == 0
+	}, time.Second, time.Millisecond*100)
 }

--- a/pkg/registry/common/expire/ns_server_test.go
+++ b/pkg/registry/common/expire/ns_server_test.go
@@ -60,7 +60,7 @@ func TestNewNetworkServiceRegistryServer(t *testing.T) {
 	require.Nil(t, err)
 	list := registry.ReadNetworkServiceList(stream)
 	require.NotEmpty(t, list)
-	<-time.After(testPeriod * 3)
+	<-time.After(testPeriod * 4)
 	stream, err = nsClient.Find(context.Background(), &registry.NetworkServiceQuery{
 		NetworkService: &registry.NetworkService{},
 	})
@@ -103,7 +103,7 @@ func TestNewNetworkServiceRegistryServer_NSEUnregister(t *testing.T) {
 		NetworkServiceNames: []string{"IP terminator"},
 	})
 	require.Nil(t, err)
-	<-time.After(testPeriod * 3)
+	<-time.After(testPeriod * 4)
 	stream, err = nsClient.Find(context.Background(), &registry.NetworkServiceQuery{
 		NetworkService: &registry.NetworkService{},
 	})

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -47,11 +47,12 @@ func TestNewNetworkServiceEndpointRegistryServer(t *testing.T) {
 	require.Nil(t, err)
 	list := registry.ReadNetworkServiceEndpointList(stream)
 	require.NotEmpty(t, list)
-	<-time.After(testPeriod * 3)
-	stream, err = c.Find(context.Background(), &registry.NetworkServiceEndpointQuery{
-		NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{},
-	})
-	require.Nil(t, err)
-	list = registry.ReadNetworkServiceEndpointList(stream)
-	require.Empty(t, list)
+	require.Eventually(t, func() bool {
+		stream, err = c.Find(context.Background(), &registry.NetworkServiceEndpointQuery{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{},
+		})
+		require.Nil(t, err)
+		list = registry.ReadNetworkServiceEndpointList(stream)
+		return len(list) == 0
+	}, time.Second, time.Millisecond*100)
 }

--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/timestamp"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"google.golang.org/grpc"
@@ -29,10 +31,15 @@ import (
 )
 
 type refreshNSEClient struct {
-	client     registry.NetworkServiceEndpointRegistryClient
-	nsesMutex  sync.Mutex
-	nses       map[string]func()
-	retryDelay time.Duration
+	client                    registry.NetworkServiceEndpointRegistryClient
+	nsesMutex                 sync.Mutex
+	nses                      map[string]func()
+	retryDelay                time.Duration
+	defaultExpirationDuration time.Duration
+}
+
+func (c *refreshNSEClient) setDefaultExpiration(duration time.Duration) {
+	c.defaultExpirationDuration = duration
 }
 
 func (c *refreshNSEClient) setRetryPeriod(p time.Duration) {
@@ -70,6 +77,16 @@ func (c *refreshNSEClient) Register(ctx context.Context, in *registry.NetworkSer
 	}
 	c.nsesMutex.Lock()
 	defer c.nsesMutex.Unlock()
+	if resp.ExpirationTime == nil {
+		expirationTime := time.Now().Add(c.defaultExpirationDuration)
+		resp.ExpirationTime = &timestamp.Timestamp{
+			Seconds: expirationTime.Unix(),
+			Nanos:   int32(expirationTime.Nanosecond()),
+		}
+	}
+	if v, ok := c.nses[resp.Name]; ok {
+		v()
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	c.nses[resp.Name] = cancel
 	c.startRefresh(ctx, resp)
@@ -98,9 +115,10 @@ func (c *refreshNSEClient) Unregister(ctx context.Context, in *registry.NetworkS
 // NewNetworkServiceEndpointRegistryClient creates new NetworkServiceEndpointRegistryClient that will refresh expiration time for registered NSEs
 func NewNetworkServiceEndpointRegistryClient(client registry.NetworkServiceEndpointRegistryClient, options ...Option) registry.NetworkServiceEndpointRegistryClient {
 	c := &refreshNSEClient{
-		client:     client,
-		nses:       map[string]func(){},
-		retryDelay: time.Second * 5,
+		client:                    client,
+		nses:                      map[string]func(){},
+		retryDelay:                time.Second * 5,
+		defaultExpirationDuration: time.Minute * 30,
 	}
 
 	for _, o := range options {

--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -55,14 +54,29 @@ func (t *testNSEClient) Unregister(ctx context.Context, in *registry.NetworkServ
 func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	testClient := testNSEClient{}
-	refreshClient := refresh.NewNetworkServiceEndpointRegistryClient(&testClient, refresh.WithRetryPeriod(time.Millisecond*100))
-	expirationTime := time.Now().Add(time.Millisecond * 100)
+	refreshClient := refresh.NewNetworkServiceEndpointRegistryClient(&testClient, refresh.WithRetryPeriod(time.Millisecond*100), refresh.WithDefaultExpiration(time.Millisecond*100))
 	_, err := refreshClient.Register(context.Background(), &registry.NetworkServiceEndpoint{
 		Name: "nse-1",
-		ExpirationTime: &timestamp.Timestamp{
-			Seconds: expirationTime.Unix(),
-			Nanos:   int32(expirationTime.Nanosecond()),
-		},
+	})
+	require.Nil(t, err)
+	<-time.After(time.Millisecond * 100)
+	_, err = refreshClient.Unregister(context.Background(), &registry.NetworkServiceEndpoint{Name: "nse-1"})
+	require.Nil(t, err)
+	testClient.Lock()
+	defer testClient.Unlock()
+	require.Equal(t, 1, testClient.requestCount)
+}
+
+func TestNewNetworkServiceEndpointRegistryClient_CalledRegisterTwice(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	testClient := testNSEClient{}
+	refreshClient := refresh.NewNetworkServiceEndpointRegistryClient(&testClient, refresh.WithRetryPeriod(time.Millisecond*100), refresh.WithDefaultExpiration(time.Millisecond*100))
+	_, err := refreshClient.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "nse-1",
+	})
+	require.Nil(t, err)
+	_, err = refreshClient.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: "nse-1",
 	})
 	require.Nil(t, err)
 	<-time.After(time.Millisecond * 100)

--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -54,7 +54,10 @@ func (t *testNSEClient) Unregister(ctx context.Context, in *registry.NetworkServ
 func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	testClient := testNSEClient{}
-	refreshClient := refresh.NewNetworkServiceEndpointRegistryClient(&testClient, refresh.WithRetryPeriod(time.Millisecond*100), refresh.WithDefaultExpiration(time.Millisecond*100))
+	refreshClient := refresh.NewNetworkServiceEndpointRegistryClient(&testClient,
+		refresh.WithRetryPeriod(time.Millisecond*100),
+		refresh.WithDefaultExpiration(time.Millisecond*100),
+	)
 	_, err := refreshClient.Register(context.Background(), &registry.NetworkServiceEndpoint{
 		Name: "nse-1",
 	})
@@ -70,7 +73,10 @@ func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
 func TestNewNetworkServiceEndpointRegistryClient_CalledRegisterTwice(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	testClient := testNSEClient{}
-	refreshClient := refresh.NewNetworkServiceEndpointRegistryClient(&testClient, refresh.WithRetryPeriod(time.Millisecond*100), refresh.WithDefaultExpiration(time.Millisecond*100))
+	refreshClient := refresh.NewNetworkServiceEndpointRegistryClient(&testClient,
+		refresh.WithRetryPeriod(time.Millisecond*100),
+		refresh.WithDefaultExpiration(time.Millisecond*100),
+	)
 	_, err := refreshClient.Register(context.Background(), &registry.NetworkServiceEndpoint{
 		Name: "nse-1",
 	})

--- a/pkg/registry/common/refresh/options.go
+++ b/pkg/registry/common/refresh/options.go
@@ -20,6 +20,7 @@ import "time"
 
 type configurable interface {
 	setRetryPeriod(time.Duration)
+	setDefaultExpiration(duration time.Duration)
 }
 
 // Option is expire registry configuration option
@@ -37,5 +38,12 @@ func (f applierFunc) apply(c configurable) {
 func WithRetryPeriod(duration time.Duration) Option {
 	return applierFunc(func(c configurable) {
 		c.setRetryPeriod(duration)
+	})
+}
+
+// WithDefaultExpiration sets a default expiration to NSE if expiration was not set
+func WithDefaultExpiration(duration time.Duration) Option {
+	return applierFunc(func(c configurable) {
+		c.setDefaultExpiration(duration)
 	})
 }


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Context

https://github.com/networkservicemesh/sdk/issues/308

## Motivation

If refresh client tries to register NSE with expiration_time = nil then it can set some default value.
