### PR TITLE
Make updatepath restore path index on return

### DIFF
--- a/pkg/networkservice/common/updatepath/client.go
+++ b/pkg/networkservice/common/updatepath/client.go
@@ -44,15 +44,24 @@ func (i *updatePathClient) Request(ctx context.Context, request *networkservice.
 		request.Connection = &networkservice.Connection{}
 	}
 
-	request.Connection, err = updatePath(request.Connection, i.name)
+	var index uint32
+	request.Connection, index, err = updatePath(request.Connection, i.name)
 	if err != nil {
 		return nil, err
 	}
-	return next.Client(ctx).Request(ctx, request, opts...)
+
+	conn, err = next.Client(ctx).Request(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	conn.Path.Index = index
+
+	return conn, err
 }
 
 func (i *updatePathClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (_ *empty.Empty, err error) {
-	conn, err = updatePath(conn, i.name)
+	conn, _, err = updatePath(conn, i.name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/networkservice/common/updatepath/client_test.go
+++ b/pkg/networkservice/common/updatepath/client_test.go
@@ -21,13 +21,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/require"
-
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"
+	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/checks/checkrequest"
 )
 
 const (
@@ -59,10 +62,12 @@ func request(connectionID string, pathIndex uint32) *networkservice.NetworkServi
 
 func TestNewClient_SetNewConnectionId(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	client := updatepath.NewClient("nse-3")
+
 	conn, err := client.Request(context.Background(), request(connectionID, 1))
-	require.NotNil(t, conn)
 	require.NoError(t, err)
+	require.NotNil(t, conn)
 	require.Equal(t, 3, len(conn.Path.PathSegments))
 	require.Equal(t, "nse-3", conn.Path.PathSegments[2].Name)
 	require.NotEqual(t, conn.Id, connectionID)
@@ -70,73 +75,134 @@ func TestNewClient_SetNewConnectionId(t *testing.T) {
 
 func TestNewClient_SetNewConnectionId2(t *testing.T) {
 	defer goleak.VerifyNone(t)
-	client := updatepath.NewClient("nse-2")
+
+	client := next.NewNetworkServiceClient(
+		updatepath.NewClient("nse-2"),
+		checkrequest.NewClient(t, func(t *testing.T, request *networkservice.NetworkServiceRequest) {
+			require.Equal(t, 1, int(request.Connection.Path.Index))
+		}),
+	)
+
 	conn, err := client.Request(context.Background(), request(connectionID, 0))
-	require.NotNil(t, conn)
 	require.NoError(t, err)
-	require.Equal(t, 1, int(conn.Path.Index))
+	require.NotNil(t, conn)
 	require.Equal(t, conn.Id, pathSegmentID2)
 }
 
 func TestNewClient_SetNewConnectionIdSecondReq(t *testing.T) {
 	defer goleak.VerifyNone(t)
+
 	client := updatepath.NewClient("nse-1")
+
 	conn, err := client.Request(context.Background(), request(connectionID, 0))
-	assert.NotNil(t, conn)
-	assert.NoError(t, err)
-	assert.Equal(t, conn.Id, pathSegmentID1)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, conn.Id, pathSegmentID1)
 
 	firstConnID := conn.Id
 
-	conn.GetPath().Index = 0
 	conn, err = client.Request(context.Background(), &networkservice.NetworkServiceRequest{
 		Connection: conn,
 	})
-	assert.NotNil(t, conn)
-	assert.NoError(t, err)
-	assert.Equal(t, firstConnID, conn.Id)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, firstConnID, conn.Id)
 }
 
 func TestNewClient_PathSegmentNameEqualClientName(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	client := updatepath.NewClient("nse-2")
+
 	conn, err := client.Request(context.Background(), request(connectionID, 1))
-	assert.NotNil(t, conn)
-	assert.NoError(t, err)
-	assert.NotEqual(t, conn.Id, connectionID)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NotEqual(t, conn.Id, connectionID)
 }
 
 func TestNewClient_PathSegmentIdEqualConnectionId(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	client := updatepath.NewClient("nse-2")
+
 	conn, err := client.Request(context.Background(), request(pathSegmentID2, 1))
-	assert.NotNil(t, conn)
-	assert.NoError(t, err)
-	assert.Equal(t, conn.Id, pathSegmentID2)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, conn.Id, pathSegmentID2)
 }
 
 func TestNewClient_PathSegmentNameAndIDEqualClientNameAndID(t *testing.T) {
 	defer goleak.VerifyNone(t)
+
 	client := updatepath.NewClient("nse-2")
+
 	conn, err := client.Request(context.Background(), request(pathSegmentID2, 1))
-	assert.NotNil(t, conn)
-	assert.NoError(t, err)
-	assert.Equal(t, conn.Id, pathSegmentID2)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, conn.Id, pathSegmentID2)
 }
 
 func TestNewClient_InvalidIndex(t *testing.T) {
 	defer goleak.VerifyNone(t)
+
 	client := updatepath.NewClient("nse-3")
+
 	conn, err := client.Request(context.Background(), request(connectionID, 2))
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Nil(t, conn)
 }
 
 func TestNewClient_NoConnection(t *testing.T) {
 	defer goleak.VerifyNone(t)
+
 	client := updatepath.NewClient("nse-3")
+
 	conn, err := client.Request(context.Background(), &networkservice.NetworkServiceRequest{})
-	assert.NotNil(t, conn)
-	assert.NoError(t, err)
-	assert.NotEqual(t, conn.Id, connectionID)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NotEqual(t, conn.Id, connectionID)
+}
+
+func TestNewClient_RestoreIndex(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	client := next.NewNetworkServiceClient(
+		updatepath.NewClient("nse-1"),
+		newPathIndexClient(t, 0),
+		updatepath.NewClient("nse-2"),
+		newPathIndexClient(t, 1),
+		updatepath.NewClient("nse-2"),
+		newPathIndexClient(t, 1),
+		updatepath.NewClient("nse-3"),
+		newPathIndexClient(t, 2),
+	)
+
+	_, err := client.Request(context.Background(), request(connectionID, 0))
+	require.NoError(t, err)
+}
+
+type pathIndexClient struct {
+	t     *testing.T
+	index uint32
+}
+
+func newPathIndexClient(t *testing.T, index uint32) *pathIndexClient {
+	return &pathIndexClient{
+		t:     t,
+		index: index,
+	}
+}
+
+func (c *pathIndexClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	require.Equal(c.t, c.index, request.Connection.Path.Index)
+	conn, err := next.Client(ctx).Request(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+	require.Equal(c.t, c.index, conn.Path.Index)
+	return conn, nil
+}
+
+func (c *pathIndexClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/pkg/networkservice/common/updatepath/server_test.go
+++ b/pkg/networkservice/common/updatepath/server_test.go
@@ -20,66 +20,122 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"
-
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 )
 
 func TestNewServer_SetNewConnectionId(t *testing.T) {
 	defer goleak.VerifyNone(t)
+
 	server := updatepath.NewServer("nse-3")
+
 	conn, err := server.Request(context.Background(), request(connectionID, 1))
-	require.NotNil(t, conn)
 	require.NoError(t, err)
+	require.NotNil(t, conn)
 	require.NotEqual(t, conn.Id, connectionID)
 }
 
 func TestNewServer_SetNewPathId(t *testing.T) {
 	defer goleak.VerifyNone(t)
+
 	server := updatepath.NewServer("nse-3")
+
 	conn, err := server.Request(context.Background(), request(connectionID, 0))
-	require.NotNil(t, conn)
 	require.NoError(t, err)
+	require.NotNil(t, conn)
 	require.Equal(t, conn.Path.PathSegments[1].Name, "nse-3") // Check name is replaced.
 	require.Equal(t, conn.Id, conn.Path.PathSegments[1].Id)
 }
 
 func TestNewServer_PathSegmentNameEqualClientName(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	server := updatepath.NewServer("nse-2")
+
 	conn, err := server.Request(context.Background(), request(connectionID, 1))
-	require.NotNil(t, conn)
 	require.NoError(t, err)
+	require.NotNil(t, conn)
 	require.NotEqual(t, conn.Id, connectionID)
 }
 
 func TestNewServer_PathSegmentIdEqualConnectionId(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	server := updatepath.NewServer("nse-3")
-	conn, err := server.Request(context.Background(), request(pathSegmentID2, 1))
-	require.NotNil(t, conn)
 
+	server := updatepath.NewServer("nse-3")
+
+	conn, err := server.Request(context.Background(), request(pathSegmentID2, 1))
 	require.NoError(t, err)
+	require.NotNil(t, conn)
 	require.NotEqual(t, conn.Id, pathSegmentID2)
 }
 
 func TestNewServer_PathSegmentNameIDEqualClientNameID(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	server := updatepath.NewServer("nse-2")
-	conn, err := server.Request(context.Background(), request(pathSegmentID2, 1))
-	assert.NotNil(t, conn)
 
+	server := updatepath.NewServer("nse-2")
+
+	conn, err := server.Request(context.Background(), request(pathSegmentID2, 1))
 	require.NoError(t, err)
+	require.NotNil(t, conn)
 	require.Equal(t, conn.Id, pathSegmentID2)
 }
 
 func TestNewServer_InvalidIndex(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	server := updatepath.NewServer("nse-3")
+
 	conn, err := server.Request(context.Background(), request(connectionID, 2))
+	require.Error(t, err)
 	require.Nil(t, conn)
-	require.NotNil(t, err)
+}
+
+func TestNewServer_RestoreIndex(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	server := next.NewNetworkServiceServer(
+		updatepath.NewServer("nse-1"),
+		newPathIndexServer(t, 0),
+		updatepath.NewServer("nse-2"),
+		newPathIndexServer(t, 1),
+		updatepath.NewServer("nse-2"),
+		newPathIndexServer(t, 1),
+		updatepath.NewServer("nse-3"),
+		newPathIndexServer(t, 2),
+	)
+
+	_, err := server.Request(context.Background(), request(connectionID, 0))
+	require.NoError(t, err)
+}
+
+type pathIndexServer struct {
+	t     *testing.T
+	index uint32
+}
+
+func newPathIndexServer(t *testing.T, index uint32) *pathIndexServer {
+	return &pathIndexServer{
+		t:     t,
+		index: index,
+	}
+}
+
+func (s *pathIndexServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	require.Equal(s.t, s.index, request.Connection.Path.Index)
+	conn, err := next.Server(ctx).Request(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	require.Equal(s.t, s.index, conn.Path.Index)
+	return conn, nil
+}
+
+func (s *pathIndexServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	return next.Server(ctx).Close(ctx, conn)
 }

--- a/pkg/networkservice/common/updatetoken/client.go
+++ b/pkg/networkservice/common/updatetoken/client.go
@@ -43,17 +43,18 @@ func (u *updateTokenClient) Request(ctx context.Context, request *networkservice
 		request.Connection = &networkservice.Connection{}
 	}
 	err := updateToken(ctx, request.GetConnection(), u.tokenGenerator)
-	index := request.GetConnection().GetPath().GetIndex()
-	id := request.GetConnection().GetId()
 	if err != nil {
 		return nil, err
 	}
+
+	id := request.GetConnection().GetId()
+
 	rv, err := next.Client(ctx).Request(ctx, request, opts...)
 	if err != nil {
 		return nil, err
 	}
-	rv.GetPath().Index = index
 	rv.Id = id
+
 	return rv, err
 }
 

--- a/pkg/networkservice/common/updatetoken/client_test.go
+++ b/pkg/networkservice/common/updatetoken/client_test.go
@@ -135,26 +135,11 @@ func (f *updatePathClientSuite) TestNewClient_ValidIndexOverwriteValues() {
 			},
 		},
 	}
