### PR TITLE
Rework client factory using Generator

### DIFF
--- a/pkg/networkservice/chains/client/README.md
+++ b/pkg/networkservice/chains/client/README.md
@@ -2,6 +2,7 @@
 
 There are some common chain elements that we expect to have in every client chain to make NSM working. Instead of that,
 there are few different scenarios when we need to create a client chain to initiate NSM request:
+
 1. Client to NSMgr - simple case when there is an application requesting some L2/L3 connection from the NSMgr.
     * no incoming L2/L3 request - client itself is a request generator
     * complete chain
@@ -12,10 +13,11 @@ there are few different scenarios when we need to create a client chain to initi
        |                      |
     ```
 2. Server to endpoint client - we already have application running as a NSM endpoint receiving request to L2/L3
-connection, but it also needs to request some other L2/L3 connection from some other endpoint.
+   connection, but it also needs to request some other L2/L3 connection from some other endpoint.
     * there is an incoming L2/L3 request - we need to generate an outgoing L2/L3 request, but the connection we return
       is an incoming connection
     * part of some server chain - we need to add `clientConnection` and request next elements
+    * different endpoints mean different connections, even if we have same `Connection.Id` for them
     ```
     ...                 Endpoint  --Request-->  Endpoint
      |                      |                      |
@@ -23,9 +25,10 @@ connection, but it also needs to request some other L2/L3 connection from some o
      |                      |                      |
     ```
 3. Proxy to endpoint client - we already have application running as a NSM server, but it doesn't provide L2/L3
-connection, it simply passes the request to some other endpoint.
+   connection, it simply passes the request to some other endpoint.
     * there is an incoming L2/L3 request but we simply forward it
     * part of some server chain - we need to add `clientConnection` and request next elements
+    * different endpoints mean different connections, even if we have same `Connection.Id` for them
     ```
     ...                   Proxy   --Request-->  Endpoint
      |                      |                      |
@@ -40,12 +43,9 @@ connection, it simply passes the request to some other endpoint.
 It is a solution for the (1.) case. Client appends `additionalFunctionality` to the default client chain and passes
 incoming request to the NSMgr over the `grpcCC`.
 
-## client.NewCrossConnectClientFactory(..., ...additionalFunctionality)
+## client.NewClientFactory(..., ...additionalFunctionalityGenerators)
 
-It is a solution for the (2.) case. We create a new GRPC client on each new client URL received from the incoming request.
-It can be used in `connect.NewServer` so `clientConnection` will be processed correctly.
-
-## client.NewClientFactory(..., ...additionalFunctionality)
-
-It is a solution for the (3.) case. We create a new GRPC client on each new client URL received, but process like (1.).
-It can be used in `connect.NewServer` so `clientConnection` will be processed correctly.
+It is a solution for the (2.), (3.) cases. We create a new GRPC client on each new client URL received from the incoming
+request. It can be used in `connect.NewServer` so `clientConnection` will be processed correctly. If we need to
+implement mechanism translation as for (3.), we can add some mechanism translation client generator as a part of
+`additionalFunctionalityGenerators`.

--- a/pkg/networkservice/chains/client/README.md
+++ b/pkg/networkservice/chains/client/README.md
@@ -47,5 +47,5 @@ incoming request to the NSMgr over the `grpcCC`.
 
 It is a solution for the (2.), (3.) cases. We create a new GRPC client on each new client URL received from the incoming
 request. It can be used in `connect.NewServer` so `clientConnection` will be processed correctly. If we need to
-implement mechanism translation as for (3.), we can add some mechanism translation client generator as a part of
-`additionalFunctionalityGenerators`.
+implement mechanism translation as for (3.), we can add some mechanism translation client supplier as a part of
+`additionalFunctionalitySuppliers`.

--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -80,34 +80,34 @@ func NewClient(
 	return rv
 }
 
-// Generator is a type for networkservice.NetworkServiceClient generator function
-type Generator func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient
+// Supplier is a type for networkservice.NetworkServiceClient supplier function
+type Supplier func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient
 
 // NewClientFactory - returns a (2.), (3.) cases func(cc grpc.ClientConnInterface) NSM client factory.
 func NewClientFactory(
 	name string,
 	onHeal *networkservice.NetworkServiceClient,
 	tokenGenerator token.GeneratorFunc,
-	additionalFunctionalityGenerators ...Generator,
+	additionalFunctionalitySuppliers ...Supplier,
 ) func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 	return func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 		var additionalFunctionality []networkservice.NetworkServiceClient
-		for _, additionalFunctionalityFactory := range additionalFunctionalityGenerators {
+		for _, additionalFunctionalityFactory := range additionalFunctionalitySuppliers {
 			additionalFunctionality = append(additionalFunctionality, additionalFunctionalityFactory(ctx, cc))
 		}
 		return NewClient(ctx, name, onHeal, tokenGenerator, cc, additionalFunctionality...)
 	}
 }
 
