### PR TITLE
Interpose should create unique name for all new interpose NSEs

### DIFF
--- a/pkg/networkservice/common/interpose/server.go
+++ b/pkg/networkservice/common/interpose/server.go
@@ -61,7 +61,7 @@ type connectionInfo struct {
 //                        so it can capture the registrations.
 func NewServer(registryServer *registry.NetworkServiceEndpointRegistryServer) networkservice.NetworkServiceServer {
 	rv := new(interposeServer)
-	*registryServer = interpose.NewNetworkServiceRegistryServer(&rv.endpoints)
+	*registryServer = interpose.NewNetworkServiceEndpointRegistryServer(&rv.endpoints)
 	return rv
 }
 

--- a/pkg/registry/common/interpose/client.go
+++ b/pkg/registry/common/interpose/client.go
@@ -34,18 +34,18 @@ func NewNetworkServiceEndpointRegistryClient() registry.NetworkServiceEndpointRe
 	return &interposeRegistryClient{}
 }
 
-func (rc *interposeRegistryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+func (c *interposeRegistryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
 	if !Is(in.Name) {
 		in.Name = interposeName(in.Name)
 	}
 	return next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, in, opts...)
 }
 
-func (rc *interposeRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+func (c *interposeRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
 	return next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, in, opts...)
 }
 
