### PR TITLE
Fix registry refresh

### DIFF
--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -20,14 +20,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
-	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/networkservicemesh/sdk/pkg/tools/logger/logruslogger"
 )
 
 type refreshNSEClient struct {
@@ -56,7 +56,8 @@ func (c *refreshNSEClient) startRefresh(
 	client registry.NetworkServiceEndpointRegistryClient,
 	nse *registry.NetworkServiceEndpoint,
 ) {
-	logEntry := log.Entry(ctx).WithField("refreshNSEClient", "startRefresh")
+	_, logEntry := logruslogger.New(ctx)
+	logEntry = logEntry.WithField("refreshNSEClient", "startRefresh")
 
 	t := time.Unix(nse.ExpirationTime.Seconds, int64(nse.ExpirationTime.Nanos))
 	delta := time.Until(t)

--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -70,7 +70,7 @@ func (c *refreshNSEClient) startRefresh(
 
 				res, err := client.Register(ctx, nse.Clone())
 				if err != nil {
-					logEntry.Warnf("failed to update registration: %s", err.Error())
+					logEntry.Errorf("failed to update registration: %s", err.Error())
 					return
 				}
 
@@ -133,10 +133,5 @@ func (c *refreshNSEClient) Unregister(
 	}
 	c.nseCancels.Delete(nse.Name)
 
-	resp, err := next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
 }

--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -74,7 +74,6 @@ func (c *refreshNSEClient) startRefresh(
 					return
 				}
 
-				nse.Name = res.Name
 				nse.ExpirationTime = res.ExpirationTime
 
 				t = nse.ExpirationTime.AsTime().Local()

--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -27,7 +27,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/logger/logruslogger"
+	"github.com/networkservicemesh/sdk/pkg/tools/logger"
 )
 
 type refreshNSEClient struct {
@@ -41,7 +41,7 @@ type refreshNSEClient struct {
 func NewNetworkServiceEndpointRegistryClient(options ...Option) registry.NetworkServiceEndpointRegistryClient {
 	c := &refreshNSEClient{
 		defaultExpiryDuration: time.Minute * 30,
-		chainContext:          context.Background(),
+		chainContext:          logger.WithLog(context.Background()),
 	}
 
 	for _, o := range options {
@@ -56,8 +56,7 @@ func (c *refreshNSEClient) startRefresh(
 	client registry.NetworkServiceEndpointRegistryClient,
 	nse *registry.NetworkServiceEndpoint,
 ) {
-	_, logEntry := logruslogger.New(ctx)
-	logEntry = logEntry.WithField("refreshNSEClient", "startRefresh")
+	logEntry := logger.Log(ctx).WithField("refreshNSEClient", "startRefresh")
 
 	t := time.Unix(nse.ExpirationTime.Seconds, int64(nse.ExpirationTime.Nanos))
 	delta := time.Until(t)

--- a/pkg/registry/common/refresh/nse_registry_client.go
+++ b/pkg/registry/common/refresh/nse_registry_client.go
@@ -20,90 +20,26 @@ import (
 	"context"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
 type refreshNSEClient struct {
 	chainContext          context.Context
 	nseCancels            cancelsMap
-	retryDelay            time.Duration
 	defaultExpiryDuration time.Duration
 }
 
-func (c *refreshNSEClient) startRefresh(ctx context.Context, client registry.NetworkServiceEndpointRegistryClient, nse *registry.NetworkServiceEndpoint) {
-	t := time.Unix(nse.ExpirationTime.Seconds, int64(nse.ExpirationTime.Nanos))
-	delta := time.Until(t)
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(2 * time.Until(t) / 3):
-				t1 := time.Now().Add(delta)
-				nse.ExpirationTime.Seconds = t1.Unix()
-				nse.ExpirationTime.Nanos = int32(t1.Nanosecond())
-				var err error
-				nse, err = client.Register(ctx, nse)
-				if err != nil {
-					<-time.After(c.retryDelay)
-					continue
-				}
-				t = t1
-			}
-		}
-	}()
-}
-
-func (c *refreshNSEClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
-	if in.ExpirationTime == nil {
-		expirationTime := time.Now().Add(c.defaultExpiryDuration)
-		in.ExpirationTime = &timestamp.Timestamp{
-			Seconds: expirationTime.Unix(),
-			Nanos:   int32(expirationTime.Nanosecond()),
-		}
-	}
-	nse := in.Clone()
-	nextClient := next.NetworkServiceEndpointRegistryClient(ctx)
-	resp, err := nextClient.Register(ctx, in, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if cancel, ok := c.nseCancels.Load(resp.Name); ok {
-		cancel()
-	}
-	ctx, cancel := context.WithCancel(c.chainContext)
-	c.nseCancels.Store(resp.Name, cancel)
-	nse.ExpirationTime = resp.ExpirationTime
-	c.startRefresh(ctx, nextClient, nse)
-	return resp, err
-}
-
-func (c *refreshNSEClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
-	return next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, in, opts...)
-}
-
-func (c *refreshNSEClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
-	resp, err := next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, in, opts...)
-	if err != nil {
-		return nil, err
-	}
-	if cancel, ok := c.nseCancels.Load(in.Name); ok {
-		cancel()
-	}
-	c.nseCancels.Delete(in.Name)
-	return resp, nil
-}
-
-// NewNetworkServiceEndpointRegistryClient creates new NetworkServiceEndpointRegistryClient that will refresh expiration time for registered NSEs
+// NewNetworkServiceEndpointRegistryClient creates new NetworkServiceEndpointRegistryClient that will refresh expiration
+// time for registered NSEs
 func NewNetworkServiceEndpointRegistryClient(options ...Option) registry.NetworkServiceEndpointRegistryClient {
 	c := &refreshNSEClient{
-		retryDelay:            time.Second * 5,
 		defaultExpiryDuration: time.Minute * 30,
 		chainContext:          context.Background(),
 	}
@@ -113,4 +49,94 @@ func NewNetworkServiceEndpointRegistryClient(options ...Option) registry.Network
 	}
 
 	return c
+}
+
+func (c *refreshNSEClient) startRefresh(
+	ctx context.Context,
+	client registry.NetworkServiceEndpointRegistryClient,
+	nse *registry.NetworkServiceEndpoint,
+) {
+	logEntry := log.Entry(ctx).WithField("refreshNSEClient", "startRefresh")
+
+	t := time.Unix(nse.ExpirationTime.Seconds, int64(nse.ExpirationTime.Nanos))
+	delta := time.Until(t)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(2 * time.Until(t) / 3):
+				nse.ExpirationTime = timestamppb.New(time.Now().Add(delta))
+
+				res, err := client.Register(ctx, nse.Clone())
+				if err != nil {
+					logEntry.Warnf("failed to update registration: %s", err.Error())
+					return
+				}
+
+				nse.Name = res.Name
+				nse.ExpirationTime = res.ExpirationTime
+
+				t = nse.ExpirationTime.AsTime().Local()
+			}
+		}
+	}()
+}
+
+func (c *refreshNSEClient) Register(
+	ctx context.Context,
+	nse *registry.NetworkServiceEndpoint,
+	opts ...grpc.CallOption,
+) (*registry.NetworkServiceEndpoint, error) {
+	if nse.ExpirationTime == nil {
+		nse.ExpirationTime = timestamppb.New(time.Now().Add(c.defaultExpiryDuration))
+	}
+
+	refreshNSE := nse.Clone()
+
+	nextClient := next.NetworkServiceEndpointRegistryClient(ctx)
+
+	resp, err := nextClient.Register(ctx, nse, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if cancel, ok := c.nseCancels.Load(resp.Name); ok {
+		cancel()
+	}
+
+	refreshNSE.Name = resp.Name
+	refreshNSE.ExpirationTime = resp.ExpirationTime
+
+	ctx, cancel := context.WithCancel(c.chainContext)
+	c.nseCancels.Store(resp.Name, cancel)
+
+	c.startRefresh(ctx, nextClient, refreshNSE)
+
+	return resp, err
+}
+
+func (c *refreshNSEClient) Find(
+	ctx context.Context,
+	query *registry.NetworkServiceEndpointQuery,
+	opts ...grpc.CallOption,
+) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+	return next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, query, opts...)
+}
+
+func (c *refreshNSEClient) Unregister(
+	ctx context.Context,
+	nse *registry.NetworkServiceEndpoint,
+	opts ...grpc.CallOption,
+) (*empty.Empty, error) {
+	if cancel, ok := c.nseCancels.Load(nse.Name); ok {
+		cancel()
+	}
+	c.nseCancels.Delete(nse.Name)
+
+	resp, err := next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }

