### PR TITLE
Discover should use strict name match

### DIFF
--- a/pkg/networkservice/common/discover/server_test.go
+++ b/pkg/networkservice/common/discover/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -376,4 +376,123 @@ func TestNoMatchServiceEndpointFound(t *testing.T) {
 	defer cancel()
 	_, err = server.Request(ctx, request)
 	require.Error(t, err)
+}
+
+func TestMatchExactService(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	nsServer := memory.NewNetworkServiceRegistryServer()
+	nseServer := registrynext.NewNetworkServiceEndpointRegistryServer(
+		setid.NewNetworkServiceEndpointRegistryServer(),
+		memory.NewNetworkServiceEndpointRegistryServer(),
+	)
+
+	nsName := networkServiceName()
+	server := next.NewNetworkServiceServer(
+		discover.NewServer(
+			adapters.NetworkServiceServerToClient(nsServer),
+			adapters.NetworkServiceEndpointServerToClient(nseServer)),
+		checkcontext.NewServer(t, func(t *testing.T, ctx context.Context) {
+			nses := discover.Candidates(ctx).Endpoints
+			require.Len(t, nses, 1)
+			require.Equal(t, nsName, nses[0].NetworkServiceNames[0])
+		}),
+	)
+
+	// 1. Register NS, NSE with wrong name
+	wrongNSName := nsName + "-wrong"
+	_, err := nsServer.Register(context.Background(), &registry.NetworkService{
+		Name: wrongNSName,
+	})
+	require.NoError(t, err)
+	_, err = nseServer.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		NetworkServiceNames: []string{wrongNSName},
+	})
+	require.NoError(t, err)
+
+	// 2. Try to discover NSE by the right NS name
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &networkservice.Connection{
+			NetworkService: nsName,
+		},
+	}
+
+	_, err = server.Request(ctx, request.Clone())
+	require.Error(t, err)
+
+	// 3. Register NS, NSE with the right name
+	_, err = nsServer.Register(context.Background(), &registry.NetworkService{
+		Name: nsName,
+	})
+	require.NoError(t, err)
+	_, err = nseServer.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		NetworkServiceNames: []string{nsName},
+	})
+	require.NoError(t, err)
+
+	// 4. Try to discover NSE by the right NS name
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err = server.Request(ctx, request.Clone())
+	require.NoError(t, err)
+}
+
+func TestMatchExactEndpoint(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	nseServer := registrynext.NewNetworkServiceEndpointRegistryServer(
+		setid.NewNetworkServiceEndpointRegistryServer(),
+		memory.NewNetworkServiceEndpointRegistryServer(),
+	)
+
+	nseName := "final-endpoint"
+	u := "tcp://" + nseName
+	server := next.NewNetworkServiceServer(
+		discover.NewServer(
+			adapters.NetworkServiceServerToClient(memory.NewNetworkServiceRegistryServer()),
+			adapters.NetworkServiceEndpointServerToClient(nseServer)),
+		checkcontext.NewServer(t, func(t *testing.T, ctx context.Context) {
+			require.Equal(t, u, clienturlctx.ClientURL(ctx).String())
+		}),
+	)
+
+	// 1. Register NSE with wrong name
+	wrongNSEName := nseName + "-wrong"
+	wrongURL := u + "-wrong"
+	_, err := nseServer.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: wrongNSEName,
+		Url:  wrongURL,
+	})
+	require.NoError(t, err)
+
+	// 2. Try to discover NSE by the right name
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &networkservice.Connection{
+			NetworkServiceEndpointName: nseName,
+		},
+	}
+
+	_, err = server.Request(ctx, request.Clone())
+	require.Error(t, err)
+
+	// 3. Register NSE with the right name
+	_, err = nseServer.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name: nseName,
+		Url:  u,
+	})
+	require.NoError(t, err)
+
+	// 4. Try to discover NSE by the right name
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err = server.Request(ctx, request.Clone())
+	require.NoError(t, err)
 }


### PR DESCRIPTION
# Issue
Registry doesn't use strict name match for NS, NSE find. Discover can receive NS/NSE with invalid name and pass it further to the chain.
# Solution
Make extra name check for NS, NSE on discover.