### PR TITLE
Excluded prefixes file constants now are exported

### DIFF
--- a/pkg/networkservice/common/excludedprefixes/const.go
+++ b/pkg/networkservice/common/excludedprefixes/const.go
@@ -18,10 +18,10 @@ package excludedprefixes
 
 /* These variables set default path to the config file */
 const (
-	// PrefixesFile - excluded prefixes file name
-	PrefixesFile = "excluded_prefixes.yaml"
-	// NsmConfigDir - excluded prefixes file directory name
-	NsmConfigDir = "/var/lib/networkservicemesh/config"
+	// prefixesFile - excluded prefixes file name
+	prefixesFile = "excluded_prefixes.yaml"
+	// NSMConfigDir - excluded prefixes file directory name
+	NSMConfigDir = "/var/lib/networkservicemesh/config"
 	// PrefixesFilePathDefault - excluded prefixes file absolute path
-	PrefixesFilePathDefault = NsmConfigDir + "/" + PrefixesFile
+	PrefixesFilePathDefault = NSMConfigDir + "/" + prefixesFile
 )

--- a/pkg/networkservice/common/excludedprefixes/const.go
+++ b/pkg/networkservice/common/excludedprefixes/const.go
@@ -18,7 +18,10 @@ package excludedprefixes
 
 /* These variables set default path to the config file */
 const (
-	prefixesFile            = "excluded_prefixes.yaml"
-	nsmConfigDir            = "/var/lib/networkservicemesh/config"
-	prefixesFilePathDefault = nsmConfigDir + "/" + prefixesFile
+	// PrefixesFile - excluded prefixes file name
+	PrefixesFile = "excluded_prefixes.yaml"
+	// NsmConfigDir - excluded prefixes file directory name
+	NsmConfigDir = "/var/lib/networkservicemesh/config"
+	// PrefixesFilePathDefault - excluded prefixes file absolute path
+	PrefixesFilePathDefault = NsmConfigDir + "/" + PrefixesFile
 )

--- a/pkg/networkservice/common/excludedprefixes/const.go
+++ b/pkg/networkservice/common/excludedprefixes/const.go
@@ -20,8 +20,8 @@ package excludedprefixes
 const (
 	// prefixesFile - excluded prefixes file name
 	prefixesFile = "excluded_prefixes.yaml"
-	// NSMConfigDir - excluded prefixes file directory name
-	NSMConfigDir = "/var/lib/networkservicemesh/config"
+	// nsmConfigDir - excluded prefixes file directory name
+	nsmConfigDir = "/var/lib/networkservicemesh/config"
 	// PrefixesFilePathDefault - excluded prefixes file absolute path
-	PrefixesFilePathDefault = NSMConfigDir + "/" + prefixesFile
+	PrefixesFilePathDefault = nsmConfigDir + "/" + prefixesFile
 )

--- a/pkg/networkservice/common/excludedprefixes/server.go
+++ b/pkg/networkservice/common/excludedprefixes/server.go
@@ -96,7 +96,7 @@ func (eps *excludedPrefixesServer) Close(ctx context.Context, connection *networ
 // Note: request.Connection and Connection.Context should not be nil when calling Request
 func NewServer(ctx context.Context, setters ...ServerOption) networkservice.NetworkServiceServer {
 	server := &excludedPrefixesServer{
-		configPath: prefixesFilePathDefault,
+		configPath: PrefixesFilePathDefault,
 		ctx:        ctx,
 	}
 	for _, setter := range setters {


### PR DESCRIPTION
Constants are needed for networkservicemesh/cmd-exclude-prefixes-k8s#7