--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -118,6 +118,7 @@ func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 
 	countClient := new(requestCountClient)
 	registryServer := &nseRegistryServer{
+		name:           uuid.New().String(),
 		expiryDuration: testExpiryDuration,
 	}
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -138,6 +139,8 @@ func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&countClient.requestCount) > 3
 	}, time.Second, testExpiryDuration/4)
+
+	reg.Url = endpoint.Url
 
 	_, err = client.Unregister(context.Background(), reg)
 	require.NoError(t, err)
@@ -167,8 +170,6 @@ type nseRegistryServer struct {
 }
 
 func (s *nseRegistryServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	s.name = uuid.New().String()
-
 	nse = nse.Clone()
 	nse.Name = s.name
 	nse.Url = uuid.New().String()

--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -18,171 +18,187 @@ package refresh_test
 
 import (
 	"context"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
-	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
 	"github.com/networkservicemesh/sdk/pkg/registry/common/refresh"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 )
 
 const testExpiryDuration = time.Millisecond * 100
 
-type testNSEClient struct {
-	sync.Mutex
-	requestCount int
-}
-
-func (t *testNSEClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
-	t.Lock()
-	defer t.Unlock()
-	t.requestCount++
-	return next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, in, opts...)
-}
-
-func (t *testNSEClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
-	panic("implement me")
-}
-
-func (t *testNSEClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
-	return nil, nil
-}
-
-type checkExpirationTimeClient struct{ *testing.T }
-
-func (c *checkExpirationTimeClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
-	require.NotNil(c, in.ExpirationTime)
-	return in, nil
-}
-
-func (c *checkExpirationTimeClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
-	panic("implement me")
-}
-
-func (c *checkExpirationTimeClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
-	return new(empty.Empty), nil
-}
-
-type nseExpirationServer struct {
-	expirationTime time.Duration
-}
-
-func (s *nseExpirationServer) Register(_ context.Context, in *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	resp := in.Clone()
-	resp.ExpirationTime = timestamppb.New(time.Now().Add(s.expirationTime))
-	return resp, nil
-}
-
-func (s *nseExpirationServer) Find(_ *registry.NetworkServiceEndpointQuery, _ registry.NetworkServiceEndpointRegistry_FindServer) error {
-	return nil
-}
-
-func (s *nseExpirationServer) Unregister(_ context.Context, _ *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
-	return nil, nil
+func testNSE(name string) *registry.NetworkServiceEndpoint {
+	return &registry.NetworkServiceEndpoint{
+		Name: name,
+	}
 }
 
 func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	testClient := &testNSEClient{}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	countClient := new(requestCountClient)
+	client := next.NewNetworkServiceEndpointRegistryClient(
+		refresh.NewNetworkServiceEndpointRegistryClient(refresh.WithDefaultExpiryDuration(testExpiryDuration)),
+		countClient,
+	)
 
-	refreshClient := next.NewNetworkServiceEndpointRegistryClient(
-		refresh.NewNetworkServiceEndpointRegistryClient(
-			refresh.WithRetryPeriod(testExpiryDuration),
-			refresh.WithDefaultExpiryDuration(testExpiryDuration),
-			refresh.WithChainContext(ctx),
-		),
-		testClient)
-	_, err := refreshClient.Register(context.Background(), &registry.NetworkServiceEndpoint{
+	_, err := client.Register(context.Background(), &registry.NetworkServiceEndpoint{
 		Name: "nse-1",
 	})
-
 	require.NoError(t, err)
+
 	require.Eventually(t, func() bool {
-		testClient.Lock()
-		defer testClient.Unlock()
-		return testClient.requestCount > 0
+		return atomic.LoadInt32(&countClient.requestCount) > 1
 	}, time.Second, testExpiryDuration/4)
 
-	_, err = refreshClient.Unregister(context.Background(), &registry.NetworkServiceEndpoint{Name: "nse-1"})
+	_, err = client.Unregister(context.Background(), testNSE("nse-1"))
 	require.NoError(t, err)
 }
 
 func TestRefreshNSEClient_ShouldSetExpirationTime_BeforeCallNext(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	c := next.NewNetworkServiceEndpointRegistryClient(
-		&testNSEClient{},
-		refresh.NewNetworkServiceEndpointRegistryClient(refresh.WithDefaultExpiryDuration(time.Hour), refresh.WithChainContext(ctx)),
-		&checkExpirationTimeClient{T: t},
-	)
-
-	_, err := c.Register(context.Background(), &registry.NetworkServiceEndpoint{Name: "nse-1"})
-	require.Nil(t, err)
-
-	_, err = c.Unregister(context.Background(), &registry.NetworkServiceEndpoint{Name: "nse-1"})
-	require.Nil(t, err)
-}
-
-func Test_RefreshNSEClient_ShouldUseExpirationFromServer(t *testing.T) {
-	c := next.NewNetworkServiceEndpointRegistryClient(
+	client := next.NewNetworkServiceEndpointRegistryClient(
+		new(requestCountClient),
 		refresh.NewNetworkServiceEndpointRegistryClient(refresh.WithDefaultExpiryDuration(time.Hour)),
-		adapters.NetworkServiceEndpointServerToClient(&nseExpirationServer{expirationTime: time.Hour}),
+		&checkNSEClient{
+			t: t,
+			check: func(t *testing.T, nse *registry.NetworkServiceEndpoint) {
+				require.NotNil(t, nse.ExpirationTime)
+			},
+		},
 	)
 
-	resp, err := c.Register(context.Background(), &registry.NetworkServiceEndpoint{Name: "nse-1"})
-
+	_, err := client.Register(context.Background(), testNSE("nse-1"))
 	require.NoError(t, err)
-	require.Greater(t, time.Until(resp.ExpirationTime.AsTime()).Minutes(), float64(50))
+
+	_, err = client.Unregister(context.Background(), testNSE("nse-1"))
+	require.Nil(t, err)
 }
 
 func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	countClient := new(requestCountClient)
+	client := next.NewNetworkServiceEndpointRegistryClient(
+		refresh.NewNetworkServiceEndpointRegistryClient(refresh.WithDefaultExpiryDuration(testExpiryDuration)),
+		countClient,
+	)
 
-	testClient := &testNSEClient{}
+	_, err := client.Register(context.Background(), testNSE("nse-1"))
+	require.NoError(t, err)
 
-	refreshClient := next.NewNetworkServiceEndpointRegistryClient(
-		refresh.NewNetworkServiceEndpointRegistryClient(
-			refresh.WithRetryPeriod(testExpiryDuration),
-			refresh.WithDefaultExpiryDuration(testExpiryDuration),
-			refresh.WithChainContext(ctx)),
-		testClient)
-
-	_, err := refreshClient.Register(context.Background(), &registry.NetworkServiceEndpoint{
-		Name: "nse-1",
-	})
-
-	require.Nil(t, err)
-	_, err = refreshClient.Register(context.Background(), &registry.NetworkServiceEndpoint{
-		Name: "nse-1",
-	})
-
-	require.Nil(t, err)
+	_, err = client.Register(context.Background(), testNSE("nse-1"))
+	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		testClient.Lock()
-		defer testClient.Unlock()
-		return testClient.requestCount > 0
+		return atomic.LoadInt32(&countClient.requestCount) > 2
 	}, time.Second, testExpiryDuration/4)
 
-	_, err = refreshClient.Unregister(context.Background(), &registry.NetworkServiceEndpoint{Name: "nse-1"})
+	_, err = client.Unregister(context.Background(), testNSE("nse-1"))
+	require.NoError(t, err)
+}
 
