### PR TITLE
fix: dnsresolve chain element should include service name into query

### DIFF
--- a/pkg/registry/common/dnsresolve/common.go
+++ b/pkg/registry/common/dnsresolve/common.go
@@ -37,7 +37,8 @@ type Resolver interface {
 }
 
 func resolveDomain(ctx context.Context, service, domain string, r Resolver) (*url.URL, error) {
-	_, records, err := r.LookupSRV(ctx, service, "tcp", domain)
+	serviceDomain := fmt.Sprintf("%v.%v", service, domain)
+	_, records, err := r.LookupSRV(ctx, service, "tcp", serviceDomain)
 
 	if err != nil {
 		return nil, err
@@ -47,7 +48,7 @@ func resolveDomain(ctx context.Context, service, domain string, r Resolver) (*ur
 		return nil, errors.New("resolver.LookupSERV return empty result")
 	}
 
-	ips, err := r.LookupIPAddr(ctx, records[0].Target)
+	ips, err := r.LookupIPAddr(ctx, serviceDomain)
 
 	if err != nil {
 		return nil, err

--- a/pkg/registry/common/dnsresolve/ns_server_test.go
+++ b/pkg/registry/common/dnsresolve/ns_server_test.go
@@ -18,6 +18,7 @@ package dnsresolve_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -49,17 +50,18 @@ func (c *checkNSContext) Unregister(ctx context.Context, ns *registry.NetworkSer
 }
 
 func TestDNSResolve_NewNetworkServiceRegistryServer(t *testing.T) {
+	const srv = "service1"
 	s := dnsresolve.NewNetworkServiceRegistryServer(
-		dnsresolve.WithService("service1"),
+		dnsresolve.WithService(srv),
 		dnsresolve.WithResolver(&testResolver{
 			srvRecords: map[string][]*net.SRV{
-				"_service1._tcp.domain1": {{
+				fmt.Sprintf("_%v._tcp.%v.domain1", srv, srv): {{
 					Port:   80,
 					Target: "domain1",
 				}},
 			},
 			hostRecords: map[string][]net.IPAddr{
-				"domain1": {{
+				fmt.Sprintf("%v.domain1", srv): {{
 					IP: net.ParseIP("127.0.0.1"),
 				}},
 			},
@@ -80,13 +82,13 @@ func TestDNSResolveDefault_NewNetworkServiceRegistryServer(t *testing.T) {
 	s := dnsresolve.NewNetworkServiceRegistryServer(
 		dnsresolve.WithResolver(&testResolver{
 			srvRecords: map[string][]*net.SRV{
-				"_" + dnsresolve.NSMRegistryService + "._tcp.domain1": {{
+				fmt.Sprintf("_%v._tcp.%v.domain1", dnsresolve.NSMRegistryService, dnsresolve.NSMRegistryService): {{
 					Port:   80,
 					Target: "domain1",
 				}},
 			},
 			hostRecords: map[string][]net.IPAddr{
-				"domain1": {{
+				dnsresolve.NSMRegistryService + ".domain1": {{
 					IP: net.ParseIP("127.0.0.1"),
 				}},
 			},

--- a/pkg/registry/common/dnsresolve/nse_server_test.go
+++ b/pkg/registry/common/dnsresolve/nse_server_test.go
@@ -18,6 +18,7 @@ package dnsresolve_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -49,17 +50,18 @@ func (c *checkNSEContext) Unregister(ctx context.Context, ns *registry.NetworkSe
 }
 
 func TestDNSEResolve_NewNetworkServiceEndpointRegistryServer(t *testing.T) {
+	const srv = "service1"
 	s := dnsresolve.NewNetworkServiceEndpointRegistryServer(
-		dnsresolve.WithService("service1"),
+		dnsresolve.WithService(srv),
 		dnsresolve.WithResolver(&testResolver{
 			srvRecords: map[string][]*net.SRV{
-				"_service1._tcp.domain1": {{
+				fmt.Sprintf("_%v._tcp.%v.domain1", srv, srv): {{
 					Port:   80,
 					Target: "domain1",
 				}},
 			},
 			hostRecords: map[string][]net.IPAddr{
-				"domain1": {{
+				fmt.Sprintf("%v.domain1", srv): {{
 					IP: net.ParseIP("127.0.0.1"),
 				}},
 			},
@@ -80,13 +82,13 @@ func TestDNSEResolveDefault_NewNetworkServiceEndpointRegistryServer(t *testing.T
 	s := dnsresolve.NewNetworkServiceEndpointRegistryServer(
 		dnsresolve.WithResolver(&testResolver{
 			srvRecords: map[string][]*net.SRV{
-				"_" + dnsresolve.NSMRegistryService + "._tcp.domain1": {{
+				fmt.Sprintf("_%v._tcp.%v.domain1", dnsresolve.NSMRegistryService, dnsresolve.NSMRegistryService): {{
 					Port:   80,
 					Target: "domain1",
 				}},
 			},
 			hostRecords: map[string][]net.IPAddr{
-				"domain1": {{
+				dnsresolve.NSMRegistryService + ".domain1": {{
 					IP: net.ParseIP("127.0.0.1"),
 				}},
 			},

--- a/pkg/registry/interdomain/common_test.go
+++ b/pkg/registry/interdomain/common_test.go
@@ -74,6 +74,7 @@ func (t *interdomainTestingTool) LookupIPAddr(_ context.Context, host string) ([
 }
 
 func (t *interdomainTestingTool) dialDomain(domain string) *grpc.ClientConn {
+	domain = fmt.Sprintf("%v.%v", dnsresolve.NSMRegistryService, domain)
 	_, srvs, err := t.LookupSRV(context.Background(), "", "tcp", domain)
 	require.Nil(t, err)
 	require.NotEmpty(t, srvs)
@@ -99,6 +100,7 @@ func (t *interdomainTestingTool) startNetworkServiceEndpointRegistryServerAsync(
 }
 
 func (t *interdomainTestingTool) startServerAsync(domain string, registerFunc func(server *grpc.Server)) *url.URL {
+	domain = fmt.Sprintf("%v.%v", dnsresolve.NSMRegistryService, domain)
 	s := grpc.NewServer()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.Nil(t, err)


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

In k8s to search the registry by domain we should include service name into query, example: https://github.com/networkservicemesh/sdk/compare/master...denis-tingajkin:fix_dnsresolve?expand=1#diff-c9d8b841fcd143230a5ca28860c6e096R40