### PR TITLE
fix: expire chain element could work incorrectly with registry-k8s

### DIFF
--- a/pkg/registry/common/expire/ns_server.go
+++ b/pkg/registry/common/expire/ns_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/expire/nse_server.go
+++ b/pkg/registry/common/expire/nse_server.go
@@ -41,10 +41,11 @@ func (n *nseServer) Register(ctx context.Context, nse *registry.NetworkServiceEn
 	}
 	expirationTime := time.Now().Add(n.nseExpiration)
 	nse.ExpirationTime = &timestamp.Timestamp{Seconds: expirationTime.Unix(), Nanos: int32(expirationTime.Nanosecond())}
+	unregisterNse := r.Clone()
 	timer := time.AfterFunc(n.nseExpiration, func() {
 		unregisterCtx, cancel := context.WithTimeout(extend.WithValuesFromContext(context.Background(), ctx), n.nseExpiration)
 		defer cancel()
-		_, _ = next.NetworkServiceEndpointRegistryServer(unregisterCtx).Unregister(unregisterCtx, nse)
+		_, _ = next.NetworkServiceEndpointRegistryServer(unregisterCtx).Unregister(unregisterCtx, unregisterNse)
 	})
 	if t, load := n.timers.LoadOrStore(nse.Name, timer); load {
 		timer.Stop()

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/refresh"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -51,6 +52,40 @@ func TestNewNetworkServiceEndpointRegistryServer(t *testing.T) {
 		})
 		require.Nil(t, err)
 		list = registry.ReadNetworkServiceEndpointList(stream)
+		return len(list) == 0
+	}, time.Second, time.Millisecond*100)
+}
+
+func Test_ExpireEndpointRegistryServer_ShouldCorrectlyRescheduleTimer(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := next.NewNetworkServiceEndpointRegistryServer(expire.NewNetworkServiceEndpointRegistryServer(testPeriod*2), memory.NewNetworkServiceEndpointRegistryServer())
+	c := next.NewNetworkServiceEndpointRegistryClient(refresh.NewNetworkServiceEndpointRegistryClient(refresh.WithChainContext(ctx)), adapters.NetworkServiceEndpointServerToClient(s))
+
+	_, err := c.Register(context.Background(), &registry.NetworkServiceEndpoint{})
+	require.NoError(t, err)
+
+	deadline := time.Now().Add(time.Second)
+
+	for time.Until(deadline) > 0 {
+		stream, err := c.Find(context.Background(), &registry.NetworkServiceEndpointQuery{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{},
+		})
+		require.NoError(t, err)
+		list := registry.ReadNetworkServiceEndpointList(stream)
+		require.Len(t, list, 1)
+	}
+
+	cancel()
+
+	require.Eventually(t, func() bool {
+		stream, err := c.Find(context.Background(), &registry.NetworkServiceEndpointQuery{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{},
+		})
+		require.Nil(t, err)
+		list := registry.ReadNetworkServiceEndpointList(stream)
 		return len(list) == 0
 	}, time.Second, time.Millisecond*100)
 }

--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -30,6 +30,7 @@ import (
 )
 
 type refreshNSEClient struct {
+	chainContext          context.Context
 	nseCancels            cancelsMap
 	retryDelay            time.Duration
 	defaultExpiryDuration time.Duration
@@ -75,7 +76,7 @@ func (c *refreshNSEClient) Register(ctx context.Context, in *registry.NetworkSer
 	if cancel, ok := c.nseCancels.Load(resp.Name); ok {
 		cancel()
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(c.chainContext)
 	c.nseCancels.Store(resp.Name, cancel)
 	c.startRefresh(ctx, nextClient, resp)
 	return resp, err
@@ -102,6 +103,7 @@ func NewNetworkServiceEndpointRegistryClient(options ...Option) registry.Network
 	c := &refreshNSEClient{
 		retryDelay:            time.Second * 5,
 		defaultExpiryDuration: time.Minute * 30,
+		chainContext:          context.Background(),
 	}
 
 	for _, o := range options {

--- a/pkg/registry/common/refresh/options.go
+++ b/pkg/registry/common/refresh/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/refresh/options.go
+++ b/pkg/registry/common/refresh/options.go
@@ -16,7 +16,10 @@
 
 package refresh
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Option is expire registry configuration option
 type Option interface {
@@ -40,5 +43,12 @@ func WithRetryPeriod(duration time.Duration) Option {
 func WithDefaultExpiryDuration(duration time.Duration) Option {
 	return applierFunc(func(c *refreshNSEClient) {
 		c.defaultExpiryDuration = duration
+	})
+}
+
+// WithChainContext sets a chain context
+func WithChainContext(ctx context.Context) Option {
+	return applierFunc(func(c *refreshNSEClient) {
+		c.chainContext = ctx
 	})
 }


### PR DESCRIPTION
## Description

During testing cmd-registry-k8s were found a few issues:
1. `expire` ns registry chain element uses deadline context
2. `expire` nse registry chain element should use actual NSE on unregistering