-	require.Nil(t, err)
+func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	endpoint := &registry.NetworkServiceEndpoint{
+		Name: "nse-1",
+		Url:  "url",
+	}
+
+	countClient := new(requestCountClient)
+	registryServer := &nseRegistryServer{
+		expiryDuration: testExpiryDuration,
+	}
+	client := next.NewNetworkServiceEndpointRegistryClient(
+		refresh.NewNetworkServiceEndpointRegistryClient(refresh.WithDefaultExpiryDuration(time.Hour)),
+		&checkNSEClient{
+			t: t,
+			check: func(t *testing.T, nse *registry.NetworkServiceEndpoint) {
+				if countClient.requestCount > 0 {
+					require.Equal(t, registryServer.name, nse.Name)
+					require.Equal(t, endpoint.Url, nse.Url)
+				}
+			},
+		},
+		countClient,
+		adapters.NetworkServiceEndpointServerToClient(registryServer),
+	)
+
+	resp, err := client.Register(context.Background(), endpoint.Clone())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&countClient.requestCount) > 3
+	}, time.Second, testExpiryDuration/4)
+
+	_, err = client.Unregister(context.Background(), testNSE(resp.Name))
+	require.NoError(t, err)
+}
+
+type requestCountClient struct {
+	requestCount int32
+
+	registry.NetworkServiceEndpointRegistryClient
+}
+
+func (t *requestCountClient) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	atomic.AddInt32(&t.requestCount, 1)
+
+	return next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, nse, opts...)
+}
+
+func (t *requestCountClient) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
+}
+
+type checkNSEClient struct {
+	t     *testing.T
+	check func(t *testing.T, nse *registry.NetworkServiceEndpoint)
+
+	registry.NetworkServiceEndpointRegistryClient
+}
+
+func (c *checkNSEClient) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	c.check(c.t, nse)
+
+	return next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, nse, opts...)
+}
+
+func (c *checkNSEClient) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
+}
+
+type nseRegistryServer struct {
+	expiryDuration time.Duration
+	name           string
+
+	registry.NetworkServiceEndpointRegistryServer
+}
+
+func (s *nseRegistryServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	s.name = uuid.New().String()
+
+	nse = nse.Clone()
+	nse.Name = s.name
+	nse.Url = uuid.New().String()
+	nse.ExpirationTime = timestamppb.New(time.Now().Add(s.expiryDuration))
+
+	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
+}
+
+func (s *nseRegistryServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
 }