-// FromClient is a common networkservice.NetworkServiceClient wrapper to Generator
-func FromClient(client networkservice.NetworkServiceClient) Generator {
+// FromClient is a common networkservice.NetworkServiceClient wrapper to Supplier
+func FromClient(client networkservice.NetworkServiceClient) Supplier {
 	return func(_ context.Context, _ grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 		return client
 	}
 }
 
-// FromConstructor is a common networkservice.NetworkServiceClient constructor wrapper to Generator
-func FromConstructor(constructor func() networkservice.NetworkServiceClient) Generator {
+// FromConstructor is a common networkservice.NetworkServiceClient constructor wrapper to Supplier
+func FromConstructor(constructor func() networkservice.NetworkServiceClient) Supplier {
 	return func(_ context.Context, _ grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 		return constructor()
 	}

--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco Systems, Inc.
+// Copyright (c) 2020-2021 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -92,17 +92,10 @@ func NewClientFactory(
 ) func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 	return func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 		var additionalFunctionality []networkservice.NetworkServiceClient
-		for _, additionalFunctionalityFactory := range additionalFunctionalitySuppliers {
-			additionalFunctionality = append(additionalFunctionality, additionalFunctionalityFactory(ctx, cc))
+		for _, supplier := range additionalFunctionalitySuppliers {
+			additionalFunctionality = append(additionalFunctionality, supplier(ctx, cc))
 		}
 		return NewClient(ctx, name, onHeal, tokenGenerator, cc, additionalFunctionality...)
-	}
-}
-
-// FromClient is a common networkservice.NetworkServiceClient wrapper to Supplier
-func FromClient(client networkservice.NetworkServiceClient) Supplier {
-	return func(_ context.Context, _ grpc.ClientConnInterface) networkservice.NetworkServiceClient {
-		return client
 	}
 }
 

--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -121,7 +121,7 @@ func NewServer(ctx context.Context, nsmRegistration *registryapi.NetworkServiceE
 				nsmRegistration.Name,
 				addressof.NetworkServiceClient(adapters.NewServerToClient(rv)),
 				tokenGenerator,
-				newSendFDClient(), // Send passed files.
+				client.FromClient(newSendFDClient()), // Send passed files.
 			),
 			clientDialOptions...),
 	)

