### PR TITLE
fix: clienturl should work correctly in case of using unix sockets in k8s env

### DIFF
--- a/pkg/networkservice/common/clienturl/client.go
+++ b/pkg/networkservice/common/clienturl/client.go
@@ -71,7 +71,7 @@ func (u *clientURLClient) init() error {
 			return
 		}
 		var cc *grpc.ClientConn
-		cc, u.dialErr = grpc.DialContext(u.ctx, grpcutils.URLToTarget(clientURL), u.dialOptions...)
+		cc, u.dialErr = grpcutils.DialContext(u.ctx, grpcutils.URLToTarget(clientURL), u.dialOptions...)
 		if u.dialErr != nil {
 			return
 		}

--- a/pkg/registry/common/clienturl/ns_client.go
+++ b/pkg/registry/common/clienturl/ns_client.go
@@ -95,7 +95,7 @@ func (u *nsRegistryURLClient) init() error {
 			return
 		}
 		var cc *grpc.ClientConn
-		cc, u.dialErr = grpc.DialContext(u.ctx, grpcutils.URLToTarget(clientURL), u.dialOptions...)
+		cc, u.dialErr = grpcutils.DialContext(u.ctx, grpcutils.URLToTarget(clientURL), u.dialOptions...)
 		if u.dialErr != nil {
 			return
 		}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>