--- a/pkg/registry/common/refresh/options.go
+++ b/pkg/registry/common/refresh/options.go
@@ -32,13 +32,6 @@ func (f applierFunc) apply(c *refreshNSEClient) {
 	f(c)
 }
 
-// WithRetryPeriod sets a specific period to reconnect in case of a server returning an error
-func WithRetryPeriod(duration time.Duration) Option {
-	return applierFunc(func(c *refreshNSEClient) {
-		c.retryDelay = duration
-	})
-}
-
 // WithDefaultExpiryDuration sets a default expiration_time if it is nil on NSE registration
 func WithDefaultExpiryDuration(duration time.Duration) Option {
 	return applierFunc(func(c *refreshNSEClient) {

--- a/pkg/registry/utils/checks/checknse/doc.go
+++ b/pkg/registry/utils/checks/checknse/doc.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package checknse - provides registry chain elements for checking the *registry.NetworkServiceEndpoint passed on
+// by the previous chain element
+package checknse

--- a/pkg/registry/utils/checks/checknse/nse_client.go
+++ b/pkg/registry/utils/checks/checknse/nse_client.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checknse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+)
+
+type checkNSEClient struct {
+	*testing.T
+	check func(*testing.T, *registry.NetworkServiceEndpoint)
+}
+
+// NewClient - returns NetworkServiceEndpointRegistryClient that checks the NSE passed in from the previous NSClient in the chain
+//             t - *testing.T used for the check
+//             check - function that checks the *registry.NetworkServiceEndpoint
+func NewClient(t *testing.T, check func(*testing.T, *registry.NetworkServiceEndpoint)) registry.NetworkServiceEndpointRegistryClient {
+	return &checkNSEClient{
+		T:     t,
+		check: check,
+	}
+}
+
+func (c *checkNSEClient) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	c.check(c.T, nse)
+	return next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, nse, opts...)
+}
+
+func (c *checkNSEClient) Find(ctx context.Context, query *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+	return next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, query, opts...)
+}
+
+func (c *checkNSEClient) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+	c.check(c.T, nse)
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
+}

