### PR TITLE
Fix query cache goleaks

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
 	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/payload"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
@@ -569,8 +570,16 @@ func testNSEAndClient(
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
 
-	err = sandbox.UnregisterEndpoint(ctx, nseReg, domain.Nodes[0].NSMgr)
+	_, err = domain.Nodes[0].NSMgr.NetworkServiceEndpointRegistryServer().Unregister(ctx, nseReg)
 	require.NoError(t, err)
+
+	for _, name := range nseReg.NetworkServiceNames {
+		_, err = domain.Nodes[0].NSMgr.NetworkServiceRegistryServer().Unregister(ctx, &registry.NetworkService{
+			Name:    name,
+			Payload: payload.IP,
+		})
+		require.NoError(t, err)
+	}
 }
 
 type passThroughClient struct {

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -327,9 +327,7 @@ func TestNSMGR_ConnectToDeadNSE(t *testing.T) {
 }
 
 func TestNSMGR_LocalUsecase(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
+	ctx := context.Background()
 
 	domain := sandbox.NewBuilder(t).
 		SetNodesCount(1).
@@ -343,11 +341,15 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-remote"},
 	}
 
+	nseCtx, nseCancel := context.WithCancel(ctx)
+
 	counter := &counterServer{}
-	_, err := sandbox.NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr, counter)
+	_, err := sandbox.NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr, counter)
 	require.NoError(t, err)
 
-	nsc := sandbox.NewClient(ctx, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr.URL)
+	clientCtx, clientCancel := context.WithCancel(ctx)
+
+	nsc := sandbox.NewClient(clientCtx, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr.URL)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -360,28 +362,31 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 		},
 	}
 
-	conn, err := nsc.Request(ctx, request.Clone())
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	requestCtx, cancel := context.WithCancel(ctx)
+
+	conn, err := nsc.Request(requestCtx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
 	require.Equal(t, 5, len(conn.Path.PathSegments))
 
-	// Simulate refresh from client.
+	cancel()
 
-	refreshRequest := request.Clone()
-	refreshRequest.Connection = conn.Clone()
+	requestCtx, cancel = context.WithCancel(ctx)
 
-	conn2, err := nsc.Request(ctx, refreshRequest)
-	require.NoError(t, err)
-	require.NotNil(t, conn2)
-	require.Equal(t, 5, len(conn2.Path.PathSegments))
-	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
-	// Close.
-
-	e, err := nsc.Close(ctx, conn)
+	e, err := nsc.Close(requestCtx, conn)
 	require.NoError(t, err)
 	require.NotNil(t, e)
 	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+
+	cancel()
+
+	clientCancel()
+	nseCancel()
+
+	<-time.After(2 * time.Second)
 }
 
 func TestNSMGR_PassThroughRemote(t *testing.T) {
@@ -505,6 +510,61 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 	// Path length to first endpoint is 5
 	// Path length from NSE client to other local endpoint is 5
 	require.Equal(t, 5*(nsesCount-1)+5, len(conn.Path.PathSegments))
+}
+
+func TestNSMGR_ShouldCleanAllClientAndEndpointGoroutines(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	domain := sandbox.NewBuilder(t).
+		SetNodesCount(1).
+		SetRegistryProxySupplier(nil).
+		SetContext(ctx).
+		Build()
+	defer domain.Cleanup()
+
+	nseCtx, nseCancel := context.WithCancel(ctx)
+
+	nseReg := &registry.NetworkServiceEndpoint{
+		Name:                "final-endpoint",
+		NetworkServiceNames: []string{"my-service"},
+	}
+	_, err := sandbox.NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr)
+	require.NoError(t, err)
+
+	clientCtx, clientCancel := context.WithCancel(ctx)
+
+	nsc := sandbox.NewClient(clientCtx, sandbox.GenerateTestToken, domain.Nodes[0].NSMgr.URL)
+
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	conn, err := func() (*networkservice.Connection, error) {
+		requestCtx, requestCancel := context.WithCancel(ctx)
+		defer requestCancel()
+
+		return nsc.Request(requestCtx, &networkservice.NetworkServiceRequest{
+			MechanismPreferences: []*networkservice.Mechanism{
+				{Cls: cls.LOCAL, Type: kernelmech.MECHANISM},
+			},
+			Connection: &networkservice.Connection{
+				NetworkService: "my-service",
+			},
+		})
+	}()
+	require.NoError(t, err)
+
+	_, err = func() (interface{}, error) {
+		closeCtx, closeCancel := context.WithCancel(ctx)
+		defer closeCancel()
+
+		return nsc.Close(closeCtx, conn)
+	}()
+	require.NoError(t, err)
+
+	clientCancel()
+	nseCancel()
 }
 
 type passThroughClient struct {

--- a/pkg/registry/common/querycache/nse_client.go
+++ b/pkg/registry/common/querycache/nse_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
@@ -42,34 +43,51 @@ func (q *queryCacheNSEClient) Find(ctx context.Context, in *registry.NetworkServ
 	if in.Watch {
 		return next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, in, opts...)
 	}
+
 	if nse, ok := q.cache.Load(in.String()); ok {
 		resultCh := make(chan *registry.NetworkServiceEndpoint, 1)
 		resultCh <- nse
 		close(resultCh)
 		return streamchannel.NewNetworkServiceEndpointFindClient(ctx, resultCh), nil
 	}
+
 	client, err := next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, in, opts...)
 	if err != nil {
 		return nil, err
 	}
