### PR TITLE
fix: grpcutils.ListenAndServe add a check if previous socket file was deleted successfully

### DIFF
--- a/pkg/tools/grpcutils/listen_and_serve.go
+++ b/pkg/tools/grpcutils/listen_and_serve.go
@@ -47,7 +47,7 @@ func ListenAndServe(ctx context.Context, address *url.URL, server *grpc.Server) 
 
 	if network == unixScheme {
 		err := os.Remove(target)
-		if !errors.Is(err, os.ErrNotExist) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			errCh <- errors.Wrap(err, "Cannot delete exist socket file")
 			close(errCh)
 			return errCh


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>