### PR TITLE
Rework clientmap.RefcountMap, add tests, add bench tests.

### DIFF
--- a/pkg/tools/clientmap/README.md
+++ b/pkg/tools/clientmap/README.md
@@ -17,7 +17,7 @@ if count becomes 0, value deletes.
 `clientmap.RefcountMap` is a very thin wrapper, it doesn't hardly affect the `clientmap.Map` performance:
 ```
 BenchmarkMap
-BenchmarkMap-4           	15998454	        84.6 ns/op
+BenchmarkMap-4           	20850049	        54.7 ns/op
 BenchmarkRefcountMap
-BenchmarkRefcountMap-4   	10496374	       106 ns/op
+BenchmarkRefcountMap-4   	14408266	        76.3 ns/op
 ```

--- a/pkg/tools/clientmap/README.md
+++ b/pkg/tools/clientmap/README.md
@@ -1,0 +1,23 @@
+# clientmap.Map
+
+It is a `sync.Map` typed for the `string` keys and `networkservice.NetworkServiceClient` values.
+
+# clientmap.RefcountMap
+
+It is a `clientmap.Map` wrapped with refcounting:
+```
+Store, LoadOrStore (store)  -->  count = 1
+Load, LoadOrStore (load)    -->  count += 1
+LoadAndDelete, Delete       -->  count -= 1
+```
+if count becomes 0, value deletes.
+
+## Performance
+
+`clientmap.RefcountMap` is a very thin wrapper, it doesn't hardly affect the `clientmap.Map` performance:
+```
+BenchmarkMap
+BenchmarkMap-4           	15998454	        84.6 ns/op
+BenchmarkRefcountMap
+BenchmarkRefcountMap-4   	10496374	       106 ns/op
+```

--- a/pkg/tools/clientmap/bench_test.go
+++ b/pkg/tools/clientmap/bench_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clientmap_test
+
+import (
+	"testing"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
+	"github.com/networkservicemesh/sdk/pkg/tools/clientmap"
+)
+
+var ids = []string{
+	"00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+	"10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+	"20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+	"30", "31", "32", "33", "34", "35", "36", "37", "38", "39",
+	"40", "41", "42", "43", "44", "45", "46", "47", "48", "49",
+	"50", "51", "52", "53", "54", "55", "56", "57", "58", "59",
+	"60", "61", "62", "63", "64", "65", "66", "67", "68", "69",
+	"70", "71", "72", "73", "74", "75", "76", "77", "78", "79",
+	"80", "81", "82", "83", "84", "85", "86", "87", "88", "89",
+	"90", "91", "92", "93", "94", "95", "96", "97", "98", "99", "100",
+}
+
+func BenchmarkMap(b *testing.B) {
+	var m clientmap.Map
+	b.SetParallelism(1000)
+	b.RunParallel(func(pb *testing.PB) {
+		client := null.NewClient()
+		for i := 0; pb.Next(); i++ {
+			id := ids[i%len(ids)]
+			switch i % 6 {
+			case 0:
+				m.Store(id, client)
+			case 1:
+				client, _ = m.LoadOrStore(id, client)
+			case 2:
+				client, _ = m.Load(id)
+			case 3, 4, 5:
+				client, _ = m.LoadAndDelete(id)
+			}
+		}
+	})
+}
+
+func BenchmarkRefcountMap(b *testing.B) {
+	var m clientmap.RefcountMap
+	b.SetParallelism(1000)
+	b.RunParallel(func(pb *testing.PB) {
+		client := null.NewClient()
+		for i := 0; pb.Next(); i++ {
+			id := ids[i%len(ids)]
+			switch i % 8 {
+			case 0:
+				m.Store(id, client)
+			case 1:
+				client, _ = m.LoadOrStore(id, client)
+			case 2:
+				client, _ = m.Load(id)
+			case 3:
+				client, _ = m.LoadUnsafe(id)
+			case 4, 5, 6, 7:
+				client, _ = m.LoadAndDelete(id)
+			}
+		}
+	})
+}

