### PR TITLE
Fix: refresh client should set expire_time before call the next client

### DIFF
--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -31,15 +31,15 @@ import (
 )
 
 type refreshNSEClient struct {
-	client                    registry.NetworkServiceEndpointRegistryClient
-	nsesMutex                 sync.Mutex
-	nseCancels                map[string]context.CancelFunc
-	retryDelay                time.Duration
-	defaultExpirationDuration time.Duration
+	client                registry.NetworkServiceEndpointRegistryClient
+	nsesMutex             sync.Mutex
+	nseCancels            map[string]context.CancelFunc
+	retryDelay            time.Duration
+	defaultExpiryDuration time.Duration
 }
 
-func (c *refreshNSEClient) setDefaultExpiration(duration time.Duration) {
-	c.defaultExpirationDuration = duration
+func (c *refreshNSEClient) setDefaultExpiryDuration(duration time.Duration) {
+	c.defaultExpiryDuration = duration
 }
 
 func (c *refreshNSEClient) setRetryPeriod(p time.Duration) {
@@ -71,19 +71,19 @@ func (c *refreshNSEClient) startRefresh(ctx context.Context, nse *registry.Netwo
 }
 
 func (c *refreshNSEClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	if in.ExpirationTime == nil {
+		expirationTime := time.Now().Add(c.defaultExpiryDuration)
+		in.ExpirationTime = &timestamp.Timestamp{
+			Seconds: expirationTime.Unix(),
+			Nanos:   int32(expirationTime.Nanosecond()),
+		}
+	}
 	resp, err := next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, in, opts...)
 	if err != nil {
 		return nil, err
 	}
 	c.nsesMutex.Lock()
 	defer c.nsesMutex.Unlock()
-	if resp.ExpirationTime == nil {
-		expirationTime := time.Now().Add(c.defaultExpirationDuration)
-		resp.ExpirationTime = &timestamp.Timestamp{
-			Seconds: expirationTime.Unix(),
-			Nanos:   int32(expirationTime.Nanosecond()),
-		}
-	}
 	if v, ok := c.nseCancels[resp.Name]; ok {
 		v()
 	}
@@ -115,10 +115,10 @@ func (c *refreshNSEClient) Unregister(ctx context.Context, in *registry.NetworkS
 // NewNetworkServiceEndpointRegistryClient creates new NetworkServiceEndpointRegistryClient that will refresh expiration time for registered NSEs
 func NewNetworkServiceEndpointRegistryClient(client registry.NetworkServiceEndpointRegistryClient, options ...Option) registry.NetworkServiceEndpointRegistryClient {
 	c := &refreshNSEClient{
-		client:                    client,
-		nseCancels:                map[string]context.CancelFunc{},
-		retryDelay:                time.Second * 5,
-		defaultExpirationDuration: time.Minute * 30,
+		client:                client,
+		nseCancels:            map[string]context.CancelFunc{},
+		retryDelay:            time.Second * 5,
+		defaultExpiryDuration: time.Minute * 30,
 	}
 
 	for _, o := range options {

--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -38,14 +38,6 @@ type refreshNSEClient struct {
 	defaultExpiryDuration time.Duration
 }
 
-func (c *refreshNSEClient) setDefaultExpiryDuration(duration time.Duration) {
-	c.defaultExpiryDuration = duration
-}
-
-func (c *refreshNSEClient) setRetryPeriod(p time.Duration) {
-	c.retryDelay = p
-}
-
 func (c *refreshNSEClient) startRefresh(ctx context.Context, nse *registry.NetworkServiceEndpoint) {
 	t := time.Unix(nse.ExpirationTime.Seconds, int64(nse.ExpirationTime.Nanos))
 	delta := time.Until(t)

--- a/pkg/registry/common/refresh/options.go
+++ b/pkg/registry/common/refresh/options.go
@@ -18,32 +18,27 @@ package refresh
 
 import "time"
 
-type configurable interface {
-	setRetryPeriod(time.Duration)
-	setDefaultExpiryDuration(duration time.Duration)
-}
-
 // Option is expire registry configuration option
 type Option interface {
-	apply(configurable)
+	apply(client *refreshNSEClient)
 }
 
-type applierFunc func(configurable)
+type applierFunc func(*refreshNSEClient)
 
-func (f applierFunc) apply(c configurable) {
+func (f applierFunc) apply(c *refreshNSEClient) {
 	f(c)
 }
 
 // WithRetryPeriod sets a specific period to reconnect in case of a server returning an error
 func WithRetryPeriod(duration time.Duration) Option {
-	return applierFunc(func(c configurable) {
-		c.setRetryPeriod(duration)
+	return applierFunc(func(c *refreshNSEClient) {
+		c.retryDelay = duration
 	})
 }
 
 // WithDefaultExpiryDuration sets a default expiration_time if it is nil on NSE registration
 func WithDefaultExpiryDuration(duration time.Duration) Option {
-	return applierFunc(func(c configurable) {
-		c.setDefaultExpiryDuration(duration)
+	return applierFunc(func(c *refreshNSEClient) {
+		c.defaultExpiryDuration = duration
 	})
 }

--- a/pkg/registry/common/refresh/options.go
+++ b/pkg/registry/common/refresh/options.go
@@ -20,7 +20,7 @@ import "time"
 
 type configurable interface {
 	setRetryPeriod(time.Duration)
-	setDefaultExpiration(duration time.Duration)
+	setDefaultExpiryDuration(duration time.Duration)
 }
 
 // Option is expire registry configuration option
@@ -41,9 +41,9 @@ func WithRetryPeriod(duration time.Duration) Option {
 	})
 }
 
-// WithDefaultExpiration sets a default expiration to NSE if expiration was not set
-func WithDefaultExpiration(duration time.Duration) Option {
+// WithDefaultExpiryDuration sets a default expiration_time if it is nil on NSE registration
+func WithDefaultExpiryDuration(duration time.Duration) Option {
 	return applierFunc(func(c configurable) {
-		c.setDefaultExpiration(duration)
+		c.setDefaultExpiryDuration(duration)
 	})
 }


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Description

During testing in registry-memory found that refresh client chain element is working incorrectly with grpc. It should set expiration_time for nse before call the next client.