### PR TITLE
Rework heal.

### DIFF
--- a/pkg/networkservice/common/heal/client_test.go
+++ b/pkg/networkservice/common/heal/client_test.go
@@ -18,12 +18,14 @@ package heal_test
 
 import (
 	"context"
+	"io/ioutil"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
@@ -54,6 +56,7 @@ func (t *testOnHeal) Close(ctx context.Context, in *networkservice.Connection, o
 
 func TestHealClient_Request(t *testing.T) {
 	defer goleak.VerifyNone(t)
+	logrus.SetOutput(ioutil.Discard)
 	eventCh := make(chan *networkservice.ConnectionEvent, 1)
 	defer close(eventCh)
 
@@ -115,6 +118,7 @@ func TestHealClient_Request(t *testing.T) {
 
 func TestHealClient_EmptyInit(t *testing.T) {
 	defer goleak.VerifyNone(t)
+	logrus.SetOutput(ioutil.Discard)
 	eventCh := make(chan *networkservice.ConnectionEvent, 1)
 	defer close(eventCh)
 
@@ -151,6 +155,7 @@ func TestHealClient_EmptyInit(t *testing.T) {
 
 func TestNewClient_MissingConnectionsInInit(t *testing.T) {
 	defer goleak.VerifyNone(t)
+	logrus.SetOutput(ioutil.Discard)
 	eventCh := make(chan *networkservice.ConnectionEvent, 1)
 
 	requestCh := make(chan *networkservice.NetworkServiceRequest)

--- a/pkg/networkservice/core/eventchannel/monitor_client.go
+++ b/pkg/networkservice/core/eventchannel/monitor_client.go
@@ -62,12 +62,13 @@ func (m *monitorConnectionClient) MonitorConnections(ctx context.Context, _ *net
 				}
 				var newFanoutEventChs []chan *networkservice.ConnectionEvent
 				for _, ch := range m.fanoutEventChs {
-					if ch != fanoutEventCh {
-						newFanoutEventChs = append(newFanoutEventChs, ch)
+					if ch == fanoutEventCh {
+						close(fanoutEventCh)
+						continue
 					}
+					newFanoutEventChs = append(newFanoutEventChs, ch)
 				}
 				m.fanoutEventChs = newFanoutEventChs
-				close(fanoutEventCh)
 			})
 		}()
 	})


### PR DESCRIPTION
Heal had a few issues:

1.  It was doing an expensive init in the constructor
2.  The eventLoop could be clearer and simpler
3.  There unecessary information being kept at struct{} level
4.  It was attempting to Close things after the clientContext was Done.
    This is pretty much guaranteed to fail, as when the clientContext is Done, so typically is
    the grpc.ClientConn for the underlying connection.  If we want to handle graceful Close
    when shutting down a client, we probably need to do that in a separate chain element.
    This is why closers were removed and TestHealClient_MonitorClose was deleted.