### PR TITLE
Fix interpose chain element

### DIFF
--- a/pkg/networkservice/common/interpose/server.go
+++ b/pkg/networkservice/common/interpose/server.go
@@ -22,16 +22,21 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/networkservicemesh/api/pkg/api/registry"
-	"github.com/pkg/errors"
-
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
-	"github.com/networkservicemesh/sdk/pkg/registry/common/interpose"
 	"github.com/networkservicemesh/sdk/pkg/tools/clienturlctx"
 	"github.com/networkservicemesh/sdk/pkg/tools/stringurl"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/common/interpose"
+
+	"github.com/pkg/errors"
+
+	"github.com/golang/protobuf/ptypes/empty"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 )
 
 type interposeServer struct {
@@ -129,24 +134,13 @@ func (l *interposeServer) Request(ctx context.Context, request *networkservice.N
 }
 
 func (l *interposeServer) getConnectionID(conn *networkservice.Connection) string {
-	id := ""
-	segmentIdx := conn.GetPath().GetIndex()
-	isCrossNSEPrev := false
-
-	l.endpoints.Range(func(key string, crossNSEURL *url.URL) bool {
-		isCrossNSEPrev =
-			conn.Path.PathSegments[segmentIdx-1].Name == key
-		return !isCrossNSEPrev
-	})
-	if isCrossNSEPrev {
-		for j := segmentIdx - 2; j > 0; j-- {
-			if conn.GetPath().GetPathSegments()[j].Name == l.name {
-				id = conn.GetPath().GetPathSegments()[j].Id
-				break
-			}
+	id := conn.Id
+	for i := conn.GetPath().GetIndex(); i > 0; i-- {
+		lid := conn.GetPath().GetPathSegments()[i].Id
+		_, ok := l.activeConnection.Load(lid)
+		if ok {
+			return lid
 		}
-	} else {
-		id = conn.GetPath().GetPathSegments()[segmentIdx].Id
 	}
 	return id
 }

--- a/pkg/registry/common/interpose/server.go
+++ b/pkg/registry/common/interpose/server.go
@@ -52,10 +52,9 @@ func (l *interposeRegistry) Register(ctx context.Context, request *registry.Netw
 			return nil, errors.New("invalid endpoint URL passed with context")
 		}
 
-		if request.Name == interposeNSEName {
-			// Generate uniq name only if full equal to endpoints prefix.
-			request.Name = interposeNSEName + uuid.New().String()
-		}
+		// Generate uniq name for interpose endpoint, since we use it in maps.
+		request.Name = interposeNSEName + uuid.New().String()
+
 		u, err := url.Parse(request.Url)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Cannot register cross nse with passed URL")


### PR DESCRIPTION
1. Simplify check for direction, if active connections contain path with longest index, we already visited interpose, if not we not.

2. Always generate uniq interpose endpoint name.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>