### PR TITLE
fix: Nested serialize.Executor.AsyncExec calls may deadlock when overwhelmed 

### DIFF
--- a/pkg/tools/serialize/serialize.go
+++ b/pkg/tools/serialize/serialize.go
@@ -42,10 +42,12 @@ func NewExecutor() Executor {
 //        It immediately returns a channel that will be closed when f() has completed execution.
 func (e *Executor) AsyncExec(f func()) <-chan struct{} {
 	done := make(chan struct{})
+	e.mutex.Lock()
 	e.queue.PushBack(func() {
 		f()
 		close(done)
 	})
+	e.mutex.Unlock()
 	// Start go routine if we don't have one
 	if atomic.AddInt32(&e.count, 1) == 1 {
 		go func() {

--- a/pkg/tools/serialize/serialize_test.go
+++ b/pkg/tools/serialize/serialize_test.go
@@ -22,11 +22,32 @@ package serialize_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/serialize"
 )
+
+func TestNestedAsyncExec(t *testing.T) {
+	var exec serialize.Executor
+
+	exec.AsyncExec(func() {
+		time.Sleep(time.Millisecond * 50)
+		exec.AsyncExec(func() {
+			time.Sleep(time.Millisecond * 50)
+			exec.AsyncExec(func() {
+				time.Sleep(time.Millisecond * 50)
+			})
+		})
+	})
+
+	for i := 0; i < 1e3; i++ {
+		exec.AsyncExec(func() {})
+	}
+
+	<-exec.AsyncExec(func() {})
+}
 
 func TestASyncExec(t *testing.T) {
 	exec := serialize.NewExecutor()


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

https://github.com/networkservicemesh/sdk/issues/512