### PR TITLE
Remove addressof from the client chain

### DIFF
--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatetoken"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injectpeer"
-	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"google.golang.org/grpc"
@@ -55,7 +54,7 @@ import (
 func NewClient(ctx context.Context, name string, onHeal *networkservice.NetworkServiceClient, tokenGenerator token.GeneratorFunc, cc grpc.ClientConnInterface, additionalFunctionality ...networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
 	var rv networkservice.NetworkServiceClient
 	if onHeal == nil {
-		onHeal = addressof.NetworkServiceClient(rv)
+		onHeal = &rv
 	}
 	rv = chain.NewNetworkServiceClient(
 		append(


### PR DESCRIPTION
The issue with the old code (simplified for the clarity):

```go
var rv networkservice.NetworkServiceClient
onHeal = addressof.NetworkServiceClient(rv)
rv = something()

// Now, *onHeal == nil, which isn't expected
```

This code is an equivalent to the following:

```go
var rv networkservice.NetworkServiceClient
client := rv
onHeal = &client
rv = something()

// Now, *onHeal == nil, which isn't expected
```

The new code:
```go
var rv networkservice.NetworkServiceClient
onHeal = &rv
rv = something()

// *onHeal == rv, as expected
```

---

Related: https://github.com/networkservicemesh/sdk/issues/534#issuecomment-709687956
This is not the only instance where a similar issue with `addressof` occurs, I'll address the others in a separate issue.