### PR TITLE
Rework heal chain element to support updatetoken restoring Connection.Id to the Path.Index

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -249,3 +249,7 @@ issues:
       linters:
         - funlen
         - gocyclo
+    - path: pkg/networkservice/common/heal/client.go
+      linters:
+        - gocyclo
+      text: "processEvent"

--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -21,6 +21,8 @@ import (
 	"context"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatetoken"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injectpeer"
+	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"google.golang.org/grpc"
@@ -31,7 +33,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 
-	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injectpeer"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
@@ -52,18 +53,23 @@ import (
 //             - cc - grpc.ClientConnInterface for the endpoint to which this client should connect
 //             - additionalFunctionality - any additional NetworkServiceClient chain elements to be included in the chain
 func NewClient(ctx context.Context, name string, onHeal *networkservice.NetworkServiceClient, tokenGenerator token.GeneratorFunc, cc grpc.ClientConnInterface, additionalFunctionality ...networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
-	return chain.NewNetworkServiceClient(
+	var rv networkservice.NetworkServiceClient
+	if onHeal == nil {
+		onHeal = addressof.NetworkServiceClient(rv)
+	}
+	rv = chain.NewNetworkServiceClient(
 		append(
 			append([]networkservice.NetworkServiceClient{
 				authorize.NewClient(),
 				updatepath.NewClient(name),
 				heal.NewClient(ctx, networkservice.NewMonitorConnectionClient(cc), onHeal),
 				refresh.NewClient(ctx),
-				injectpeer.NewClient(),
-				updatetoken.NewClient(tokenGenerator),
 			}, additionalFunctionality...),
+			injectpeer.NewClient(),
+			updatetoken.NewClient(tokenGenerator),
 			networkservice.NewNetworkServiceClient(cc),
 		)...)
+	return rv
 }
 
 // NewClientFactory - returns a func(cc grpc.ClientConnInterface)that returns a  standard Client pieces plus whatever

--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -19,31 +19,28 @@ package heal
 
 import (
 	"context"
-	"sync"
-	"time"
+	"runtime"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
-	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
-	"github.com/networkservicemesh/sdk/pkg/tools/extend"
 	"github.com/networkservicemesh/sdk/pkg/tools/serialize"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 )
 
 type healClient struct {
-	ctx            context.Context
-	client         networkservice.MonitorConnectionClient
-	onHeal         *networkservice.NetworkServiceClient
-	heals          map[string]func()
-	connections    map[string]*networkservice.Connection
-	updateExecutor serialize.Executor
-	eventLoopOnce  sync.Once
+	ctx                   context.Context
+	client                networkservice.MonitorConnectionClient
+	onHeal                *networkservice.NetworkServiceClient
+	cancelHealMap         map[string]func() <-chan error
+	cancelHealMapExecutor serialize.Executor
 }
 
 // NewClient - creates a new networkservice.NetworkServiceClient chain element that implements the healing algorithm
@@ -61,12 +58,10 @@ type healClient struct {
 //                        If onHeal nil, onHeal will be pointed to the returned networkservice.NetworkServiceClient
 func NewClient(ctx context.Context, client networkservice.MonitorConnectionClient, onHeal *networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
 	rv := &healClient{
-		ctx:            ctx,
-		client:         client,
-		onHeal:         onHeal,
-		heals:          make(map[string]func()),
-		connections:    make(map[string]*networkservice.Connection),
-		updateExecutor: serialize.NewExecutor(),
+		ctx:           ctx,
+		client:        client,
+		onHeal:        onHeal,
+		cancelHealMap: make(map[string]func() <-chan error),
 	}
 
 	if rv.onHeal == nil {
@@ -76,116 +71,211 @@ func NewClient(ctx context.Context, client networkservice.MonitorConnectionClien
 	return rv
 }
 
-func (f *healClient) monitorLoop() {
-	go f.eventLoopOnce.Do(func() {
-		for {
-			select {
-			case <-f.ctx.Done():
-				return
-			default:
-			}
-			recv, err := f.client.MonitorConnections(f.ctx, &networkservice.MonitorScopeSelector{}, grpc.WaitForReady(true))
-			if err != nil {
-				continue
-			}
-			f.eventloop(recv)
-		}
-	})
-}
-
-// Should only be called inside monitorLoop
-func (f *healClient) eventloop(recv networkservice.MonitorConnection_MonitorConnectionsClient) {
-	for {
-		select {
-		case <-f.ctx.Done():
-			return
-		default:
-		}
-		event, err := recv.Recv()
-		if err != nil {
-			f.updateExecutor.AsyncExec(func() {
-				for id, heal := range f.heals {
-					heal()
-					delete(f.connections, id)
-				}
-			})
-			break
-		}
-		f.updateExecutor.AsyncExec(func() {
-			switch event.GetType() {
-			case networkservice.ConnectionEventType_INITIAL_STATE_TRANSFER:
-				f.connections = event.GetConnections()
-				if event.GetConnections() == nil {
-					f.connections = map[string]*networkservice.Connection{}
-				}
-
-			case networkservice.ConnectionEventType_UPDATE:
-				for _, conn := range event.GetConnections() {
-					f.connections[conn.GetId()] = conn
-				}
-
-			case networkservice.ConnectionEventType_DELETE:
-				for _, conn := range event.GetConnections() {
-					delete(f.connections, conn.GetId())
-				}
-			}
-
-			for id, heal := range f.heals {
-				if _, ok := f.connections[id]; !ok {
-					heal()
-				}
-			}
-		})
-	}
-}
-
 func (f *healClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
-	f.monitorLoop()
-	rv, err := next.Client(ctx).Request(ctx, request, opts...)
+	conn, err := next.Client(ctx).Request(ctx, request, opts...)
 	if err != nil {
 		return nil, err
 	}
-	// Clone the request
-	req := request.Clone()
-	// Set its connection to the returned connection we received
-	req.Connection = rv.Clone()
-
-	// TODO handle deadline ok
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		// If we don't have a deadline, we can literally deadlock on our attempts to heal (or make initial requests)
-		return nil, errors.Errorf("all requests require a context with a deadline")
+	err = f.startHeal(ctx, request.Clone().SetRequestConnection(conn.Clone()), opts...)
+	if err != nil {
+		return nil, err
 	}
-	duration := time.Until(deadline)
-	f.updateExecutor.AsyncExec(func() {
-		f.heals[req.GetConnection().GetId()] = func() {
-			healCtx, cancel := context.WithTimeout(f.ctx, duration)
-			defer cancel()
-			healCtx = extend.WithValuesFromContext(healCtx, ctx)
-			select {
-			case <-healCtx.Done():
-				return
-			default:
-			}
-			// TODO wrap another span around this
-			_, err := (*f.onHeal).Request(healCtx, req, opts...)
-			if err != nil {
-				trace.Log(healCtx).Errorf("Attempt to heal connection %s resulted in error: %+v", req.GetConnection().GetId(), err)
-			}
-		}
-	})
-	return rv, nil
+	return conn, nil
 }
 
 func (f *healClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	f.monitorLoop()
-	f.updateExecutor.AsyncExec(func() {
-		delete(f.heals, conn.GetId())
-		delete(f.connections, conn.GetId())
-	})
+	f.stopHeal(conn)
 	rv, err := next.Client(ctx).Close(ctx, conn, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return rv, nil
+}
+
+func (f *healClient) stopHeal(conn *networkservice.Connection) {
+	var cancelHeal func() <-chan error
+	<-f.cancelHealMapExecutor.AsyncExec(func() {
+		cancelHeal = f.cancelHealMap[conn.GetId()]
+	})
+	<-cancelHeal()
+}
+
+// startHeal - start a healAsNeeded using the request as the request for re-request if healing is needed.
+func (f *healClient) startHeal(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) error {
+	id := request.GetConnection().GetId()
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	errCh := make(chan error, 1)
+	f.cancelHealMapExecutor.AsyncExec(func() {
+		if cancel, ok := f.cancelHealMap[id]; ok {
+			go cancel() // TODO - what to do with the errCh here?
+		}
+		f.cancelHealMap[id] = func() <-chan error {
+			cancel()
+			return errCh
+		}
+	})
+	go f.healAsNeeded(ctx, request, errCh, opts...)
+	return <-errCh
+}
+
+// healAsNeeded - heal the connection found in request.  Will immediately do a monitor to make sure the server has the
+// expected connection and it is sane, returning an error via errCh if there is an issue, and nil via errCh if there is
+// not.  You will only *ever* receive one real error via the errCh.  errCh will be closed when healAsNeeded is finished
+// allowing it to double as a 'done' channel we can use when we stopHealing in f.Close.
+// healAsNeeded will then continue to monitor the servers opinions about the state of the connection until either
+// expireTime has passed or stopHeal is called (as in Close) or a different pathSegment is found via monitoring
+// indicating that a later Request has occurred and in doing so created its own healAsNeeded and so we can stop this one
+func (f *healClient) healAsNeeded(ctx context.Context, request *networkservice.NetworkServiceRequest, errCh chan error, opts ...grpc.CallOption) {
+	// When we are done, close the errCh
+	defer close(errCh)
+
+	pathSegment := request.GetConnection().GetNextPathSegment()
+
+	// Monitor the pathSegment - the first time with the calls context, so we can pass back and error
+	// if we can't confirm via monitor the other side has the expected state
+	recv, err := f.initialMonitorSegment(ctx, pathSegment)
+	if err != nil {
+		errCh <- errors.Wrapf(err, "error calling MonitorConnection_MonitorConnectionsClient.Recv to get initial confirmation server has connection: %+v", request.GetConnection())
+		return
+	}
+
+	// Make sure we have a valid expireTime to work with
+	expireTime, err := ptypes.Timestamp(pathSegment.GetExpires())
+	if err != nil {
+		errCh <- errors.Wrapf(err, "error converting pathSegment.GetExpires() to time.Time: %+v", pathSegment.GetExpires())
+		return
+	}
+
+	// Set the ctx Deadline to expireTime based on the heal servers context
+	ctx, cancel := context.WithDeadline(f.ctx, expireTime)
+	defer cancel()
+	id := request.GetConnection().GetId()
+	f.cancelHealMapExecutor.AsyncExec(func() {
+		if cancel, ok := f.cancelHealMap[id]; ok {
+			go cancel() // TODO - what to do with the errCh here?
+		}
+		f.cancelHealMap[id] = func() <-chan error {
+			cancel()
+			return errCh
+		}
+	})
+
+	// Tell the caller all is well by sending them a nil err so the call can continue
+	errCh <- nil
+
+	// Start looping over events
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		event, err := recv.Recv()
+		if err != nil {
+			// If we get an error, try to get a new recv ... if that fails, loop around and try again until
+			// we succeed or the ctx is canceled or expires
+			newRecv, newRecvErr := f.client.MonitorConnections(ctx, &networkservice.MonitorScopeSelector{
+				PathSegments: []*networkservice.PathSegment{
+					pathSegment,
+				},
+			})
+			if newRecvErr == nil {
+				recv = newRecv
+			}
+			runtime.Gosched()
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if err := f.processEvent(ctx, request, event, opts...); err != nil {
+			if err != nil {
+				return
+			}
+		}
+	}
+}
+
+// initialMonitorSegment - monitors for pathSegment and returns a recv and an error if the server does not have
+// a record for the connection matching our expectations
+func (f *healClient) initialMonitorSegment(ctx context.Context, pathSegment *networkservice.PathSegment) (networkservice.MonitorConnection_MonitorConnectionsClient, error) {
+	// If pathSegment is nil, the server is very very screwed up
+	if pathSegment == nil {
+		return nil, errors.New("pathSegment for server connection must not be nil")
+	}
+
+	// Monitor *just* this connection
+	recv, err := f.client.MonitorConnections(ctx, &networkservice.MonitorScopeSelector{
+		PathSegments: []*networkservice.PathSegment{
+			pathSegment,
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error when attempting to MonitorConnections")
+	}
+
+	// Get an initial event to make sure we have the expected connection
+	event, err := recv.Recv()
+	if err != nil {
+		return nil, err
+	}
+	// If we didn't get an event something very bad has happened
+	if event.Connections == nil || event.Connections[pathSegment.GetId()] == nil {
+		return nil, errors.Errorf("connection with id %s not found in MonitorConnections event as expected: event: %+v", pathSegment.Id, event)
+	}
+	// If its not *our* connection something's gone wrong like a later Request succeeding
+	if !pathSegment.Equal(event.GetConnections()[pathSegment.GetId()].GetCurrentPathSegment()) {
+		return nil, errors.Errorf("server reports a different connection for this id, pathSegments do not match.  Expected: %+v Received %+v", pathSegment, event.GetConnections()[pathSegment.GetId()].GetCurrentPathSegment())
+	}
+	return recv, nil
+}
+
+// processEvent - process event, calling (*f.OnHeal).Request(ctx,request,opts...) if the server does not have our connection.
+// returns a non-nil error if the event is such that we should no longer to continue to attempt to heal.
+func (f *healClient) processEvent(ctx context.Context, request *networkservice.NetworkServiceRequest, event *networkservice.ConnectionEvent, opts ...grpc.CallOption) error {
+	pathSegment := request.GetConnection().GetNextPathSegment()
+	switch event.GetType() {
+	case networkservice.ConnectionEventType_UPDATE:
+		// We should never receive an UPDATE that isn't ours, but in case we do...
+		if event.Connections == nil || event.Connections[pathSegment.GetId()] == nil {
+			break
+		}
+		fallthrough
+	case networkservice.ConnectionEventType_INITIAL_STATE_TRANSFER:
+		if event.Connections != nil && event.Connections[pathSegment.GetId()] != nil {
+			// If the server has a pathSegment for this Connection.Id, but its not the one we
+			// got back from it... we should fail, as different Request came after ours successfully
+			if !pathSegment.Equal(event.GetConnections()[pathSegment.GetId()].GetCurrentPathSegment()) {
+				return errors.Errorf("server has a different pathSegment than was returned to this call.")
+			}
+			break
+		}
+		fallthrough
+	case networkservice.ConnectionEventType_DELETE:
+		if event.Connections != nil && event.Connections[pathSegment.Id] != nil && pathSegment.Equal(event.GetConnections()[pathSegment.GetId()].GetCurrentPathSegment()) {
+			_, err := (*f.onHeal).Request(ctx, request, opts...)
+			for err != nil {
+				// Note: ctx here has deadline set to the expireTime of the pathSegment... so there is a finite stop point
+				// to trying to heal.  Additionally, a Close on the connection will trigger a cancel on ctx and
+				// wait for errCh to finish *before* calling Close down the line... so we won't accidentally
+				// recreate a closed connection.
+				runtime.Gosched()
+				select {
+				case <-ctx.Done():
+					return nil
+				default:
+				}
+				_, err := (*f.onHeal).Request(ctx, request, opts...)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+	return nil
 }

--- a/pkg/networkservice/common/heal/client_test.go
+++ b/pkg/networkservice/common/heal/client_test.go
@@ -25,6 +25,14 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/chainstest"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/monitor"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatetoken"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -34,12 +42,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/eventchannel"
 	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
-)
-
-const (
-	waitForTimeout  = 50 * time.Millisecond
-	waitHealTimeout = 500 * time.Millisecond
-	tickTimeout     = 10 * time.Millisecond
 )
 
 type testOnHeal struct {
@@ -62,6 +64,7 @@ func TestHealClient_Request(t *testing.T) {
 	defer close(eventCh)
 
 	onHealCh := make(chan struct{})
+	// TODO for tomorrow... check on how to work onHeal into the new chain I've built
 	onHeal := &testOnHeal{
 		RequestFunc: func(ctx context.Context, in *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (connection *networkservice.Connection, e error) {
 			if ctx.Err() == nil {
@@ -73,39 +76,30 @@ func TestHealClient_Request(t *testing.T) {
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+	monitorServer := eventchannel.NewMonitorServer(eventCh)
+	server := chain.NewNetworkServiceServer(
+		updatepath.NewServer("testServer"),
+		monitor.NewServer(ctx, &monitorServer),
+		updatetoken.NewServer(chainstest.GenerateTestToken),
+	)
 	client := chain.NewNetworkServiceClient(
-		heal.NewClient(ctx, eventchannel.NewMonitorConnectionClient(eventCh), addressof.NetworkServiceClient(onHeal)))
+		updatepath.NewClient("testClient"),
+		heal.NewClient(ctx, adapters.NewMonitorServerToClient(monitorServer), addressof.NetworkServiceClient(onHeal)),
+		updatetoken.NewClient(chainstest.GenerateTestToken),
+		adapters.NewServerToClient(server),
+	)
 
-	requestCtx, reqCancelFunc := context.WithTimeout(context.Background(), waitForTimeout)
+	requestCtx, reqCancelFunc := context.WithTimeout(ctx, waitForTimeout)
 	defer reqCancelFunc()
-	_, err := client.Request(requestCtx, &networkservice.NetworkServiceRequest{
+	conn, err := client.Request(requestCtx, &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
-			Id:             "conn-1",
 			NetworkService: "ns-1",
 		},
 	})
 	require.Nil(t, err)
-
-	eventCh <- &networkservice.ConnectionEvent{
-		Type: networkservice.ConnectionEventType_INITIAL_STATE_TRANSFER,
-		Connections: map[string]*networkservice.Connection{
-			"conn-1": {
-				Id:             "conn-1",
-				NetworkService: "ns-1",
-			},
-		},
-	}
-
 	t1 := time.Now()
-	eventCh <- &networkservice.ConnectionEvent{
-		Type: networkservice.ConnectionEventType_DELETE,
-		Connections: map[string]*networkservice.Connection{
-			"conn-1": {
-				Id:             "conn-1",
-				NetworkService: "ns-1",
-			},
-		},
-	}
+	_, err = server.Close(requestCtx, conn.Clone())
+	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), waitHealTimeout)
 	defer cancel()
 	select {
@@ -116,6 +110,8 @@ func TestHealClient_Request(t *testing.T) {
 		// All is fine, test is passed
 		break
 	}
+	_, err = client.Close(requestCtx, conn)
+	require.NoError(t, err)
 	logrus.Infof("passed with total time: %v", time.Since(t1))
 }
 
@@ -125,35 +121,47 @@ func TestHealClient_EmptyInit(t *testing.T) {
 	eventCh := make(chan *networkservice.ConnectionEvent, 1)
 	defer close(eventCh)
 
+	onHealCh := make(chan struct{})
+	// TODO for tomorrow... check on how to work onHeal into the new chain I've built
+	onHeal := &testOnHeal{
+		RequestFunc: func(ctx context.Context, in *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (connection *networkservice.Connection, e error) {
+			if ctx.Err() == nil {
+				close(onHealCh)
+			}
+			return &networkservice.Connection{}, nil
+		},
+	}
+
+	eventTrigger := &testOnHeal{
+		RequestFunc: func(ctx context.Context, in *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+			eventCh <- &networkservice.ConnectionEvent{
+				Type:        networkservice.ConnectionEventType_INITIAL_STATE_TRANSFER,
+				Connections: make(map[string]*networkservice.Connection),
+			}
+			return next.Client(ctx).Request(ctx, in)
+		},
+	}
+
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 	client := chain.NewNetworkServiceClient(
-		heal.NewClient(ctx, eventchannel.NewMonitorConnectionClient(eventCh), nil))
+		updatepath.NewClient("testClient"),
+		heal.NewClient(ctx, eventchannel.NewMonitorConnectionClient(eventCh), addressof.NetworkServiceClient(onHeal)),
+		updatetoken.NewClient(chainstest.GenerateTestToken),
+		updatepath.NewClient("testServer"),
+		eventTrigger,
+		updatetoken.NewClient(chainstest.GenerateTestToken),
+	)
 
-	ctx, cancel := context.WithTimeout(ctx, waitForTimeout)
-	defer cancel()
-	_, err := client.Request(ctx, &networkservice.NetworkServiceRequest{
+	requestCtx, reqCancelFunc := context.WithTimeout(ctx, waitForTimeout)
+	defer reqCancelFunc()
+
+	_, err := client.Request(requestCtx, &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
-			Id:             "conn-1",
 			NetworkService: "ns-1",
 		},
 	})
-	require.Nil(t, err)
-
-	eventCh <- &networkservice.ConnectionEvent{
-		Type:        networkservice.ConnectionEventType_INITIAL_STATE_TRANSFER,
-		Connections: make(map[string]*networkservice.Connection),
-	}
-
-	eventCh <- &networkservice.ConnectionEvent{
-		Type: networkservice.ConnectionEventType_UPDATE,
-		Connections: map[string]*networkservice.Connection{
-			"conn-1": {
-				Id:             "conn-1",
-				NetworkService: "ns-1",
-			},
-		},
-	}
+	require.Error(t, err)
 }
 
 func TestNewClient_MissingConnectionsInInit(t *testing.T) {

--- a/pkg/networkservice/common/heal/constants_test.go
+++ b/pkg/networkservice/common/heal/constants_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package heal_test
+
+import (
+	"time"
+)
+
+const (
+	waitForTimeout  = 100 * time.Millisecond
+	waitHealTimeout = 1000 * time.Millisecond
+	tickTimeout     = 20 * time.Millisecond
+)

--- a/pkg/networkservice/common/heal/constants_windows_test.go
+++ b/pkg/networkservice/common/heal/constants_windows_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package heal_test
+
+import "time"
+
+const (
+	waitForTimeout  = 50 * time.Millisecond
+	waitHealTimeout = 500 * time.Millisecond
+	tickTimeout     = 10 * time.Millisecond
+)

--- a/pkg/networkservice/common/updatetoken/client.go
+++ b/pkg/networkservice/common/updatetoken/client.go
@@ -44,6 +44,7 @@ func (u *updateTokenClient) Request(ctx context.Context, request *networkservice
 	}
 	err := updateToken(ctx, request.GetConnection(), u.tokenGenerator)
 	index := request.GetConnection().GetPath().GetIndex()
+	id := request.GetConnection().GetId()
 	if err != nil {
 		return nil, err
 	}
@@ -52,6 +53,7 @@ func (u *updateTokenClient) Request(ctx context.Context, request *networkservice
 		return nil, err
 	}
 	rv.GetPath().Index = index
+	rv.Id = id
 	return rv, err
 }
 

--- a/pkg/networkservice/core/adapters/monitor_server_to_client.go
+++ b/pkg/networkservice/core/adapters/monitor_server_to_client.go
@@ -41,5 +41,5 @@ func (m *monitorServerToClient) MonitorConnections(ctx context.Context, selector
 	go func() {
 		_ = m.server.MonitorConnections(selector, srv)
 	}()
-	return eventchannel.NewMonitorConnectionMonitorConnectionsClient(eventCh), nil
+	return eventchannel.NewMonitorConnectionMonitorConnectionsClient(ctx, eventCh), nil
 }

--- a/pkg/networkservice/core/eventchannel/monitor_client.go
+++ b/pkg/networkservice/core/eventchannel/monitor_client.go
@@ -72,7 +72,7 @@ func (m *monitorConnectionClient) MonitorConnections(ctx context.Context, _ *net
 			})
 		}()
 	})
-	return NewMonitorConnectionMonitorConnectionsClient(fanoutEventCh), nil
+	return NewMonitorConnectionMonitorConnectionsClient(ctx, fanoutEventCh), nil
 }
 
 func (m *monitorConnectionClient) eventLoop() {

--- a/pkg/networkservice/core/eventchannel/monitor_connection_client_test.go
+++ b/pkg/networkservice/core/eventchannel/monitor_connection_client_test.go
@@ -17,6 +17,7 @@
 package eventchannel_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -29,7 +30,7 @@ import (
 func TestMonitorConnection_MonitorConnectionsClient_Recv(t *testing.T) {
 	numEvents := 50
 	eventCh := make(chan *networkservice.ConnectionEvent, numEvents)
-	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(eventCh)
+	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(context.Background(), eventCh)
 	eventsIn := make([]*networkservice.ConnectionEvent, numEvents)
 	for i := 0; i < numEvents; i++ {
 		eventsIn[i] = &networkservice.ConnectionEvent{
@@ -59,7 +60,7 @@ func TestMonitorConnection_MonitorConnectionsClient_Recv(t *testing.T) {
 
 func TestMonitorConnection_MonitorConnectionsClient_RecvMsg(t *testing.T) {
 	eventCh := make(chan *networkservice.ConnectionEvent, 100)
-	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(eventCh)
+	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(context.Background(), eventCh)
 
 	var wrongTypeEvent struct{}
 	err := mcc.RecvMsg(wrongTypeEvent)
@@ -91,13 +92,13 @@ func TestMonitorConnection_MonitorConnectionsClient_RecvMsg(t *testing.T) {
 
 func TestMonitorConnection_MonitorConnectionsClient_CloseSend(t *testing.T) {
 	eventCh := make(chan *networkservice.ConnectionEvent)
-	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(eventCh)
+	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(context.Background(), eventCh)
 	assert.Nil(t, mcc.CloseSend())
 }
 
 func TestMonitorConnection_MonitorConnectionsClient_Header(t *testing.T) {
 	eventCh := make(chan *networkservice.ConnectionEvent)
-	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(eventCh)
+	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(context.Background(), eventCh)
 	header, err := mcc.Header()
 	assert.Nil(t, err)
 	assert.NotNil(t, header)
@@ -105,12 +106,12 @@ func TestMonitorConnection_MonitorConnectionsClient_Header(t *testing.T) {
 
 func TestMonitorConnection_MonitorConnectionsClient_SendMsg(t *testing.T) {
 	eventCh := make(chan *networkservice.ConnectionEvent)
-	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(eventCh)
+	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(context.Background(), eventCh)
 	assert.Nil(t, mcc.SendMsg(nil))
 }
 
 func TestMonitorConnection_MonitorConnectionsClient_Trailer(t *testing.T) {
 	eventCh := make(chan *networkservice.ConnectionEvent)
-	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(eventCh)
+	mcc := eventchannel.NewMonitorConnectionMonitorConnectionsClient(context.Background(), eventCh)
 	assert.NotNil(t, mcc.Trailer())
 }


### PR DESCRIPTION
The updatetoken chain element should restore the Connection.Id to match Path.PathSegment[Index].

Additionally, updatetoken should be the last thing that happens before
sending out the RPC call, so as to insure the Connection.Id and Path.Index
are always for the Connection.Id within the client when in client chain
elements.

This is important because otherwise the Connect.Id on the return through the
client does not match the Request.Connection.Id, and various indexing by identifiers
fails to work properly (including things like heal etc).

Because injectpeer is simply present to enable updatetoken, it is also moved
to the end of the chain just before updatetoken.

Unfortunately, this revealed a huge number of race conditions in the heal chain element,
which has been completely reworked to dispel them.

In doing so, it was discovered that eventchannel//monitor_client.go and monitor_connection_client.go
has some issues around respecting context.Context.

Which resulted in some small changes to adapters/monitor_server_to_client.go