### PR TITLE
Add grpcutils.DialContext function for NSM clients

### DIFF
--- a/pkg/tools/grpcutils/dial.go
+++ b/pkg/tools/grpcutils/dial.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcutils
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+// DialContext tries to create a client connection to the given target during 1 minute.
+// This function may be useful in the environments when not guarantee that the server socket is immediately provided.
+func DialContext(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return DialContextTimeout(ctx, target, time.Minute, opts...)
+}
+
+// DialContextTimeout tries to create a client connection to the given target during passed timeout.
+// This function may be useful in the environments when not guarantee that the server socket is immediately provided.
+func DialContextTimeout(ctx context.Context, target string, duration time.Duration, opts ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
+	timeout := time.After(duration)
+	for {
+		select {
+		case <-ctx.Done():
+			return conn, errors.Wrap(err, ctx.Err().Error())
+		case <-timeout:
+			return conn, errors.Wrapf(err, "cannot connect to %v during %v", target, duration)
+		default:
+			conn, err = grpc.DialContext(ctx, target, opts...)
+			if err == nil {
+				return
+			}
+			<-time.After(time.Millisecond * 50)
+		}
+	}
+}

--- a/pkg/tools/grpcutils/dial_test.go
+++ b/pkg/tools/grpcutils/dial_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcutils_test
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"net/url"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+)
+
+func TestDialContextTimeout(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	s := grpc.NewServer()
+	dir, err := ioutil.TempDir(os.TempDir(), t.Name())
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+	u := &url.URL{Scheme: "unix", Path: path.Join(dir, "server.sock")}
+	l, err := net.Listen(u.Scheme, u.Path)
+	defer func() {
+		_ = l.Close()
+	}()
+	require.NoError(t, err)
+
+	go func() {
+		<-time.After(time.Millisecond * 200)
+		_ = s.Serve(l)
+	}()
+
+	conn, err := grpcutils.DialContext(context.Background(), u.String(), grpc.WithInsecure())
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	_ = conn.Close()
+}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Problem

When using NSM applications with ListenOn based on `unix` then client application could fail because of k8s is not guarantee that server socket will be immediately provided.