### PR TITLE
Stabilize heal tests

### DIFF
--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Cisco Systems, Inc.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,7 +78,7 @@ func (f *healClient) Request(ctx context.Context, request *networkservice.Networ
 	if err != nil {
 		return nil, err
 	}
-	err = f.startHeal(ctx, request.Clone().SetRequestConnection(conn.Clone()), opts...)
+	err = f.startHeal(request.Clone().SetRequestConnection(conn.Clone()), opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +103,7 @@ func (f *healClient) stopHeal(conn *networkservice.Connection) {
 }
 
 // startHeal - start a healAsNeeded using the request as the request for re-request if healing is needed.
-func (f *healClient) startHeal(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) error {
+func (f *healClient) startHeal(request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) error {
 	errCh := make(chan error, 1)
 	go f.healAsNeeded(request, errCh, opts...)
 	return <-errCh

--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -141,7 +141,8 @@ func (f *healClient) healAsNeeded(request *networkservice.NetworkServiceRequest,
 		}
 	})
 
-	// Monitor the pathSegment
+	// Monitor the pathSegment for the first time, so we can pass back an error
+	// if we can't confirm via monitor the other side has the expected state
 	recv, err := f.initialMonitorSegment(ctx, pathSegment)
 	if err != nil {
 		errCh <- errors.Wrapf(err, "error calling MonitorConnection_MonitorConnectionsClient.Recv to get initial confirmation server has connection: %+v", request.GetConnection())

--- a/pkg/networkservice/common/heal/client_test.go
+++ b/pkg/networkservice/common/heal/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/heal"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/monitor"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"

--- a/pkg/networkservice/common/heal/client_test.go
+++ b/pkg/networkservice/common/heal/client_test.go
@@ -60,7 +60,6 @@ func (t *testOnHeal) Close(ctx context.Context, in *networkservice.Connection, o
 }
 
 func TestHealClient_Request(t *testing.T) {
-	t.Skip("https://github.com/networkservicemesh/sdk/issues/375")
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	logrus.SetOutput(ioutil.Discard)
 	eventCh := make(chan *networkservice.ConnectionEvent, 1)

--- a/pkg/networkservice/common/heal/constants_test.go
+++ b/pkg/networkservice/common/heal/constants_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Cisco and/or its affiliates.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,5 +27,4 @@ import (
 const (
 	waitForTimeout  = 100 * time.Millisecond
 	waitHealTimeout = 1000 * time.Millisecond
-	tickTimeout     = 20 * time.Millisecond
 )


### PR DESCRIPTION
Fixes #375

`TestHealClient_Request` - removed first `MonitorConnections` with the calls context to avoid Server to send commands to almost canceled context.
`TestNewClient_MissingConnectionsInInit` - test removed. Heal client has a check that the expected connection was received and return an error on `Request` otherwise.