### PR TITLE
fix: registry expiration logic doesn't work

### DIFF
--- a/pkg/registry/common/expire/nse_server.go
+++ b/pkg/registry/common/expire/nse_server.go
@@ -49,8 +49,10 @@ func (n *expireNSEServer) Register(ctx context.Context, nse *registry.NetworkSer
 
 	unregisterNSE := resp.Clone()
 
-	timer := time.AfterFunc(n.nseExpiration, func() {
-		unregisterCtx, cancel := context.WithTimeout(extend.WithValuesFromContext(context.Background(), ctx), time.Until(expirationTime))
+	exipreDuration := time.Until(expirationTime)
+
+	timer := time.AfterFunc(exipreDuration, func() {
+		unregisterCtx, cancel := context.WithTimeout(extend.WithValuesFromContext(context.Background(), ctx), exipreDuration)
 		defer cancel()
 		_, _ = next.NetworkServiceEndpointRegistryServer(unregisterCtx).Unregister(unregisterCtx, unregisterNSE)
 	})

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -48,18 +48,31 @@ func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testin
 	require.Greater(t, time.Until(resp.ExpirationTime.AsTime()).Minutes(), float64(50))
 }
 
-func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput(t *testing.T) {
+func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	s := expire.NewNetworkServiceEndpointRegistryServer(time.Hour)
+	s := next.NewNetworkServiceEndpointRegistryServer(expire.NewNetworkServiceEndpointRegistryServer(time.Hour), memory.NewNetworkServiceEndpointRegistryServer())
 
 	resp, err := s.Register(context.Background(), &registry.NetworkServiceEndpoint{
 		Name:           "nse-1",
-		ExpirationTime: timestamppb.New(time.Now().Add(10 * time.Minute)),
+		ExpirationTime: timestamppb.New(time.Now().Add(time.Millisecond * 200)),
 	})
 	require.NoError(t, err)
 
-	require.Less(t, time.Until(resp.ExpirationTime.AsTime()).Minutes(), float64(11))
+	require.Less(t, time.Until(resp.ExpirationTime.AsTime()).Seconds(), float64(65))
+
+	c := adapters.NetworkServiceEndpointServerToClient(s)
+
+	require.Eventually(t, func() bool {
+		stream, err := c.Find(context.Background(), &registry.NetworkServiceEndpointQuery{
+			NetworkServiceEndpoint: new(registry.NetworkServiceEndpoint),
+		})
+		require.NoError(t, err)
+
+		list := registry.ReadNetworkServiceEndpointList(stream)
+		return len(list) == 0
+	}, time.Second, time.Millisecond*100)
+
 }
 
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -72,7 +72,6 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing
 		list := registry.ReadNetworkServiceEndpointList(stream)
 		return len(list) == 0
 	}, time.Second, time.Millisecond*100)
-
 }
 
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>


Fixes ci here : https://github.com/networkservicemesh/cmd-registry-memory/pull/183
