### PR TITLE
spanhelper: use global logrus hook and a custom formatter

### DIFF
--- a/pkg/networkservice/core/trace/context.go
+++ b/pkg/networkservice/core/trace/context.go
@@ -51,18 +51,7 @@ func withLog(parent context.Context, log logrus.FieldLogger) context.Context {
 func Log(ctx context.Context) logrus.FieldLogger {
 	rv, ok := ctx.Value(logKey).(logrus.FieldLogger)
 	if !ok {
-		logger := &logrus.Logger{
-			Out:          logrus.StandardLogger().Out,
-			Formatter:    logrus.StandardLogger().Formatter,
-			Hooks:        make(logrus.LevelHooks),
-			Level:        logrus.StandardLogger().Level,
-			ExitFunc:     logrus.StandardLogger().ExitFunc,
-			ReportCaller: logrus.StandardLogger().ReportCaller,
-		}
-		for k, v := range logrus.StandardLogger().Hooks {
-			logger.Hooks[k] = v
-		}
-		rv = logger
+		return logrus.StandardLogger()
 	}
 	return rv
 }


### PR DESCRIPTION
To avoid data-races with `logrus.SetLevel()` used in tests.
`GetLevel()` uses atomic read internally.