### PR TITLE
Extract connectClient mechanism translation logic

### DIFF
--- a/pkg/networkservice/common/connect/client.go
+++ b/pkg/networkservice/common/connect/client.go
@@ -28,9 +28,8 @@ import (
 )
 
 type connectClient struct {
-	mechanism *networkservice.Mechanism
-	cancel    context.CancelFunc
-	mu        sync.Mutex
+	cancel context.CancelFunc
+	mu     sync.Mutex
 }
 
 // NewClient - client chain element for use with single incoming connection, translates from incoming server connection to
@@ -44,21 +43,14 @@ func NewClient(cancel context.CancelFunc) networkservice.NetworkServiceClient {
 func (c *connectClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	clientRequest := request.Clone()
-	clientRequest.MechanismPreferences = nil
-	clientRequest.Connection.Mechanism = c.mechanism
-	conn, err := next.Client(ctx).Request(ctx, clientRequest)
-	c.mechanism = conn.GetMechanism()
+	conn, err := next.Client(ctx).Request(ctx, request)
 	return conn, err
 }
 
 func (c *connectClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	conn = conn.Clone()
-	conn.Mechanism = c.mechanism
 	e, err := next.Client(ctx).Close(ctx, conn)
-	c.mechanism = nil
 	c.cancel()
 	return e, err
 }

--- a/pkg/networkservice/common/translatemechanism/client.go
+++ b/pkg/networkservice/common/translatemechanism/client.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package translatemechanism contains client chain-element, which replaces incoming request mechanism
+// and clears MechanismPreferences
+package translatemechanism
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+type translateMechanismClient struct {
+	mechanism *networkservice.Mechanism
+}
+
+// NewClient - creates new translateMechanismClient chain element
+func NewClient() networkservice.NetworkServiceClient {
+	return &translateMechanismClient{}
+}
+
+func (c *translateMechanismClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	clientRequest := request.Clone()
+	clientRequest.MechanismPreferences = nil
+	clientRequest.Connection.Mechanism = c.mechanism
+	conn, err := next.Client(ctx).Request(ctx, clientRequest)
+	if err != nil {
+		return nil, err
+	}
+	c.mechanism = conn.GetMechanism()
+	return conn, nil
+}
+
+func (c *translateMechanismClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	conn = conn.Clone()
+	conn.Mechanism = c.mechanism
+	e, err := next.Client(ctx).Close(ctx, conn)
+	c.mechanism = nil
+	return e, err
+}

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/translatemechanism"
+
 	"github.com/networkservicemesh/sdk/pkg/tools/spanhelper"
 
 	"github.com/google/uuid"
@@ -320,6 +322,7 @@ func supplyDummyForwarder(ctx context.Context, name string, generateToken token.
 				// What to call onHeal
 				addressof.NetworkServiceClient(adapters.NewServerToClient(result)),
 				generateToken,
+				translatemechanism.NewClient(),
 			),
 			grpc.WithInsecure(), grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 		))


### PR DESCRIPTION
Should fix #552 

Added `translateMechanism` chain-element, containing mechanism translation logic, which is supposed to be used in forwarders. 