### PR TITLE
Move from runtime.SetFinalizer to context.Context with proper lifecycle

### DIFF
--- a/pkg/networkservice/chains/endpoint/server.go
+++ b/pkg/networkservice/chains/endpoint/server.go
@@ -57,14 +57,14 @@ type endpoint struct {
 //             - authzServer authorization server chain element
 //             - tokenGenerator - token.GeneratorFunc - generates tokens for use in Path
 //             - additionalFunctionality - any additional NetworkServiceServer chain elements to be included in the chain
-func NewServer(name string, authzServer networkservice.NetworkServiceServer, tokenGenerator token.GeneratorFunc, additionalFunctionality ...networkservice.NetworkServiceServer) Endpoint {
+func NewServer(ctx context.Context, name string, authzServer networkservice.NetworkServiceServer, tokenGenerator token.GeneratorFunc, additionalFunctionality ...networkservice.NetworkServiceServer) Endpoint {
 	rv := &endpoint{}
 	var ns networkservice.NetworkServiceServer = rv
 	rv.NetworkServiceServer = chain.NewNetworkServiceServer(
 		append([]networkservice.NetworkServiceServer{
 			authzServer,
 			setid.NewServer(name),
-			monitor.NewServer(&rv.MonitorConnectionServer),
+			monitor.NewServer(ctx, &rv.MonitorConnectionServer),
 			timeout.NewServer(&ns),
 			updatepath.NewServer(name, tokenGenerator),
 		}, additionalFunctionality...)...)

--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -85,7 +85,7 @@ func NewServer(ctx context.Context, nsmRegistration *registryapi.NetworkServiceE
 	}
 
 	// Construct Endpoint
-	rv.Endpoint = endpoint.NewServer(
+	rv.Endpoint = endpoint.NewServer(ctx,
 		nsmRegistration.Name,
 		authzServer,
 		tokenGenerator,

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -20,7 +20,6 @@ package nsmgr_test
 import (
 	"context"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -34,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 
@@ -64,16 +62,13 @@ func newClient(ctx context.Context, u *url.URL) (*grpc.ClientConn, error) {
 		grpc.WithInsecure(),
 		grpc.WithBlock())
 }
-
 func TestNSmgrEndpointCallback(t *testing.T) {
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(os.Stdout, os.Stdout, os.Stderr))
-
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	// Serve endpoint
 	nseURL := &url.URL{Scheme: "tcp", Host: "127.0.0.1:0"}
-	_ = endpoint.Serve(ctx, nseURL, endpoint.NewServer("test-nse", authorize.NewServer(), TokenGenerator, setextracontext.NewServer(map[string]string{"perform": "ok"})))
+	_ = endpoint.Serve(ctx, nseURL, endpoint.NewServer(ctx, "test-nse", authorize.NewServer(), TokenGenerator, setextracontext.NewServer(map[string]string{"perform": "ok"})))
 	logrus.Infof("NSE listenON: %v", nseURL.String())
 
 	nsmgrReg := &registry.NetworkServiceEndpoint{

--- a/pkg/networkservice/common/connect/server_test.go
+++ b/pkg/networkservice/common/connect/server_test.go
@@ -207,7 +207,6 @@ func TestConnectServerShouldNotPanicOnRequest(t *testing.T) {
 }
 
 func TestParallelDial(t *testing.T) {
-	t.Skip("https://github.com/networkservicemesh/sdk/issues/377")
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	nseT := &nseTest{}

--- a/pkg/networkservice/common/heal/client_test.go
+++ b/pkg/networkservice/common/heal/client_test.go
@@ -157,7 +157,6 @@ func TestHealClient_EmptyInit(t *testing.T) {
 }
 
 func TestNewClient_MissingConnectionsInInit(t *testing.T) {
-	t.Skip("https://github.com/networkservicemesh/sdk/issues/375")
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	logrus.SetOutput(ioutil.Discard)
 	eventCh := make(chan *networkservice.ConnectionEvent, 1)

--- a/pkg/networkservice/common/monitor/server_test.go
+++ b/pkg/networkservice/common/monitor/server_test.go
@@ -33,10 +33,11 @@ func TestMonitor(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	// Specify pathSegments to test
 	segmentNames := []string{"local-nsm", "remote-nsm"}
-
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	// Create monitorServer, monitorClient, and server.
 	var monitorServer networkservice.MonitorConnectionServer
-	server := monitor.NewServer(&monitorServer)
+	server := monitor.NewServer(ctx, &monitorServer)
 	monitorClient := adapters.NewMonitorServerToClient(monitorServer)
 
 	// Create maps to hold returned connections and receivers

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -107,7 +107,6 @@ func firstGetsValueEarlier(c1, c2 <-chan struct{}) bool {
 }
 
 func TestNewClient_StopRefreshAtClose(t *testing.T) {
-	t.Skip("https://github.com/networkservicemesh/sdk/issues/237")
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	requestCh := make(chan struct{}, 1)
 	testRefresh := &testRefresh{
@@ -144,7 +143,6 @@ func TestNewClient_StopRefreshAtClose(t *testing.T) {
 }
 
 func TestNewClient_StopRefreshAtAnotherRequest(t *testing.T) {
-	t.Skip("https://github.com/networkservicemesh/sdk/issues/260")
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	requestCh := make(chan struct{}, 1)
 	testRefresh := &testRefresh{

--- a/pkg/registry/common/clienturl/ns_client_test.go
+++ b/pkg/registry/common/clienturl/ns_client_test.go
@@ -49,7 +49,11 @@ func TestClientURL_NewNetworkServiceRegistryClient(t *testing.T) {
 	}()
 	u, err := url.Parse("tcp://" + l.Addr().String())
 	require.Nil(t, err)
-	ctx := clienturl.WithClientURL(context.Background(), u)
+
+	ctx, clientCancel := context.WithCancel(context.Background())
+	defer clientCancel()
+	ctx = clienturl.WithClientURL(ctx, u)
+
 	client := clienturl.NewNetworkServiceRegistryClient(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceRegistryClient {
 		return registry.NewNetworkServiceRegistryClient(cc)
 	}, grpc.WithInsecure())

--- a/pkg/registry/common/clienturl/nse_client.go
+++ b/pkg/registry/common/clienturl/nse_client.go
@@ -18,7 +18,6 @@ package clienturl
 
 import (
 	"context"
-	"runtime"
 	"sync"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -100,9 +99,10 @@ func (u *nseRegistryURLClient) init() error {
 			return
 		}
 		u.client = u.clientFactory(u.ctx, cc)
-		runtime.SetFinalizer(u, func(u *nseRegistryURLClient) {
+		go func() {
+			<-u.ctx.Done()
 			_ = cc.Close()
-		})
+		}()
 	})
 	return u.dialErr
 }

--- a/pkg/registry/common/clienturl/nse_client_test.go
+++ b/pkg/registry/common/clienturl/nse_client_test.go
@@ -47,6 +47,7 @@ func TestClientURL_NewNetworkServiceEndpointRegistryClient(t *testing.T) {
 	go func() {
 		_ = s.Serve(l)
 	}()
+	defer s.Stop()
 	u, err := url.Parse("tcp://" + l.Addr().String())
 	require.Nil(t, err)
 	ctx := clienturl.WithClientURL(context.Background(), u)

--- a/pkg/registry/common/connect/ns_server_test.go
+++ b/pkg/registry/common/connect/ns_server_test.go
@@ -62,7 +62,10 @@ func TestConnect_NewNetworkServiceRegistryServer(t *testing.T) {
 	url1, closeServer1 := startNSServer(t)
 	url2, closeServer2 := startNSServer(t)
 
-	s := connect.NewNetworkServiceRegistryServer(func(_ context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceRegistryClient {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := connect.NewNetworkServiceRegistryServer(ctx, func(_ context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceRegistryClient {
 		return registry.NewNetworkServiceRegistryClient(cc)
 	}, connect.WithExpirationDuration(time.Millisecond*100), connect.WithClientDialOptions(grpc.WithInsecure()))
 

--- a/pkg/registry/common/connect/nse_server_test.go
+++ b/pkg/registry/common/connect/nse_server_test.go
@@ -61,7 +61,10 @@ func TestConnect_NewNetworkServiceEndpointRegistryServer(t *testing.T) {
 	url1, closeServer1 := startNSEServer(t)
 	url2, closeServer2 := startNSEServer(t)
 
-	s := connect.NewNetworkServiceEndpointRegistryServer(func(_ context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceEndpointRegistryClient {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := connect.NewNetworkServiceEndpointRegistryServer(ctx, func(_ context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceEndpointRegistryClient {
 		return registry.NewNetworkServiceEndpointRegistryClient(cc)
 	}, connect.WithExpirationDuration(time.Millisecond*100), connect.WithClientDialOptions(grpc.WithInsecure()))
 

--- a/pkg/registry/common/proxy/common_test.go
+++ b/pkg/registry/common/proxy/common_test.go
@@ -73,19 +73,19 @@ func startNSServer(t *testing.T, chain registry.NetworkServiceRegistryServer) (u
 	return u, closeFunc
 }
 
-func testingNSEServerChain(u *url.URL) registry.NetworkServiceEndpointRegistryServer {
+func testingNSEServerChain(ctx context.Context, u *url.URL) registry.NetworkServiceEndpointRegistryServer {
 	return next.NewNetworkServiceEndpointRegistryServer(
 		proxy.NewNetworkServiceEndpointRegistryServer(u),
-		connect.NewNetworkServiceEndpointRegistryServer(func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceEndpointRegistryClient {
+		connect.NewNetworkServiceEndpointRegistryServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceEndpointRegistryClient {
 			return registry.NewNetworkServiceEndpointRegistryClient(cc)
 		}, connect.WithExpirationDuration(time.Millisecond*100), connect.WithClientDialOptions(grpc.WithInsecure())),
 	)
 }
 
-func testingNSServerChain(u *url.URL) registry.NetworkServiceRegistryServer {
+func testingNSServerChain(ctx context.Context, u *url.URL) registry.NetworkServiceRegistryServer {
 	return next.NewNetworkServiceRegistryServer(
 		proxy.NewNetworkServiceRegistryServer(u),
-		connect.NewNetworkServiceRegistryServer(func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceRegistryClient {
+		connect.NewNetworkServiceRegistryServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceRegistryClient {
 			return registry.NewNetworkServiceRegistryClient(cc)
 		}, connect.WithExpirationDuration(time.Millisecond*100), connect.WithClientDialOptions(grpc.WithInsecure())),
 	)

--- a/pkg/registry/common/proxy/ns_server_test.go
+++ b/pkg/registry/common/proxy/ns_server_test.go
@@ -34,7 +34,9 @@ func TestNewProxyNetworkServiceRegistryServer_Register(t *testing.T) {
 	m := memory.NewNetworkServiceRegistryServer()
 	u, closeServer := startNSServer(t, m)
 
-	chain := testingNSServerChain(u)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain := testingNSServerChain(ctx, u)
 
 	_, err := chain.Register(context.Background(), &registry.NetworkService{Name: "nse-1"})
 	require.NoError(t, err)
@@ -65,7 +67,10 @@ func TestNewProxyNetworkServiceRegistryServer_Unregister(t *testing.T) {
 	require.Nil(t, err)
 	u, closeServer := startNSServer(t, m)
 
-	chain := testingNSServerChain(u)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	chain := testingNSServerChain(ctx, u)
 
 	checkLen := func(expected int) {
 		client := adapters.NetworkServiceServerToClient(m)
@@ -101,8 +106,9 @@ func TestNewProxyNetworkServiceRegistryServer_Find(t *testing.T) {
 	_, err := m.Register(context.Background(), &registry.NetworkService{Name: "nse-1@domain1"})
 	require.Nil(t, err)
 	u, closeServer := startNSServer(t, m)
-
-	chain := testingNSServerChain(u)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain := testingNSServerChain(ctx, u)
 
 	checkLen := func(nseName string, expected int) {
 		client := adapters.NetworkServiceServerToClient(chain)

--- a/pkg/registry/common/proxy/nse_server_test.go
+++ b/pkg/registry/common/proxy/nse_server_test.go
@@ -33,8 +33,9 @@ import (
 func TestNewProxyNetworkServiceEndpointRegistryServer_Register(t *testing.T) {
 	m := memory.NewNetworkServiceEndpointRegistryServer()
 	u, closeServer := startNSEServer(t, m)
-
-	chain := testingNSEServerChain(u)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain := testingNSEServerChain(ctx, u)
 
 	_, err := chain.Register(context.Background(), &registry.NetworkServiceEndpoint{Name: "nse-1"})
 	require.NoError(t, err)
@@ -64,8 +65,9 @@ func TestNewProxyNetworkServiceEndpointRegistryServer_Unregister(t *testing.T) {
 	_, err := m.Register(context.Background(), &registry.NetworkServiceEndpoint{Name: "nse-1@domain1"})
 	require.Nil(t, err)
 	u, closeServer := startNSEServer(t, m)
-
-	chain := testingNSEServerChain(u)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain := testingNSEServerChain(ctx, u)
 
 	checkLen := func(expected int) {
 		client := adapters.NetworkServiceEndpointServerToClient(m)
@@ -102,7 +104,9 @@ func TestNewProxyNetworkServiceEndpointRegistryServer_Find(t *testing.T) {
 	require.Nil(t, err)
 	u, closeServer := startNSEServer(t, m)
 
-	chain := testingNSEServerChain(u)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chain := testingNSEServerChain(ctx, u)
 
 	checkLen := func(nseName string, expected int) {
 		client := adapters.NetworkServiceEndpointServerToClient(chain)


### PR DESCRIPTION
Move from runtime.SetFinalizer to context with proper lifecycle

It seems it fixes all unstable tests, so I've re-enabled them :-)

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>