--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2021 Cisco and/or its affiliates.
 //
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -121,7 +121,7 @@ func NewServer(ctx context.Context, nsmRegistration *registryapi.NetworkServiceE
 				nsmRegistration.Name,
 				addressof.NetworkServiceClient(adapters.NewServerToClient(rv)),
 				tokenGenerator,
-				client.FromClient(newSendFDClient()), // Send passed files.
+				client.FromConstructor(newSendFDClient), // Send passed files.
 			),
 			clientDialOptions...),
 	)

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -364,7 +364,7 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 					connect.NewServer(ctx,
 						sandbox.NewClientFactory(sandbox.GenerateTestToken,
 							client.FromConstructor(mechanismtranslation.NewClient),
-							newPassTroughClientGenerator(
+							newPassTroughClientSupplier(
 								fmt.Sprintf("my-service-remote-%v", k-1),
 								fmt.Sprintf("endpoint-%v", k-1)),
 							client.FromClient(kernel.NewClient())),
@@ -427,7 +427,7 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 					connect.NewServer(ctx,
 						sandbox.NewClientFactory(sandbox.GenerateTestToken,
 							client.FromConstructor(mechanismtranslation.NewClient),
-							newPassTroughClientGenerator(
+							newPassTroughClientSupplier(
 								fmt.Sprintf("my-service-remote-%v", k-1),
 								fmt.Sprintf("endpoint-%v", k-1)),
 							client.FromClient(kernel.NewClient())),
@@ -471,7 +471,7 @@ type passThroughClient struct {
 	networkServiceEndpointName string
 }
 
-func newPassTroughClientGenerator(networkService, networkServiceEndpointName string) client.Generator {
+func newPassTroughClientSupplier(networkService, networkServiceEndpointName string) client.Supplier {
 	return func(_ context.Context, _ grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 		return &passThroughClient{
 			networkService:             networkService,

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -367,7 +367,9 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 							newPassTroughClientSupplier(
 								fmt.Sprintf("my-service-remote-%v", k-1),
 								fmt.Sprintf("endpoint-%v", k-1)),
-							client.FromClient(kernel.NewClient())),
+							client.FromConstructor(func() networkservice.NetworkServiceClient {
+								return kernel.NewClient()
+							})),
 						append(spanhelper.WithTracingDial(), grpc.WithBlock(), grpc.WithInsecure())...,
 					),
 				),
@@ -430,7 +432,9 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 							newPassTroughClientSupplier(
 								fmt.Sprintf("my-service-remote-%v", k-1),
 								fmt.Sprintf("endpoint-%v", k-1)),
-							client.FromClient(kernel.NewClient())),
+							client.FromConstructor(func() networkservice.NetworkServiceClient {
+								return kernel.NewClient()
+							})),
 						append(spanhelper.WithTracingDial(), grpc.WithBlock(), grpc.WithInsecure())...,
 					),
 				),

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -36,6 +36,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanismtranslation"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/memory"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/proxydns"
@@ -312,11 +313,12 @@ func supplyDummyForwarder(ctx context.Context, name string, generateToken token.
 		// Statically set the url we use to the unix file socket for the NSMgr
 		clienturl.NewServer(connectTo),
 		connect.NewServer(ctx,
-			client.NewCrossConnectClientFactory(
+			client.NewClientFactory(
 				name,
 				// What to call onHeal
 				addressof.NetworkServiceClient(adapters.NewServerToClient(result)),
-				generateToken),
+				generateToken,
+				client.FromConstructor(mechanismtranslation.NewClient)),
 			dialOptions...,
 		),
 	)

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -88,9 +88,9 @@ func NewClient(
 	connectTo *url.URL,
 	additionalFunctionality ...networkservice.NetworkServiceClient,
 ) networkservice.NetworkServiceClient {
-	var generators []client.Generator
+	var suppliers []client.Supplier
 	for _, c := range additionalFunctionality {
-		generators = append(generators, client.FromClient(c))
+		suppliers = append(suppliers, client.FromClient(c))
 	}
 	return clienturl.NewClient(
 		clienturlctx.WithClientURL(ctx, connectTo),
@@ -98,18 +98,18 @@ func NewClient(
 			fmt.Sprintf("nsc-%v", uuid.New().String()),
 			nil,
 			generatorFunc,
-			generators...),
+			suppliers...),
 		append(spanhelper.WithTracingDial(), grpc.WithBlock(), grpc.WithInsecure())...)
 }
 
 // NewClientFactory is a client.NewCrossConnectClientFactory with some fields preset for testing
 func NewClientFactory(
 	generatorFunc token.GeneratorFunc,
-	additionalFunctionalityGenerators ...client.Generator,
+	additionalFunctionalitySuppliers ...client.Supplier,
 ) func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 	return client.NewClientFactory(
 		fmt.Sprintf("nsc-%v", uuid.New().String()),
 		nil,
 		generatorFunc,
-		additionalFunctionalityGenerators...)
+		additionalFunctionalitySuppliers...)
 }

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -89,8 +89,11 @@ func NewClient(
 	additionalFunctionality ...networkservice.NetworkServiceClient,
 ) networkservice.NetworkServiceClient {
 	var suppliers []client.Supplier
-	for _, c := range additionalFunctionality {
-		suppliers = append(suppliers, client.FromClient(c))
+	for i := range additionalFunctionality {
+		c := additionalFunctionality[i]
+		suppliers = append(suppliers, client.FromConstructor(func() networkservice.NetworkServiceClient {
+			return c
+		}))
 	}
 	return clienturl.NewClient(
 		clienturlctx.WithClientURL(ctx, connectTo),


### PR DESCRIPTION
# Issue
`client.NewClientFactory` receives a list of `networkservice.NetworkServiceClient` that should be added to the new client chain and this `additionalFunctionality` list is the same chain element instances for all generated clients. If `clientURL` changes we create a new client, but we presume the old `Connection.Id`, so reusing chain elements from the old client can provide some tricky bugs.
# Solution
Instead of passing list of `networkservice.NetworkServiceClient` we can pass list of type:
```go
// Generator is a type for networkservice.NetworkServiceClient generator function
type Generator func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient
```
so on every new client creation by the factory we will create new chain elements for that client. To make usage of such 
`Generator` easier we can add some common wrappers:
```go
// FromClient is a common networkservice.NetworkServiceClient wrapper to Generator
func FromClient(client networkservice.NetworkServiceClient) Generator {
	return func(_ context.Context, _ grpc.ClientConnInterface) networkservice.NetworkServiceClient {
		return client
	}
}

// FromConstructor is a common networkservice.NetworkServiceClient constructor wrapper to Generator
func FromConstructor(constructor func() networkservice.NetworkServiceClient) Generator {
	return func(_ context.Context, _ grpc.ClientConnInterface) networkservice.NetworkServiceClient {
		return constructor()
	}
}
```
If we create a new client that is supposed to be used as a part of connect client chain and it doesn't match common wrappers it should define its own `NewClientGenerator` method in addition to (or replacing) `NewClient`.
```go
func NewClientGenerator(t ...params) client.Generator {
	return func(_ context.Context, _ grpc.ClientConnInterface) networkservice.NetworkServiceClient {
		// ...
	}
}
```
# No more need for NewCrossConnectClientFactory
`client.NewCrossConnectClientFactory` can now be replaced with:
```go
client.NewClientFactory(
	name,
	onHeal,
	tokenGenerator,
	client.FromConstructor(mechanismtranslation.NewClient), // <-- now can be used in such way
	// additionalFunctionalityGenerators...
),
```