### PR TITLE
Fix use of deprecated set-env

### DIFF
--- a/.github/workflows/pr-for-updates.yaml
+++ b/.github/workflows/pr-for-updates.yaml
@@ -14,7 +14,7 @@ jobs:
         run: |
           PULL_REQUEST_BODY=$(git log -1)
           echo ${PULL_REQUEST_BODY}
-          echo "::set-env name=PULL_REQUEST_BODY::${PULL_REQUEST_BODY}"
+          echo PULL_REQUEST_BODY=${PULL_REQUEST_BODY} >> $GITHUB_ENV
       - name: pull-request-action
         uses: vsoch/pull-request-action@1.0.6
         env:


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/