### PR TITLE
Fix mechanismsServer next chain element call

### DIFF
--- a/pkg/networkservice/common/mechanisms/server.go
+++ b/pkg/networkservice/common/mechanisms/server.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
 )
 
@@ -56,12 +55,7 @@ func (m *mechanismsServer) Request(ctx context.Context, request *networkservice.
 	if request.GetConnection().GetMechanism() != nil {
 		srv, ok := m.mechanisms[request.GetConnection().GetMechanism().GetType()]
 		if ok {
-			conn, err := srv.Request(ctx, request)
-			if err != nil {
-				return nil, err
-			}
-			request.Connection = conn
-			return next.Server(ctx).Request(ctx, request)
+			return srv.Request(ctx, request)
 		}
 		return nil, errors.Errorf("Unsupported Mechanism: %+v", request.GetConnection().GetMechanism())
 	}

--- a/pkg/networkservice/common/mechanisms/server_test.go
+++ b/pkg/networkservice/common/mechanisms/server_test.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/checks/checkcontext"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 
@@ -41,21 +41,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injecterror"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/null"
 )
-
-type countRequestsNetworkServiceServer struct {
-	requestCh chan struct{}
-	closeCh   chan struct{}
-}
-
-func (c countRequestsNetworkServiceServer) Request(ctx context.Context, serviceRequest *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	c.requestCh <- struct{}{}
-	return next.Server(ctx).Request(ctx, serviceRequest)
-}
-
-func (c countRequestsNetworkServiceServer) Close(ctx context.Context, connection *networkservice.Connection) (*empty.Empty, error) {
-	c.closeCh <- struct{}{}
-	return next.Server(ctx).Close(ctx, connection)
-}
 
 func server() networkservice.NetworkServiceServer {
 	return chain.NewNetworkServiceServer(mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
@@ -192,9 +177,13 @@ func TestDontCallNextByItself(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	logrus.SetOutput(ioutil.Discard)
 
-	requestCh := make(chan struct{}, 10)
-	closeCh := make(chan struct{}, 10)
-	server := next.NewNetworkServiceServer(server(), countRequestsNetworkServiceServer{requestCh: requestCh, closeCh: closeCh})
+	ch := make(chan struct{}, 10)
+	server := next.NewNetworkServiceServer(
+		server(),
+		checkcontext.NewServer(t, func(t *testing.T, ctx context.Context) {
+			ch <- struct{}{}
+		}),
+	)
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
 			Mechanism: &networkservice.Mechanism{
@@ -206,9 +195,9 @@ func TestDontCallNextByItself(t *testing.T) {
 	conn, err := server.Request(context.Background(), request)
 	assert.Nil(t, err)
 	assert.NotNil(t, conn)
-	assert.Equal(t, 1, len(requestCh))
+	assert.Equal(t, 1, len(ch))
 
 	_, err = server.Close(context.Background(), conn)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(closeCh))
+	assert.Equal(t, 2, len(ch))
 }


### PR DESCRIPTION
Implementation of #402 
Previously, in the one situation mechanismsServer called `next.Server(ctx).Request/Close` itself, but all of the each mechanism Servers called `next.Server...` too. Now mechanismsServer simply returns `conn` from selected mechanism Server request