### PR TITLE
fix: discover should allow try to select restarting endpoints

### DIFF
--- a/pkg/networkservice/common/discover/server.go
+++ b/pkg/networkservice/common/discover/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco Systems, Inc.
+// Copyright (c) 2020-2021 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -66,26 +66,15 @@ func (d *discoverCandidatesServer) Request(ctx context.Context, request *network
 	if err != nil {
 		return nil, err
 	}
-	visit := map[string]struct{}{}
 	for ctx.Err() == nil {
 		resp, err := next.Server(ctx).Request(WithCandidates(ctx, nses, ns), request)
 		if err == nil {
 			return resp, err
 		}
-		for _, nse := range nses {
-			visit[nse.Name] = struct{}{}
-		}
 		nses, err = d.discoverNetworkServiceEndpoints(ctx, ns, request.GetConnection().GetLabels())
 		if err != nil {
 			return nil, err
 		}
-		var newNses []*registry.NetworkServiceEndpoint
-		for _, nse := range nses {
-			if _, ok := visit[nse.Name]; !ok {
-				newNses = append(newNses, nse)
-			}
-		}
-		nses = newNses
 	}
 	return nil, errors.Wrap(ctx.Err(), "no match endpoints or all endpoints fail")
 }


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>


## Description

Currently, if the endpoint is restarting discover excludes him from the selection list.