### PR TITLE
Fix issue with interpose chain element in passthrough case

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -300,6 +300,7 @@ func (p *passThroughClient) Request(ctx context.Context, request *networkservice
 		Connection: &networkservice.Connection{
 			NetworkService:             p.networkService,
 			NetworkServiceEndpointName: p.networkServiceEndpointName,
+			Path:                       request.Connection.Path.Clone(),
 			Context:                    &networkservice.ConnectionContext{},
 		},
 	}
@@ -308,8 +309,7 @@ func (p *passThroughClient) Request(ctx context.Context, request *networkservice
 		return nil, err
 	}
 
-	request.Connection.Path.Index += conn.Path.Index
-	request.Connection.Path.PathSegments = append(request.Connection.Path.PathSegments, conn.Path.PathSegments...)
+	request.Connection.Path.PathSegments = conn.Path.PathSegments
 
 	return next.Client(ctx).Request(ctx, request, opts...)
 }


### PR DESCRIPTION
# `interpose.NewServer()` works invalid in pass through case
If we have such chain:
```
client -> NSMgr -(1)-> Forwarder -> NSMgr -(2)-> pass through NSE -> NSMgr -(3)-> Forwarder -> NSMgr -(4)-> NSE
```
on (3) interpose chain element should create a new `connectionInfo` for the connection, but there is an existing `connectionInfo` for some Connection.ID from the connection path, so it doesn't do it.
# Solution
Add `connectionInfo.clientConnID` field and add `connectionInfo` by both client and forwarder connection ID. Check whether the last actual connection ID in the path matches `connectionInfo.clientConnID` or not.