### PR TITLE
Set back nse@domain name on return from interdomainURLServer

### DIFF
--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -86,9 +86,7 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 	// Simulate refresh from client.
 
 	refreshRequest := request.Clone()
-	refreshRequest.GetConnection().Context = conn.Context
-	refreshRequest.GetConnection().Mechanism = conn.Mechanism
-	refreshRequest.GetConnection().NetworkServiceEndpointName = conn.NetworkServiceEndpointName
+	refreshRequest.Connection = conn.Clone()
 
 	conn, err = nsc.Request(ctx, refreshRequest)
 	require.NoError(t, err)


### PR DESCRIPTION
# Issue
interdomainURLServer updates `Request.Connection.NetworkServiceEndpointName` from `nse@domain.url` to `nse` and doesn't set it back to the returned `Connection`. If no one before in the chain saves full name, `@domain.url` will be lost and refresh request will be trying to find `nse` locally until timeout.
# Solution
Set `Connection.NetworkServiceEndpointName = interDomainNSEName` on return.