--- a/pkg/tools/clientmap/bench_test.go
+++ b/pkg/tools/clientmap/bench_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	parallelCount = 23
+	parallelCount = 20
 )
 
 var ids = []string{
@@ -33,20 +33,23 @@ var ids = []string{
 
 func BenchmarkMap(b *testing.B) {
 	var m clientmap.Map
+	client := null.NewClient()
 	b.SetParallelism(parallelCount)
+
+	b.ResetTimer()
+
 	b.RunParallel(func(pb *testing.PB) {
-		client := null.NewClient()
 		for i := 0; pb.Next(); i++ {
 			id := ids[i%len(ids)]
 			switch i % 6 {
 			case 0:
 				m.Store(id, client)
 			case 1:
-				client, _ = m.LoadOrStore(id, client)
+				_, _ = m.LoadOrStore(id, client)
 			case 2:
-				client, _ = m.Load(id)
+				_, _ = m.Load(id)
 			case 3, 4, 5:
-				client, _ = m.LoadAndDelete(id)
+				_, _ = m.LoadAndDelete(id)
 			}
 		}
 	})
@@ -54,20 +57,23 @@ func BenchmarkMap(b *testing.B) {
 
 func BenchmarkRefcountMap(b *testing.B) {
 	var m clientmap.RefcountMap
+	client := null.NewClient()
 	b.SetParallelism(parallelCount)
+
+	b.ResetTimer()
+
 	b.RunParallel(func(pb *testing.PB) {
-		client := null.NewClient()
 		for i := 0; pb.Next(); i++ {
 			id := ids[i%len(ids)]
 			switch i % 6 {
 			case 0:
 				m.Store(id, client)
 			case 1:
-				client, _ = m.LoadOrStore(id, client)
+				_, _ = m.LoadOrStore(id, client)
 			case 2:
-				client, _ = m.Load(id)
+				_, _ = m.Load(id)
 			case 3, 4, 5:
-				client, _, _ = m.LoadAndDelete(id)
+				_, _, _ = m.LoadAndDelete(id)
 			}
 		}
 	})

--- a/pkg/tools/clientmap/bench_test.go
+++ b/pkg/tools/clientmap/bench_test.go
@@ -23,22 +23,17 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/clientmap"
 )
 
+const (
+	parallelCount = 23
+)
+
 var ids = []string{
-	"00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
-	"10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
-	"20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
-	"30", "31", "32", "33", "34", "35", "36", "37", "38", "39",
-	"40", "41", "42", "43", "44", "45", "46", "47", "48", "49",
-	"50", "51", "52", "53", "54", "55", "56", "57", "58", "59",
-	"60", "61", "62", "63", "64", "65", "66", "67", "68", "69",
-	"70", "71", "72", "73", "74", "75", "76", "77", "78", "79",
-	"80", "81", "82", "83", "84", "85", "86", "87", "88", "89",
-	"90", "91", "92", "93", "94", "95", "96", "97", "98", "99", "100",
+	"00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10",
 }
 
 func BenchmarkMap(b *testing.B) {
 	var m clientmap.Map
-	b.SetParallelism(1000)
+	b.SetParallelism(parallelCount)
 	b.RunParallel(func(pb *testing.PB) {
 		client := null.NewClient()
 		for i := 0; pb.Next(); i++ {
@@ -59,7 +54,7 @@ func BenchmarkMap(b *testing.B) {
 
 func BenchmarkRefcountMap(b *testing.B) {
 	var m clientmap.RefcountMap
-	b.SetParallelism(1000)
+	b.SetParallelism(parallelCount)
 	b.RunParallel(func(pb *testing.PB) {
 		client := null.NewClient()
 		for i := 0; pb.Next(); i++ {

--- a/pkg/tools/clientmap/bench_test.go
+++ b/pkg/tools/clientmap/bench_test.go
@@ -64,17 +64,15 @@ func BenchmarkRefcountMap(b *testing.B) {
 		client := null.NewClient()
 		for i := 0; pb.Next(); i++ {
 			id := ids[i%len(ids)]
-			switch i % 8 {
+			switch i % 6 {
 			case 0:
 				m.Store(id, client)
 			case 1:
 				client, _ = m.LoadOrStore(id, client)
 			case 2:
 				client, _ = m.Load(id)
-			case 3:
-				client, _ = m.LoadUnsafe(id)
-			case 4, 5, 6, 7:
-				client, _ = m.LoadAndDelete(id)
+			case 3, 4, 5:
+				client, _, _ = m.LoadAndDelete(id)
 			}
 		}
 	})

--- a/pkg/tools/clientmap/refcount.go
+++ b/pkg/tools/clientmap/refcount.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/tools/clientmap/refcount.go
+++ b/pkg/tools/clientmap/refcount.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -17,73 +17,121 @@
 package clientmap
 
 import (
-	"context"
-	"sync/atomic"
+	"sync"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"google.golang.org/grpc"
 )
 
-type refcountClient struct {
-	count  int32
-	client networkservice.NetworkServiceClient
+type entry struct {
+	count int
+	lock  sync.Mutex
+	value networkservice.NetworkServiceClient
 }
 
-func (r *refcountClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
-	return r.client.Request(ctx, request)
-}
-
-func (r *refcountClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	return r.client.Close(ctx, conn)
-}
-
-// RefcountMap - clientmap.Map wrapped with refcounting.  Each Store,Load,LoadOrStore increments the count,
-//               each Delete decrements the count.  When the count is zero, Delete deletes.
+// RefcountMap is a sync.Map wrapped with refcounting. Each Store, Load, LoadOrStore increments the count, each
+// LoadAndDelete, Delete decrements the count. When the count == 1, LoadAndDelete, Delete deletes.
 type RefcountMap struct {
-	Map
+	m sync.Map
 }
 
-// Store sets the value for a key.
-// Increments the refcount
-func (r *RefcountMap) Store(key string, value networkservice.NetworkServiceClient) {
-	client := &refcountClient{client: value}
-	r.Map.Store(key, client)
-	atomic.AddInt32(&client.count, 1)
+// Store sets the value for a key
+// count = 1.
+func (m *RefcountMap) Store(key string, value networkservice.NetworkServiceClient) {
+	m.m.Store(key, &entry{
+		count: 1,
+		value: value,
+	})
 }
 
-// LoadOrStore returns the existing value for the key if present. Otherwise, it stores and returns the given value. The loaded result is true if the value was loaded, false if stored.
-// Increments the refcount.
-func (r *RefcountMap) LoadOrStore(key string, value networkservice.NetworkServiceClient) (networkservice.NetworkServiceClient, bool) {
-	client := &refcountClient{client: value}
-	rv, loaded := r.Map.LoadOrStore(key, client)
-	if client, ok := rv.(*refcountClient); ok {
-		atomic.AddInt32(&client.count, 1)
-		return client.client, loaded
-	}
-	return rv, loaded
-}
-
-// Load returns the value stored in the map for a key, or nil if no value is present. The ok result indicates whether value was found in the map.
-// Increments refcount.
-func (r *RefcountMap) Load(key string) (networkservice.NetworkServiceClient, bool) {
-	rv, loaded := r.Map.Load(key)
-	if client, ok := rv.(*refcountClient); ok {
-		atomic.AddInt32(&client.count, 1)
-		return client.client, loaded
-	}
-	return rv, loaded
-}
-
-// Delete decrements the refcount and deletes the value for a key if refcount is zero. Returns true if value is no (more) present.
-func (r *RefcountMap) Delete(key string) bool {
-	rv, loaded := r.Map.Load(key)
+// LoadOrStore returns the existing value for the key if present. Otherwise, it stores and returns the given value. The
+// loaded result is true if the value was loaded, false if stored.
+// store  -->  count = 1
+// load   -->  count += 1
+func (m *RefcountMap) LoadOrStore(key string, value networkservice.NetworkServiceClient) (networkservice.NetworkServiceClient, bool) {
+	raw, loaded := m.m.LoadOrStore(key, &entry{
+		count: 1,
+		value: value,
+	})
+	entry := raw.(*entry)
 	if !loaded {
-		return true
+		return entry.value, false
 	}
-	if client, ok := rv.(*refcountClient); ok && atomic.AddInt32(&client.count, -1) == 0 {
-		r.Map.Delete(key)
-		return true
+
+	entry.lock.Lock()
+
+	if entry.count == 0 {
+		entry.lock.Unlock()
+		return m.LoadOrStore(key, value)
 	}
-	return false
+	entry.count++
+
+	entry.lock.Unlock()
+
+	return entry.value, true
+}
+
+// Load returns the value stored in the map for a key, or nil if no value is present. The loaded result indicates
+// whether value was found in the map.
+// count += 1
+func (m *RefcountMap) Load(key string) (networkservice.NetworkServiceClient, bool) {
+	raw, loaded := m.m.Load(key)
+	if !loaded {
+		return nil, false
+	}
+	entry := raw.(*entry)
+
+	entry.lock.Lock()
+	defer entry.lock.Unlock()
+
+	if entry.count == 0 {
+		return nil, false
+	}
+	entry.count++
+
+	return entry.value, true
+}
+
+// LoadUnsafe returns the value stored in the map for a key, or nil if no value is present. The loaded result indicates
+// whether value was found in the map.
+func (m *RefcountMap) LoadUnsafe(key string) (networkservice.NetworkServiceClient, bool) {
+	raw, loaded := m.m.Load(key)
+	if !loaded {
+		return nil, false
+	}
+	entry := raw.(*entry)
+
+	return entry.value, loaded
+}
+
+// LoadAndDelete is trying to delete the value for a key, returning the previous value if any. The loaded result
+// reports whether the key was present.
+// count == 1  -->  delete
+// count > 1   -->  count -= 1
+func (m *RefcountMap) LoadAndDelete(key string) (networkservice.NetworkServiceClient, bool) {
+	raw, loaded := m.m.Load(key)
+	if !loaded {
+		return nil, false
+	}
+	entry := raw.(*entry)
+
+	entry.lock.Lock()
+	defer entry.lock.Unlock()
+
+	if entry.count == 0 {
+		return nil, false
+	}
+	entry.count--
+
+	if entry.count == 0 {
+		m.m.Delete(key)
+	}
+
+	return entry.value, true
+}
+
+// Delete is trying to delete the value for a key.
+// count == 1  -->  delete
+// count > 1   -->  count -= 1
+func (m *RefcountMap) Delete(key string) {
+	m.LoadAndDelete(key)
 }

--- a/pkg/tools/clientmap/refcount_test.go
+++ b/pkg/tools/clientmap/refcount_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2020 Doc.ai and/or its affiliates.
+//
 // Copyright (c) 2020 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/pkg/tools/clientmap/refcount_test.go
+++ b/pkg/tools/clientmap/refcount_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	parallelCount = 1000
+	retriesCount = 1000
 )
 
 func TestRefcountMap(t *testing.T) {
@@ -204,7 +204,7 @@ func TestRefcountMap_Actions(t *testing.T) {
 func runSample(t *testing.T, m *clientmap.RefcountMap, sample *sample) {
 	t.Run(sample.name, func(t *testing.T) {
 		value := null.NewClient()
-		for i := 0; i < parallelCount; i++ {
+		for i := 0; i < retriesCount; i++ {
 			key := strconv.Itoa(i)
 			if sample.withValue {
 				m.Store(key, value)

--- a/pkg/tools/clientmap/refcount_test.go
+++ b/pkg/tools/clientmap/refcount_test.go
@@ -17,12 +17,19 @@
 package clientmap_test
 
 import (
+	"strconv"
+	"sync"
 	"testing"
 
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
 	"github.com/networkservicemesh/sdk/pkg/tools/clientmap"
+)
+
+const (
+	parallelCount = 1000
 )
 
 func TestRefcountMap(t *testing.T) {
@@ -79,4 +86,161 @@ func CheckRefcount(t *testing.T, m *clientmap.RefcountMap, key string, refcount 
 		client, loaded = m.LoadOrStore(key, client)
 		assert.True(t, loaded || i == 0)
 	}
+}
+
+type sample struct {
+	name      string
+	withValue bool
+	actions   []action
+	validator func(count int, results []bool) bool
+}
+
+var samples = []*sample{
+	{
+		name: "LoadOrStore + LoadOrStore",
+		// 0 1 -> 2 { false, true }
+		// 1 0 -> 2 { true, false }
+		actions: []action{loadOrStore, loadOrStore},
+		validator: func(count int, results []bool) bool {
+			return (count == 2) && !results[0] && results[1] ||
+				(count == 2) && results[0] && !results[1]
+		},
+	},
+	{
+		name: "LoadOrStore + LoadAndDelete",
+		// 0 1 -> 0 { false, true }
+		// 1 0 -> 1 { false, false }
+		actions: []action{loadOrStore, loadAndDelete},
+		validator: func(count int, results []bool) bool {
+			return (count == 0) && !results[0] && results[1] ||
+				(count == 1) && !results[0] && !results[1]
+		},
+	},
+	{
+		name:      "LoadOrStore + LoadAndDelete with value",
+		withValue: true,
+		// 0 1 -> 1 { true, true }
+		// 1 0 -> 1 { false, true }
+		actions: []action{loadOrStore, loadAndDelete},
+		validator: func(count int, results []bool) bool {
+			return (count == 1) && results[0] && results[1] ||
+				(count == 1) && !results[0] && results[1]
+		},
+	},
+	{
+		name:      "LoadAndDelete + LoadAndDelete with value",
+		withValue: true,
+		// 0 1 -> 0 { true, false }
+		// 1 0 -> 0 { false, true }
+		actions: []action{loadAndDelete, loadAndDelete},
+		validator: func(count int, results []bool) bool {
+			return (count == 0) && results[0] && !results[1] ||
+				(count == 0) && !results[0] && results[1]
+		},
+	},
+	{
+		name:      "LoadAndDelete + Load with value",
+		withValue: true,
+		// 0 1 -> 0 { true, false }
+		// 1 0 -> 1 { true, true }
+		actions: []action{loadAndDelete, load},
+		validator: func(count int, results []bool) bool {
+			return (count == 0) && results[0] && !results[1] ||
+				(count == 1) && results[0] && results[1]
+		},
+	},
+	{
+		name:      "LoadAndDelete + LoadAndDelete + Load with value",
+		withValue: true,
+		// 0 1 2 -> 0 { true, false, false }
+		// 0 2 1 -> 0 { true, false, false } (same as ^)
+		// 1 0 2 -> 0 { false, true, false }
+		// 1 2 0 -> 0 { true, true, true }
+		// 2 0 1 -> 0 { false, true, false } (same as ^^)
+		// 2 1 0 -> 0 { true, true, true } (same as ^^)
+		actions: []action{loadAndDelete, loadAndDelete, load},
+		validator: func(count int, results []bool) bool {
+			return (count == 0) && results[0] && !results[1] && !results[2] ||
+				(count == 0) && !results[0] && results[1] && !results[2] ||
+				(count == 0) && results[0] && results[1] && results[2]
+		},
+	},
+	{
+		name:      "LoadOrStore + LoadOrStore + LoadAndDelete with value",
+		withValue: true,
+		// 0 1 2 -> 2 { true, true, true }
+		// 0 2 1 -> 2 { true, true, true } (same as ^)
+		// 1 0 2 -> 2 { true, true, true } (same as ^)
+		// 1 2 0 -> 2 { false, true, true }
+		// 2 0 1 -> 2 { true, true, true } (same as ^^)
+		// 2 1 0 -> 2 { true, false, true }
+		actions: []action{loadOrStore, loadOrStore, loadAndDelete},
+		validator: func(count int, results []bool) bool {
+			return (count == 2) && results[0] && results[1] && results[2] ||
+				(count == 2) && !results[0] && results[1] && results[2] ||
+				(count == 2) && results[0] && !results[1] && results[2]
+		},
+	},
+}
+
+func TestRefcountMap_Actions(t *testing.T) {
+	for _, sample := range samples {
+		runSample(t, new(clientmap.RefcountMap), sample)
+	}
+}
+
+func runSample(t *testing.T, m *clientmap.RefcountMap, sample *sample) {
+	t.Run(sample.name, func(t *testing.T) {
+		value := null.NewClient()
+		for i := 0; i < parallelCount; i++ {
+			key := strconv.Itoa(i)
+			if sample.withValue {
+				m.Store(key, value)
+			}
+
+			results := runActions(m, key, value, sample.actions...)
+
+			var count int
+			for _, loaded := m.LoadAndDelete(key); loaded; _, loaded = m.LoadAndDelete(key) {
+				count++
+			}
+
+			assert.True(t, sample.validator(count, results),
+				"count = %v, results = %v", count, results)
+		}
+	})
+}
+
+type action func(*clientmap.RefcountMap, string, networkservice.NetworkServiceClient) bool
+
+func loadOrStore(m *clientmap.RefcountMap, key string, value networkservice.NetworkServiceClient) bool {
+	_, ok := m.LoadOrStore(key, value)
+	return ok
+}
+
+func load(m *clientmap.RefcountMap, key string, _ networkservice.NetworkServiceClient) bool {
+	_, ok := m.Load(key)
+	return ok
+}
+
+func loadAndDelete(m *clientmap.RefcountMap, key string, _ networkservice.NetworkServiceClient) bool {
+	_, ok := m.LoadAndDelete(key)
+	return ok
+}
+
+func runActions(m *clientmap.RefcountMap, key string, value networkservice.NetworkServiceClient, actions ...action) []bool {
+	wg := new(sync.WaitGroup)
+	wg.Add(len(actions))
+
+	results := make([]bool, len(actions))
+	for i := range actions {
+		go func(k int) {
+			results[k] = actions[k](m, key, value)
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+
+	return results
 }


### PR DESCRIPTION
# Issue
Existing refcount map is incorrect, such test can fail:
```go
var m clientmap.RefcountMap
m.Store("a", null.NewClient())

var loaded bool
go func() {
    _, loaded = m.Load("a") // count += 1 (if exists)
}()
go m.Delete("a") // count -= 1 (delete if 0)

_, exists := m.Load("a")
require.Equal(t, loaded, exists) // if loaded, Delete can't delete, only should decrement the count
```
# Solution
Rework refcount map with per-entry locks, add action tests, add bench tests.