### PR TITLE
feat: Add nsmgr-proxy chain elements: add pkg/tools/sandbox

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -30,16 +30,16 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	"github.com/networkservicemesh/api/pkg/api/registry"
-
-	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/chainstest"
+	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
 func TestNSMGR_RemoteUsecase(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()
-	domain := chainstest.NewDomainBuilder(t).
+	domain := sandbox.NewBuilder(t).
 		SetNodesCount(2).
+		SetRegistryProxySupplier(nil).
 		SetContext(ctx).
 		Build()
 	defer domain.Cleanup()
@@ -49,7 +49,7 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-remote"},
 	}
 
-	_, err := chainstest.NewEndpoint(ctx, nseReg, chainstest.GenerateTestToken, domain.Nodes[0].NSMgr)
+	_, err := sandbox.NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr)
 	require.NoError(t, err)
 
 	request := &networkservice.NetworkServiceRequest{
@@ -63,7 +63,7 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 		},
 	}
 
-	nsc, err := chainstest.NewClient(ctx, chainstest.GenerateTestToken, domain.Nodes[1].NSMgr.URL)
+	nsc, err := sandbox.NewClient(ctx, sandbox.GenerateTestToken, domain.Nodes[1].NSMgr.URL)
 	require.NoError(t, err)
 
 	conn, err := nsc.Request(ctx, request)
@@ -89,9 +89,10 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	domain := chainstest.NewDomainBuilder(t).
+	domain := sandbox.NewBuilder(t).
 		SetNodesCount(1).
 		SetContext(ctx).
+		SetRegistryProxySupplier(nil).
 		Build()
 	defer domain.Cleanup()
 
@@ -99,10 +100,10 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 		Name:                "final-endpoint",
 		NetworkServiceNames: []string{"my-service-remote"},
 	}
-	_, err := chainstest.NewEndpoint(ctx, nseReg, chainstest.GenerateTestToken, domain.Nodes[0].NSMgr)
+	_, err := sandbox.NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr)
 	require.NoError(t, err)
 
