### PR TITLE
Disable unstable test TestNewClient_StopRefreshAtClose

### DIFF
--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -107,6 +107,7 @@ func firstGetsValueEarlier(c1, c2 <-chan struct{}) bool {
 }
 
 func TestNewClient_StopRefreshAtClose(t *testing.T) {
+	t.Skip("https://github.com/networkservicemesh/sdk/issues/237")
 	defer goleak.VerifyNone(t)
 	requestCh := make(chan struct{}, 1)
 	testRefresh := &testRefresh{


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

https://github.com/networkservicemesh/sdk/issues/237