-func (rc *interposeRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+func (c *interposeRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
 	if !Is(in.Name) {
 		in.Name = interposeName(in.Name)
 	}

--- a/pkg/registry/common/interpose/server.go
+++ b/pkg/registry/common/interpose/server.go
@@ -34,9 +34,9 @@ type interposeRegistryServer struct {
 	nses *stringurl.Map
 }
 
-// NewNetworkServiceRegistryServer - creates a NetworkServiceRegistryServer that registers local Cross connect Endpoints
-//				and adds them to Map
-func NewNetworkServiceRegistryServer(nses *stringurl.Map) registry.NetworkServiceEndpointRegistryServer {
+// NewNetworkServiceEndpointRegistryServer - creates a NetworkServiceRegistryServer that registers local
+//                                           Cross connect Endpoints and adds them to Map
+func NewNetworkServiceEndpointRegistryServer(nses *stringurl.Map) registry.NetworkServiceEndpointRegistryServer {
 	return &interposeRegistryServer{
 		nses: nses,
 	}

--- a/pkg/registry/common/interpose/server.go
+++ b/pkg/registry/common/interpose/server.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -30,44 +31,51 @@ import (
 )
 
 type interposeRegistryServer struct {
-	endpoints *stringurl.Map
+	nses *stringurl.Map
 }
 
 // NewNetworkServiceRegistryServer - creates a NetworkServiceRegistryServer that registers local Cross connect Endpoints
 //				and adds them to Map
 func NewNetworkServiceRegistryServer(nses *stringurl.Map) registry.NetworkServiceEndpointRegistryServer {
-	return &interposeRegistryServer{endpoints: nses}
+	return &interposeRegistryServer{
+		nses: nses,
+	}
 }
 
-func (rs *interposeRegistryServer) Register(ctx context.Context, request *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	if !Is(request.Name) {
-		return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, request)
+func (s *interposeRegistryServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	if !Is(nse.Name) {
+		return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
 	}
 
-	u, err := url.Parse(request.Url)
+	if _, ok := s.nses.Load(nse.Name); ok {
+		return nse, nil
+	}
+
+	u, err := url.Parse(nse.Url)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot register cross NSE with passed URL: %s", request.Url)
+		return nil, errors.Wrapf(err, "cannot register cross NSE with passed URL: %s", nse.Url)
 	}
 	if u.String() == "" {
-		return nil, errors.Errorf("cannot register cross NSE with passed URL: %s", request.Url)
+		return nil, errors.Errorf("cannot register cross NSE with passed URL: %s", nse.Url)
 	}
 
-	rs.endpoints.LoadOrStore(request.Name, u)
+	nse.Name = interposeName(uuid.New().String())
+	s.nses.LoadOrStore(nse.Name, u)
 
-	return request, nil
+	return nse, nil
 }
 
-func (rs *interposeRegistryServer) Find(query *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
+func (s *interposeRegistryServer) Find(query *registry.NetworkServiceEndpointQuery, server registry.NetworkServiceEndpointRegistry_FindServer) error {
 	// No need to modify find logic.
-	return next.NetworkServiceEndpointRegistryServer(s.Context()).Find(query, s)
+	return next.NetworkServiceEndpointRegistryServer(server.Context()).Find(query, server)
 }
 
-func (rs *interposeRegistryServer) Unregister(ctx context.Context, request *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
-	if !Is(request.Name) {
-		return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, request)
+func (s *interposeRegistryServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	if !Is(nse.Name) {
+		return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
 	}
 
-	rs.endpoints.Delete(request.Name)
+	s.nses.Delete(nse.Name)
 
 	return new(empty.Empty), nil
 }

--- a/pkg/registry/common/interpose/server_test.go
+++ b/pkg/registry/common/interpose/server_test.go
@@ -55,15 +55,25 @@ func TestInterposeRegistryServer_InterposeNSE(t *testing.T) {
 
 	crossMap, server := testServer()
 
-	reg, err := server.Register(context.Background(), testNSE(namePrefix+name, validURL))
+	reg1, err := server.Register(context.Background(), testNSE(namePrefix+name, validURL))
 	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(reg.Name, namePrefix))
+	require.True(t, strings.HasPrefix(reg1.Name, namePrefix))
+
+	reg2, err := server.Register(context.Background(), testNSE(namePrefix+name, validURL))
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(reg2.Name, namePrefix))
+
+	require.NotEqual(t, reg1.Name, reg2.Name)
 
 	requireCrossMapEqual(t, map[string]string{
-		reg.Name: validURL,
+		reg1.Name: validURL,
+		reg2.Name: validURL,
 	}, crossMap)
 
-	_, err = server.Unregister(context.Background(), reg.Clone())
+	_, err = server.Unregister(context.Background(), reg1)
+	require.NoError(t, err)
+
+	_, err = server.Unregister(context.Background(), reg2)
 	require.NoError(t, err)
 
 	requireCrossMapEqual(t, map[string]string{}, crossMap)

--- a/pkg/registry/common/interpose/server_test.go
+++ b/pkg/registry/common/interpose/server_test.go
@@ -39,7 +39,7 @@ const (
 
 func testServer() (*stringurl.Map, registry.NetworkServiceEndpointRegistryServer) {
 	var crossMap stringurl.Map
-	server := interpose.NewNetworkServiceRegistryServer(&crossMap)
+	server := interpose.NewNetworkServiceEndpointRegistryServer(&crossMap)
 	return &crossMap, server
 }
 

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -43,8 +43,9 @@ import (
 )
 
 const (
-	defaultContextTimeout         = time.Second * 15
-	defaultRegistryExpiryDuration = 500 * time.Millisecond
+	defaultContextTimeout = time.Second * 15
+	// DefaultRegistryExpiryDuration is a default expiry duration for registry
+	DefaultRegistryExpiryDuration = 500 * time.Millisecond
 )
 
 // Builder implements builder pattern for building NSM Domain
@@ -261,7 +262,7 @@ func (b *Builder) newRegistry(ctx context.Context, proxyRegistryURL *url.URL) *R
 	if b.supplyRegistry == nil {
 		return nil
 	}
-	result := b.supplyRegistry(ctx, defaultRegistryExpiryDuration, proxyRegistryURL, grpc.WithInsecure(), grpc.WithBlock())
+	result := b.supplyRegistry(ctx, DefaultRegistryExpiryDuration, proxyRegistryURL, grpc.WithInsecure(), grpc.WithBlock())
 	serveURL := &url.URL{Scheme: "tcp", Host: "127.0.0.1:0"}
 	serve(ctx, serveURL, result.Register)
 	logger.Log(ctx).Infof("Registry listen on: %v", serveURL)


### PR DESCRIPTION
# Issue
If multiple interpose NSEs will try to register with same names, we will have a collision and lose some of them.
# Solution
Generate new unique name for interpose NSEs if we haven't registered them yet before.