### PR TITLE
Fix interpose

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -114,7 +114,7 @@ func NewServer(ctx context.Context, nsmRegistration *registryapi.NetworkServiceE
 		localbypass.NewServer(&localbypassRegistryServer),
 		excludedprefixes.NewServer(ctx),
 		newRecvFD(), // Receive any files passed
-		interpose.NewServer(nsmRegistration.Name, &interposeRegistry),
+		interpose.NewServer(&interposeRegistry),
 		filtermechanisms.NewServer(&urlsRegistryServer),
 		connect.NewServer(
 			ctx,


### PR DESCRIPTION
# Issue
`interpose.NewServer()` works incorrect for refresh, close scenarios. Existing test doesn't cover it.
# Solution
Remove bool switches, check _if interpose_ case with `connectionInfo.clientConnID`. Add valid test.