### PR TITLE
Add spire healthcheck timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/RoaringBitmap/roaring v0.4.23
-	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edwarnicke/exechelper v1.0.1
@@ -15,7 +14,6 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/google/uuid v1.1.1
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
-	github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2
 	github.com/nats-io/nats-streaming-server v0.17.0
 	github.com/nats-io/stan.go v0.6.0
 	github.com/networkservicemesh/api v0.0.0-20200925211324-37a4e74e139d

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx2
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 h1:SKI1/fuSdodxmNNyVBR8d7X/HuLnRpvvFO0AgyQk764=
-github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -124,8 +122,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2 h1:JAEbJn3j/FrhdWA9jW8B5ajsLIjeuEHLi8xE4fk997o=
-github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2/go.mod h1:0KeJpeMD6o+O4hW7qJOT7vyQPKrWmj26uf5wMc/IiIs=
 github.com/mattn/go-runewidth v0.0.0-20181025052659-b20a3daf6a39/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mna/pigeon v0.0.0-20180808201053-bb0192cfc2ae/go.mod h1:Iym28+kJVnC1hfQvv5MUtI6AiFFzvQjHcvI4RFTG/04=


### PR DESCRIPTION
Spire agent fails to start in 10 attempts while testing on packet setup:
```
...
Sep 29 01:56:12.171 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.170 [INFO] [cmd:spire-agent run] time="2020-09-29T01:56:12Z" level=warning msg="Current umask 0022 is too permissive; setting umask 0027."
Sep 29 01:56:12.192 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.170 [INFO] [cmd:spire-agent run] time="2020-09-29T01:56:12Z" level=warning msg="Insecure bootstrap enabled; skipping server certificate verification" subsystem_name=attestor
Sep 29 01:56:12.214 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.230 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.253 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.270 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.286 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.312 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.331 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 01:56:12.354 [INFO] [cmd:spire-agent healthcheck] Agent is unavailable.
--- FAIL: TestForwarderTestSuite (0.40s)
    main_test.go:81: 
        	Error Trace:	main_test.go:81
        	            				suite.go:118
        	            				main_test.go:165
        	Error:      	"%!s(<-chan error=0xc00033aa20)" should have 0 item(s), but has 1
        	Test:       	TestForwarderTestSuite
FAIL
FAIL	github.com/networkservicemesh/cmd-forwarder-sriov	0.411s
```
With timeouts added spire agents starts:
```
Sep 29 02:32:10.254 [WARN] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 02:32:10.254 [INFO] [cmd:spire-agent run] time="2020-09-29T02:32:10Z" level=warning msg="Insecure bootstrap enabled; skipping server certificate verification" subsystem_name=attestor
Sep 29 02:32:10.381 [WARN] [cmd:spire-agent healthcheck] Agent is unavailable.
Sep 29 02:32:10.254 [INFO] [cmd:spire-agent run] time="2020-09-29T02:32:10Z" level=error msg="No identity issued" error="<nil>" registered=false subsystem_name=workload_api
Sep 29 02:32:10.505 [INFO] [cmd:spire-agent healthcheck] Agent is healthy.
```