### PR TITLE
fix: expire registry chain element should correctly set expiration time

### DIFF
--- a/pkg/registry/common/expire/ns_server.go
+++ b/pkg/registry/common/expire/ns_server.go
@@ -69,6 +69,7 @@ func (n *nsServer) checkUpdates() {
 			})
 			if v, loaded := n.timers.LoadOrStore(nse.Name, timer); loaded {
 				timer.Stop()
+				v.Stop()
 				v.Reset(duration)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Description

If the next of the `expire` chain element do remote register then `expire` not set the expiration time for the response.