### PR TITLE
Remove deprecated upstream_bundle spire server option

### DIFF
--- a/pkg/tools/spire/server.conf.go
+++ b/pkg/tools/spire/server.conf.go
@@ -26,7 +26,7 @@ const (
     trust_domain = "example.org"
     data_dir = "%[1]s/data"
     log_level = "WARN"
-    upstream_bundle = true
+    ca_key_type = "rsa-2048"
     default_svid_ttl = "1h"
     ca_subject = {
         country = ["US"],


### PR DESCRIPTION
Remove deprecated upstream_bundle spire server option

According to https://github.com/spiffe/spire/pull/1702

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>