### PR TITLE
fix: interdomain registry chain elements should work correctly on passed interdomain ns

### DIFF
--- a/pkg/registry/chains/proxydns/server.go
+++ b/pkg/registry/chains/proxydns/server.go
@@ -35,7 +35,7 @@ import (
 func NewServer(ctx context.Context, dnsResolver dnsresolve.Resolver, handlingDNSDomain string, proxyNSMgrURL *url.URL, options ...grpc.DialOption) registry.Registry {
 	nseChain := chain.NewNetworkServiceEndpointRegistryServer(
 		dnsresolve.NewNetworkServiceEndpointRegistryServer(dnsresolve.WithResolver(dnsResolver)),
-		swap.NewNetworkServiceEndpointRegistryServer(handlingDNSDomain, proxyNSMgrURL, nil),
+		swap.NewNetworkServiceEndpointRegistryServer(handlingDNSDomain, proxyNSMgrURL),
 		connect.NewNetworkServiceEndpointRegistryServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) registryapi.NetworkServiceEndpointRegistryClient {
 			return registryapi.NewNetworkServiceEndpointRegistryClient(cc)
 		}, connect.WithClientDialOptions(options...)))

--- a/pkg/registry/common/dnsresolve/nse_server.go
+++ b/pkg/registry/common/dnsresolve/nse_server.go
@@ -18,6 +18,7 @@ package dnsresolve
 
 import (
 	"context"
+	"errors"
 	"net"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/clienturlctx"
@@ -66,7 +67,10 @@ func (d *dnsNSEResolveServer) Register(ctx context.Context, ns *registry.Network
 
 func (d *dnsNSEResolveServer) Find(q *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
 	ctx := s.Context()
-	domain := interdomain.Domain(q.NetworkServiceEndpoint.Name)
+	domain := findDomain(q.NetworkServiceEndpoint)
+	if domain == "" {
+		return errors.New("domain cannot be empty")
+	}
 	url, err := resolveDomain(ctx, d.service, domain, d.resolver)
 	if err != nil {
 		return err
@@ -88,4 +92,17 @@ func (d *dnsNSEResolveServer) Unregister(ctx context.Context, ns *registry.Netwo
 
 func (d *dnsNSEResolveServer) setResolver(r Resolver) {
 	d.resolver = r
+}
+
+func findDomain(nse *registry.NetworkServiceEndpoint) string {
+	domain := interdomain.Domain(nse.Name)
+	if domain != "" {
+		return domain
+	}
+	for _, service := range nse.NetworkServiceNames {
+		if domain = interdomain.Domain(service); domain != "" {
+			return domain
+		}
+	}
+	return ""
 }

--- a/pkg/registry/common/proxy/nse_server.go
+++ b/pkg/registry/common/proxy/nse_server.go
@@ -46,7 +46,7 @@ func (n *nseServer) Register(ctx context.Context, nse *registry.NetworkServiceEn
 }
 
 func (n nseServer) Find(q *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
-	if !interdomain.Is(q.NetworkServiceEndpoint.Name) {
+	if !isInterdomain(q.NetworkServiceEndpoint) {
 		return nil
 	}
 	if n.proxyRegistryURL == nil {
@@ -72,4 +72,16 @@ func NewNetworkServiceEndpointRegistryServer(proxyRegistryURL *url.URL) registry
 	return &nseServer{
 		proxyRegistryURL: proxyRegistryURL,
 	}
+}
+
+func isInterdomain(nse *registry.NetworkServiceEndpoint) bool {
+	if interdomain.Is(nse.Name) {
+		return true
+	}
+	for _, ns := range nse.NetworkServiceNames {
+		if interdomain.Is(ns) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/registry/common/swap/nse_server_test.go
+++ b/pkg/registry/common/swap/nse_server_test.go
@@ -32,24 +32,21 @@ import (
 )
 
 func TestNewSwapNetworkServiceEndpointRegistryServer_RegisterUnregister(t *testing.T) {
-	expected := &url.URL{Path: "test"}
-	s := swap.NewNetworkServiceEndpointRegistryServer("my.cluster", nil, expected)
+	s := swap.NewNetworkServiceEndpointRegistryServer("my.cluster", nil)
 	response, err := s.Register(context.Background(), &registry.NetworkServiceEndpoint{Name: "my-nse@floating.registry.domain"})
 	require.Nil(t, err)
 	require.Equal(t, response.Name, "my-nse@my.cluster")
-	require.Equal(t, expected.String(), response.Url)
 	request := &registry.NetworkServiceEndpoint{Name: "my-nse@floating.registry.domain"}
 	_, err = s.Unregister(context.Background(), request)
 	require.Nil(t, err)
 	require.Equal(t, "my-nse@my.cluster", request.Name)
-	require.Equal(t, expected.String(), request.Url)
 }
 
 func TestNewSwapNetworkServiceEndpointRegistryServer_Find(t *testing.T) {
 	proxyNSMgr := &url.URL{Path: "proxy"}
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 	s := next.NewNetworkServiceEndpointRegistryServer(
-		swap.NewNetworkServiceEndpointRegistryServer("my.cluster", proxyNSMgr, nil),
+		swap.NewNetworkServiceEndpointRegistryServer("my.cluster", proxyNSMgr),
 		mem,
 	)
 	_, err := mem.Register(context.Background(), &registry.NetworkServiceEndpoint{

--- a/pkg/tools/matchutils/utils.go
+++ b/pkg/tools/matchutils/utils.go
@@ -36,10 +36,21 @@ func MatchNetworkServiceEndpoints(left, right *registry.NetworkServiceEndpoint) 
 	return (left.Name == "" || matchString(right.Name, left.Name)) &&
 		(left.NetworkServiceLabels == nil || reflect.DeepEqual(left.NetworkServiceLabels, right.NetworkServiceLabels)) &&
 		(left.ExpirationTime == nil || left.ExpirationTime.Seconds == right.ExpirationTime.Seconds) &&
-		(left.NetworkServiceNames == nil || reflect.DeepEqual(left.NetworkServiceNames, right.NetworkServiceNames)) &&
+		(left.NetworkServiceNames == nil || contains(right.NetworkServiceNames, left.NetworkServiceNames)) &&
 		(left.Url == "" || matchString(right.Url, left.Url))
 }
 
 func matchString(left, right string) bool {
 	return strings.Contains(left, right)
+}
+
+func contains(what, where []string) bool {
+	set := make(map[string]struct{})
+	for _, s := range what {
+		set[s] = struct{}{}
+	}
+	for _, s := range where {
+		delete(set, s)
+	}
+	return len(set) == 0
 }


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

#406
This PR is part of splitting PR #465
This part fixes a case when the registry find NSE by ns name with "@"