-	expected := &networkservice.Connection{
-		Id: "conn-1",
-		Path: &networkservice.Path{
-			Index: 1,
-			PathSegments: []*networkservice.PathSegment{
-				{
-					Name: "nsc-0",
-					Id:   "conn-0",
-				}, {
-					Name:    "nsc-1",
-					Id:      "conn-1",
-					Token:   f.Token,
-					Expires: f.ExpiresProto,
-				}, {
-					Name: "nsc-2",
-					Id:   "conn-2",
-				},
-			},
-		},
-	}
+
+	expected := request.Connection.Clone()
+	expected.Path.PathSegments[1].Token = f.Token
+	expected.Path.PathSegments[1].Expires = f.ExpiresProto
+
 	conn, err := client.Request(context.Background(), request)
 	assert.NoError(t, err)
 	equalJSON(t, expected, conn)

--- a/pkg/networkservice/common/updatetoken/server_test.go
+++ b/pkg/networkservice/common/updatetoken/server_test.go
@@ -105,6 +105,7 @@ func (f *updateTokenServerSuite) TestNewServer_IndexInLastPositionAddNewSegment(
 func (f *updateTokenServerSuite) TestNewServer_ValidIndexOverwriteValues() {
 	t := f.T()
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
 			Id: "conn-2",
@@ -125,26 +126,11 @@ func (f *updateTokenServerSuite) TestNewServer_ValidIndexOverwriteValues() {
 			},
 		},
 	}
-	expected := &networkservice.Connection{
-		Id: "conn-2",
-		Path: &networkservice.Path{
-			Index: 2,
-			PathSegments: []*networkservice.PathSegment{
-				{
-					Name: "nsc-0",
-					Id:   "conn-0",
-				}, {
-					Name: "nsc-1",
-					Id:   "conn-1",
-				}, {
-					Name:    "nsc-2",
-					Id:      "conn-2",
-					Token:   f.Token,
-					Expires: f.ExpiresProto,
-				},
-			},
-		},
-	}
+
+	expected := request.Connection.Clone()
+	expected.Path.PathSegments[2].Token = f.Token
+	expected.Path.PathSegments[2].Expires = f.ExpiresProto
+
 	server := next.NewNetworkServiceServer(updatepath.NewServer("nsc-2"), updatetoken.NewServer(TokenGenerator))
 	conn, err := server.Request(context.Background(), request)
 	assert.NoError(t, err)


### PR DESCRIPTION
# Issue
Update path doesn't update path index back on return. If chain elements accesses `Path.Index` `after next.().Request` there is no guarantee that it is pointing to the current path segment.
# Solution
Set `conn.Path.Index = request.Connection.Path.Index` on return.