### PR TITLE
Fix issue with storing invalid URL in interpose registry

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -132,10 +132,10 @@ func NewServer(ctx context.Context, nsmRegistration *registryapi.NetworkServiceE
 	nsChain := chain_registry.NewNetworkServiceRegistryServer(nsRegistry)
 	nseChain := chain_registry.NewNetworkServiceEndpointRegistryServer(
 		nilEndpointFilter(
-			urlsRegistryServer,
 			newRecvFDEndpointRegistry(), // Allow to receive a passed files
-			interposeRegistry,           // Store cross connect NSEs
-			localbypassRegistryServer,   // Store endpoint Id to EndpointURL for local access.
+			urlsRegistryServer,
+			interposeRegistry,         // Store cross connect NSEs
+			localbypassRegistryServer, // Store endpoint Id to EndpointURL for local access.
 			seturl.NewNetworkServiceEndpointRegistryServer(nsmRegistration.Url), // Remember endpoint URL
 			nseRegistry, // Register NSE inside Remote registry with ID assigned
 		)...,

--- a/pkg/networkservice/common/excludedprefixes/server.go
+++ b/pkg/networkservice/common/excludedprefixes/server.go
@@ -81,6 +81,9 @@ func (eps *excludedPrefixesServer) Request(ctx context.Context, request *network
 	logger := trace.Log(ctx)
 
 	conn := request.GetConnection()
+	if conn.GetContext() == nil {
+		conn.Context = &networkservice.ConnectionContext{}
+	}
 	if conn.GetContext().GetIpContext() == nil {
 		conn.Context.IpContext = &networkservice.IPContext{}
 	}


### PR DESCRIPTION
# Issue
NSMgr stores `inode://` URL in interpose registry and then fails to access forwarder.
# Solution
```go
    newRecvFDEndpointRegistry(), // <-- first replace `inode` URL with `unix` URL
    urlsRegistryServer, // <-- then store it into the interpose registry
```