### PR TITLE
Add support for go 1.15

### DIFF
--- a/pkg/networkservice/core/eventchannel/monitor_client_test.go
+++ b/pkg/networkservice/core/eventchannel/monitor_client_test.go
@@ -18,6 +18,7 @@ package eventchannel_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
@@ -47,8 +48,8 @@ func TestNewMonitorConnectionClient_MonitorConnections(t *testing.T) {
 		eventsIn[i] = &networkservice.ConnectionEvent{
 			Type: networkservice.ConnectionEventType_UPDATE,
 			Connections: map[string]*networkservice.Connection{
-				string(i): {
-					Id: (string(i)),
+				fmt.Sprintf("%d", i): {
+					Id: fmt.Sprintf("%d", i),
 				},
 			},
 		}

--- a/pkg/networkservice/core/eventchannel/monitor_connection_client_test.go
+++ b/pkg/networkservice/core/eventchannel/monitor_connection_client_test.go
@@ -17,6 +17,7 @@
 package eventchannel_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
@@ -34,8 +35,8 @@ func TestMonitorConnection_MonitorConnectionsClient_Recv(t *testing.T) {
 		eventsIn[i] = &networkservice.ConnectionEvent{
 			Type: networkservice.ConnectionEventType_UPDATE,
 			Connections: map[string]*networkservice.Connection{
-				string(i): {
-					Id: (string(i)),
+				fmt.Sprintf("%d", i): {
+					Id: fmt.Sprintf("%d", i),
 				},
 			},
 		}


### PR DESCRIPTION
Add support for go 1.15 for tests to compile.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>