### PR TITLE
Fix NS watch

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -149,8 +149,6 @@ func TestNSMGR_SelectsRestartingEndpoint(t *testing.T) {
 }
 
 func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
-	t.Skip("https://github.com/networkservicemesh/sdk/issues/619")
-
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()


### PR DESCRIPTION
# Issue
`discover` chain element don't read fully channel from `registry.ReadNetworkServiceEndpointChannel` - it results in #619.
# Solution
Use GRPC Stream instead of channels.

Closes #619.