### PR TITLE
fix: update-dependent-repositories-gomod fails fast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,7 +134,9 @@ jobs:
           GITHUB_LOGIN: nsmbot
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   update-dependent-repositories:
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         repository: [cmd-registry-memory, cmd-registry-proxy-dns, sdk-kernel, sdk-vppagent, cmd-nsmgr]
     name: Update ${{ matrix.repository }}

--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   update-dependent-repositories:
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         repository: [cmd-registry-memory, cmd-registry-proxy-dns, sdk-kernel, sdk-vppagent, cmd-nsmgr, cmd-nsmgr-proxy]
     name: Update ${{ matrix.repository }}


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

 update-dependent-repositories-gomod fails fast and other repositories don't update (if one of the repositories can not be updated)