--- a/pkg/registry/utils/checks/checknse/nse_server.go
+++ b/pkg/registry/utils/checks/checknse/nse_server.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checknse
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+)
+
+type checkNSEServer struct {
+	*testing.T
+	check func(*testing.T, *registry.NetworkServiceEndpoint)
+}
+
+// NewServer - returns NetworkServiceEndpointRegistryServer that checks the NSE passed in from the previous Server in the chain
+//             t - *testing.T used for the check
+//             check - function that checks the *registry.NetworkServiceEndpoint
+func NewServer(t *testing.T, check func(*testing.T, *registry.NetworkServiceEndpoint)) registry.NetworkServiceEndpointRegistryServer {
+	return &checkNSEServer{
+		T:     t,
+		check: check,
+	}
+}
+
+func (s *checkNSEServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	s.check(s.T, nse)
+	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
+}
+
+func (s *checkNSEServer) Find(query *registry.NetworkServiceEndpointQuery, server registry.NetworkServiceEndpointRegistry_FindServer) error {
+	return next.NetworkServiceEndpointRegistryServer(server.Context()).Find(query, server)
+}
+
+func (s *checkNSEServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	s.check(s.T, nse)
+	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
+}


### PR DESCRIPTION
# Issues
1. `refresh` uses name from client.
2. `startRefresh` overrides initial URL with returned from server.
3. `startRefresh` should fail on error returned from server.
4. Tests wait for incorrect `requestCount`.
# Solution
1. Always override only name and expiration time with returned from server.
2. Same.
3. Stop retrying to refresh on error returned, log a warning message.
4. Fix tests.