+
 	nses := registry.ReadNetworkServiceEndpointList(client)
+
 	resultCh := make(chan *registry.NetworkServiceEndpoint, len(nses))
 	for _, nse := range nses {
+		resultCh <- nse
+
 		nseQuery := &registry.NetworkServiceEndpointQuery{
 			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
 				Name: nse.Name,
 			},
 		}
-		resultCh <- nse
+
 		key := nseQuery.String()
 		q.cache.Store(key, nse)
+
 		go func() {
 			defer q.cache.Delete(key)
+
+			findCtx, findCancel := context.WithCancel(q.chainCtx)
+			defer findCancel()
+
 			nseQuery.Watch = true
-			stream, err := next.NetworkServiceEndpointRegistryClient(ctx).Find(q.chainCtx, nseQuery, opts...)
+
+			stream, err := next.NetworkServiceEndpointRegistryClient(ctx).Find(findCtx, nseQuery, opts...)
 			if err != nil {
 				return
 			}
+
+			if q.checkQuery(ctx, nseQuery, opts...) != nil {
+				return
+			}
+
 			for update, err := stream.Recv(); err == nil; update, err = stream.Recv() {
 				if update.Name != nseQuery.NetworkServiceEndpoint.Name {
 					continue
@@ -82,7 +100,25 @@ func (q *queryCacheNSEClient) Find(ctx context.Context, in *registry.NetworkServ
 		}()
 	}
 	close(resultCh)
+
 	return streamchannel.NewNetworkServiceEndpointFindClient(ctx, resultCh), nil
+}
+
+func (q *queryCacheNSEClient) checkQuery(ctx context.Context, nseQuery *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) error {
+	nseQuery = proto.Clone(nseQuery).(*registry.NetworkServiceEndpointQuery)
+	nseQuery.Watch = false
+
+	findCtx, findCancel := context.WithCancel(q.chainCtx)
+	defer findCancel()
+
+	client, err := next.NetworkServiceEndpointRegistryClient(ctx).Find(findCtx, nseQuery, opts...)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Recv()
+
+	return err
 }
 
 func (q *queryCacheNSEClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {

--- a/pkg/registry/common/querycache/nse_client_test.go
+++ b/pkg/registry/common/querycache/nse_client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -105,4 +105,53 @@ func Test_QueryCacheServer_ShouldCacheNSEs(t *testing.T) {
 			return len(list) == 0
 		}, time.Second, time.Second/10)
 	}
+}
+
+func Test_QueryCacheServer_ShouldCleanupGoroutinesOnNSEUnregister(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mem := memory.NewNetworkServiceEndpointRegistryServer()
+
+	reg, err := func() (*registry.NetworkServiceEndpoint, error) {
+		registerCtx, registerCancel := context.WithCancel(ctx)
+		defer registerCancel()
+
+		return mem.Register(registerCtx, &registry.NetworkServiceEndpoint{
+			Name: "nse-1",
+		})
+	}()
+	require.NoError(t, err)
+
+	client := next.NewNetworkServiceEndpointRegistryClient(
+		querycache.NewClient(ctx),
+		adapters.NetworkServiceEndpointServerToClient(mem),
+	)
+
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	_, err = func() (interface{}, error) {
+		findCtx, findCancel := context.WithCancel(ctx)
+		defer findCancel()
+
+		return client.Find(findCtx, &registry.NetworkServiceEndpointQuery{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
+				Name: reg.Name,
+			},
+		})
+	}()
+	require.NoError(t, err)
+
+	// Wait a bit for the (cache -> registry) stream to start
+	<-time.After(1 * time.Millisecond)
+
+	_, err = func() (interface{}, error) {
+		unregisterCtx, unregisterCancel := context.WithCancel(ctx)
+		defer unregisterCancel()
+
+		return mem.Unregister(unregisterCtx, reg)
+	}()
+	require.NoError(t, err)
 }

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/networkservicemesh/api/pkg/api/networkservice/payload"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/logger"
@@ -75,7 +76,10 @@ func NewEndpoint(ctx context.Context, nse *registry.NetworkServiceEndpoint, gene
 	}
 
 	for _, service := range nse.NetworkServiceNames {
-		if _, err := mgr.NetworkServiceRegistryServer().Register(ctx, &registry.NetworkService{Name: service, Payload: "IP"}); err != nil {
+		if _, err := mgr.NetworkServiceRegistryServer().Register(ctx, &registry.NetworkService{
+			Name:    service,
+			Payload: payload.IP,
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -83,7 +87,10 @@ func NewEndpoint(ctx context.Context, nse *registry.NetworkServiceEndpoint, gene
 	go func() {
 		<-ctx.Done()
 		for _, service := range nse.NetworkServiceNames {
-			_, _ = mgr.NetworkServiceRegistryServer().Unregister(context.Background(), &registry.NetworkService{Name: service, Payload: "IP"})
+			_, _ = mgr.NetworkServiceRegistryServer().Unregister(context.Background(), &registry.NetworkService{
+				Name:    service,
+				Payload: payload.IP,
+			})
 		}
 		_, _ = mgr.NetworkServiceEndpointRegistryServer().Unregister(context.Background(), nse)
 	}()

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -22,17 +22,14 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/networkservicemesh/api/pkg/api/networkservice/payload"
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/networkservicemesh/sdk/pkg/tools/logger"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/payload"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
@@ -41,6 +38,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/tools/clienturlctx"
+	"github.com/networkservicemesh/sdk/pkg/tools/logger"
 	"github.com/networkservicemesh/sdk/pkg/tools/opentracing"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
@@ -93,22 +91,6 @@ func NewEndpoint(ctx context.Context, nse *registry.NetworkServiceEndpoint, gene
 	logger.Log(ctx).Infof("Started listen endpoint %v on %v.", nse.Name, u.String())
 
 	return &EndpointEntry{Endpoint: ep, URL: u}, nil
-}
-
-// UnregisterEndpoint unregisters endpoint from NSMgr
-func UnregisterEndpoint(ctx context.Context, nse *registry.NetworkServiceEndpoint, mgr nsmgr.Nsmgr) (err error) {
-	if _, unregisterErr := mgr.NetworkServiceEndpointRegistryServer().Unregister(ctx, nse); unregisterErr != nil {
-		err = errors.Wrapf(unregisterErr, "%v\n", err)
-	}
-	for _, name := range nse.NetworkServiceNames {
-		if _, unregisterErr := mgr.NetworkServiceRegistryServer().Unregister(ctx, &registry.NetworkService{
-			Name:    name,
-			Payload: payload.IP,
-		}); unregisterErr != nil {
-			err = errors.Wrapf(unregisterErr, "%v\n", err)
-		}
-	}
-	return err
 }
 
 // NewClient is a client.NewClient over *url.URL with some fields preset for testing


### PR DESCRIPTION
# Issues
1. Query cache starts watching Find on chain context, it lasts until the application closes.
2. There is a possible leak when registry deletes NSE in process of cache Find.
# Solutions
1. Start watching Find on special context and close it after NSE remove.
2. Double check that NSE exists in registry before starting to wait events for it.