-	nsc, err := chainstest.NewClient(ctx, chainstest.GenerateTestToken, domain.Nodes[0].NSMgr.URL)
+	nsc, err := sandbox.NewClient(ctx, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr.URL)
 	require.NoError(t, err)
 
 	request := &networkservice.NetworkServiceRequest{

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -19,8 +19,11 @@ package nsmgr_test
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"go.uber.org/goleak"
 
@@ -30,11 +33,13 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	"github.com/networkservicemesh/api/pkg/api/registry"
+
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
 func TestNSMGR_RemoteUsecase(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	logrus.SetOutput(ioutil.Discard)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()
 	domain := sandbox.NewBuilder(t).
@@ -87,6 +92,7 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 
 func TestNSMGR_LocalUsecase(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	logrus.SetOutput(ioutil.Discard)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 	domain := sandbox.NewBuilder(t).

--- a/pkg/networkservice/common/heal/client_test.go
+++ b/pkg/networkservice/common/heal/client_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
-	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/chainstest"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/monitor"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatetoken"
@@ -80,12 +81,12 @@ func TestHealClient_Request(t *testing.T) {
 	server := chain.NewNetworkServiceServer(
 		updatepath.NewServer("testServer"),
 		monitor.NewServer(ctx, &monitorServer),
-		updatetoken.NewServer(chainstest.GenerateTestToken),
+		updatetoken.NewServer(sandbox.GenerateTestToken),
 	)
 	client := chain.NewNetworkServiceClient(
 		updatepath.NewClient("testClient"),
 		heal.NewClient(ctx, adapters.NewMonitorServerToClient(monitorServer), addressof.NetworkServiceClient(onHeal)),
-		updatetoken.NewClient(chainstest.GenerateTestToken),
+		updatetoken.NewClient(sandbox.GenerateTestToken),
 		adapters.NewServerToClient(server),
 	)
 
@@ -147,10 +148,10 @@ func TestHealClient_EmptyInit(t *testing.T) {
 	client := chain.NewNetworkServiceClient(
 		updatepath.NewClient("testClient"),
 		heal.NewClient(ctx, eventchannel.NewMonitorConnectionClient(eventCh), addressof.NetworkServiceClient(onHeal)),
-		updatetoken.NewClient(chainstest.GenerateTestToken),
+		updatetoken.NewClient(sandbox.GenerateTestToken),
 		updatepath.NewClient("testServer"),
 		eventTrigger,
-		updatetoken.NewClient(chainstest.GenerateTestToken),
+		updatetoken.NewClient(sandbox.GenerateTestToken),
 	)
 
 	requestCtx, reqCancelFunc := context.WithTimeout(ctx, waitForTimeout)

--- a/pkg/registry/chains/memory/server.go
+++ b/pkg/registry/chains/memory/server.go
@@ -48,7 +48,7 @@ func NewServer(ctx context.Context, proxyRegistryURL *url.URL, options ...grpc.D
 		}, connect.WithClientDialOptions(options...)),
 	)
 	nsChain := chain.NewNetworkServiceRegistryServer(
-		expire.NewNetworkServiceServer(adapters.NetworkServiceEndpointServerToClient(nseChain)),
+		expire.NewNetworkServiceServer(ctx, adapters.NetworkServiceEndpointServerToClient(nseChain)),
 		memory.NewNetworkServiceRegistryServer(),
 		proxy.NewNetworkServiceRegistryServer(proxyRegistryURL),
 		connect.NewNetworkServiceRegistryServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceRegistryClient {

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/goleak"
+
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/registry/memory"
 
@@ -33,6 +35,7 @@ import (
 )
 
 func TestNewNetworkServiceEndpointRegistryServer(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	s := next.NewNetworkServiceEndpointRegistryServer(expire.NewNetworkServiceEndpointRegistryServer(), memory.NewNetworkServiceEndpointRegistryServer())
 	expiration := time.Now().Add(testPeriod * 2)
 	_, err := s.Register(context.Background(), &registry.NetworkServiceEndpoint{

--- a/pkg/registry/memory/ns_server.go
+++ b/pkg/registry/memory/ns_server.go
@@ -55,7 +55,7 @@ func (n *networkServiceRegistryServer) Find(query *registry.NetworkServiceQuery,
 		var err error
 		n.networkServices.Range(func(key string, value *registry.NetworkService) bool {
 			if matchutils.MatchNetworkServices(ns, value) {
-				err = s.Send(value)
+				err = s.Send(value.Clone())
 				return err == nil
 			}
 			return true

--- a/pkg/registry/memory/nse_server.go
+++ b/pkg/registry/memory/nse_server.go
@@ -53,7 +53,7 @@ func (n *networkServiceEndpointRegistryServer) Find(query *registry.NetworkServi
 		var err error
 		n.networkServiceEndpoints.Range(func(key string, value *registry.NetworkServiceEndpoint) bool {
 			if matchutils.MatchNetworkServiceEndpoints(ns, value) {
-				err = s.Send(value)
+				err = s.Send(value.Clone())
 				return err == nil
 			}
 			return true

--- a/pkg/tools/sandbox/README.md
+++ b/pkg/tools/sandbox/README.md
@@ -1,0 +1,118 @@
+## Intro
+
+The main goal of package `sandbox` is a simplification setup of NSMgr infrastructure for unit testing.
+For example, if we need to check any chain element with remote NSM use-case then we need to configure and start the next GRPC servers:
+```
+NSMgr1
+NSMgr2
+Forwarder1
+Forwarder2
+Registry
+```
+And after that add needed test steps and asserts. So to reduce test lines was developed `sandbox` package.
+
+
+## Uses
+
+Let's consider the most common use-cases of package `sandbox`.
+
+### Setup single node NSM 
+
+Problem: setup NSMgr and Forwarder to checking new endpoint chain element.\
+Solution:
+```go
+	...
+	localDomain := sandbox.NewBuilder(t).
+		SetNodesCount(1).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		Build()
+	defer localDomain.Cleanup()
+	registerMyNewEndpoint(localDomain.Nodes[0].NSMgr.URL)
+    ...
+```
+
+Problem: setup my external NSMgr and Forwarder to checking my external NSMgr.\
+Solution:
+```go
+	...
+	localDomain := sandbox.NewBuilder(t).
+		SetNodesCount(1).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		SetNSMgrSupplier(myExternalNSMgrFunc)
+		Build()
+	defer localDomain.Cleanup()
+    ...
+```
+
+Problem: setup my NSMgr and new Forwarder to checking my Forwarder chain.\
+Solution:
+```go
+	...
+	localDomain := sandbox.NewBuilder(t).
+		SetNodesCount(1).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		SetForwarderSupplier(myNewForwarderFunc)
+		Build()
+	defer localDomain.Cleanup()
+	...
+```
+
+### Setup remote NSM infrastructure for remote use-case 
+
+Problem: setup NSMgr and Forwarder to checking remote use-case.\
+Solution:
+```go
+	...
+	localDomain := sandbox.NewBuilder(t).
+		SetNodesCount(2).
+		Build()
+	defer localDomain.Cleanup()
+	urlForNSERegistration := localDomain.Nodes[1].NSMgr.URL
+    ...
+```
+
+### Setup only local registry
+
+Problem: setup registry and to check API\
+Solution: 
+```go
+	...
+	localDomain := sandbox.NewBuilder(t).
+		SetNodesCount(0).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		Build()
+	defer localDomain.Cleanup()
+	registryURL := localDomain.Registry.URL
+	// Create new registry client by registryURL
+	...
+```
+
+### Setup remote NSM infrastructure for interdomain use-case 
+
+Problem: setup NSMgrs, Forwarders, Registries to checking interdomain use-case via DNS.\
+Solution:
+```go
+	...
+        fakeServer := new(sandbox.FakeDNSResolver)
+	domain1 := sandbox.NewBuilder(t).
+		SetContext(ctx).
+		SetNodesCount(1).
+		SetDNSDomainName("domain1").
+		SetDNSResolver(fakeServer).
+		Build()
+	defer domain1.Cleanup()
+	fakeServer.Register("domain1", domain1.Registry.URL)
+	domain2 := sandbox.NewBuilder(t).
+		SetContext(ctx).
+		SetNodesCount(1).
+		SetDNSDomainName("domain2").
+		SetDNSResolver(fakeServer).
+		Build()
+	defer domain1.Cleanup()
+	fakeServer.Register("domain2", domain2.Registry.URL)
+	...
+```

--- a/pkg/tools/sandbox/doc.go
+++ b/pkg/tools/sandbox/doc.go
@@ -14,5 +14,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package chainstest provides API for testing NSM chains such as Forwarder, NSC, NSMGR, NSE.
-package chainstest
+// Package sandbox provides API for testing NSM chains such as Forwarder, NSC, NSMgrs, Registries, NSE.
+package sandbox

--- a/pkg/tools/sandbox/fake_resolver.go
+++ b/pkg/tools/sandbox/fake_resolver.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"sync"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/common/dnsresolve"
+)
+
+// FakeDNSResolver implements dnsresolve.Resolver interface and can be used for logic DNS testing
+type FakeDNSResolver struct {
+	sync.Mutex
+	ports map[string]string
+}
+
+// LookupSRV lookups DNS SRV record
+func (f *FakeDNSResolver) LookupSRV(ctx context.Context, service, proto, name string) (string, []*net.SRV, error) {
+	f.Lock()
+	defer f.Unlock()
+	if f.ports == nil {
+		f.ports = map[string]string{}
+	}
+	if v, ok := f.ports[name]; ok {
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return "", nil, err
+		}
+		return fmt.Sprintf("_%v._%v.%v", service, proto, name), []*net.SRV{{
+			Port:   uint16(i),
+			Target: name,
+		}}, nil
+	}
+	return "", nil, errors.New("not found")
+}
+
+// LookupIPAddr lookups IP address by host
+func (f *FakeDNSResolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, error) {
+	f.Lock()
+	defer f.Unlock()
+	if f.ports == nil {
+		f.ports = map[string]string{}
+	}
+	if _, ok := f.ports[host]; ok {
+		return []net.IPAddr{{
+			IP: net.ParseIP("127.0.0.1"),
+		}}, nil
+	}
+	return nil, errors.New("not found")
+}
+
+// Register adds new DNS record by passed url.URL
+func (f *FakeDNSResolver) Register(name string, u *url.URL) error {
+	if u == nil {
+		return errors.New("u cannot be nil")
+	}
+	f.Lock()
+	defer f.Unlock()
+	if f.ports == nil {
+		f.ports = map[string]string{}
+	}
+	key := fmt.Sprintf("%v.%v", dnsresolve.NSMRegistryService, name)
+	var err error
+	_, f.ports[key], err = net.SplitHostPort(u.Host)
+	return err
+}
+
+var _ dnsresolve.Resolver = (*FakeDNSResolver)(nil)

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package chainstest
+package sandbox
 
 import (
 	"context"
@@ -27,6 +27,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/registry"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/dnsresolve"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
@@ -37,7 +38,10 @@ type SupplyNSMgrFunc func(context.Context, *registryapi.NetworkServiceEndpoint, 
 type SupplyForwarderFunc func(context.Context, string, token.GeneratorFunc, *url.URL, ...grpc.DialOption) endpoint.Endpoint
 
 // SupplyRegistryFunc supplies Registry
-type SupplyRegistryFunc func() registry.Registry
+type SupplyRegistryFunc func(ctx context.Context, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry
+
+// SupplyRegistryProxyFunc supplies registry proxy
+type SupplyRegistryProxyFunc func(ctx context.Context, dnsResolver dnsresolve.Resolver, handlingDNSDomain string, proxyNSMgrURL *url.URL, options ...grpc.DialOption) registry.Registry
 
 // Node is pair of Forwarder and NSMgr
 type Node struct {
@@ -65,10 +69,12 @@ type EndpointEntry struct {
 
 // Domain contains attached to domain nodes, registry
 type Domain struct {
-	Nodes     []*Node
-	Registry  *RegistryEntry
-	Name      string
-	resources []context.CancelFunc
+	Nodes         []*Node
+	Registry      *RegistryEntry
+	RegistryProxy *RegistryEntry
+	DNSResolver   dnsresolve.Resolver
+	Name          string
+	resources     []context.CancelFunc
 }
 
 // Cleanup frees all resources related to the domain


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation
https://github.com/networkservicemesh/sdk/issues/406
This PR is part of splitting PR https://github.com/networkservicemesh/sdk/pull/465
This part adds using the real registry chains for nsmgr testing.
Also, this PR moves chainstest into pkg `sandbox`.

