### PR TITLE
fix: correctly pass generate token func for forwarders in sandbox

### DIFF
--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -312,7 +312,7 @@ func supplyDummyForwarder(ctx context.Context, name string, generateToken token.
 				name,
 				// What to call onHeal
 				addressof.NetworkServiceClient(adapters.NewServerToClient(result)),
-				GenerateTestToken,
+				generateToken,
 			),
 			grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 		))


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>