### PR TITLE
feat: add nsmlabel tool to help developers build NSCs

### DIFF
--- a/pkg/tools/nsmlabel/nsmlabel.go
+++ b/pkg/tools/nsmlabel/nsmlabel.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nsmlabel provides helper function for buildning networkservice.NetworkServiceClient
+package nsmlabel
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/common"
+)
+
+// Parse parses url.URL to tuple of required networkservice.Request parameters
+func Parse(u *url.URL) (mechanism *networkservice.Mechanism, networkService string, labels map[string]string) {
+	labels = make(map[string]string)
+	mechanism = &networkservice.Mechanism{Cls: cls.LOCAL, Type: u.Scheme}
+	for k, values := range u.Query() {
+		labels[k] = strings.Join(values, ",")
+	}
+	networkService = u.Host
+
+	segments := strings.Split(u.Path, "/")
+
+	if len(segments) > 1 {
+		mechanism.Parameters = make(map[string]string)
+		mechanism.Parameters[common.InterfaceNameKey] = segments[len(segments)-1]
+	}
+
+	return mechanism, networkService, labels
+}

--- a/pkg/tools/nsmlabel/nsmlabel_test.go
+++ b/pkg/tools/nsmlabel/nsmlabel_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsmlabel_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/memif"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/vfio"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/nsmlabel"
+)
+
+func must(u *url.URL, err error) *url.URL {
+	if err != nil {
+		panic(err.Error())
+	}
+	return u
+}
+func Test_ParseNSMLabel(t *testing.T) {
+	var samples = []struct {
+		u              *url.URL
+		interfaceName  string
+		networkService string
+		mechanism      string
+		labels         map[string]string
+	}{
+		{
+			u:              must(url.Parse("vfio://my-service/nsm-1")),
+			interfaceName:  "nsm-1",
+			networkService: "my-service",
+			mechanism:      vfio.MECHANISM,
+		},
+		{
+			u:              must(url.Parse("vfio://second-service?sriovToken=intel/10G")),
+			networkService: "second-service",
+			mechanism:      vfio.MECHANISM,
+			labels: map[string]string{
+				"sriovToken": "intel/10G",
+			},
+		},
+		{
+			u:              must(url.Parse("memif://my-vpp-service?A=1&B=2&C=3")),
+			networkService: "my-vpp-service",
+			mechanism:      memif.MECHANISM,
+			labels: map[string]string{
+				"A": "1",
+				"B": "2",
+				"C": "3",
+			},
+		},
+	}
+
+	for _, sample := range samples {
+		m, ns, labels := nsmlabel.Parse(sample.u)
+		require.Equal(t, cls.LOCAL, m.Cls)
+		require.Equal(t, strings.ToLower(sample.mechanism), m.Type)
+		require.Equal(t, sample.networkService, ns)
+		require.Len(t, labels, len(sample.labels))
+		if len(sample.labels) > 0 {
+			require.Equal(t, sample.labels, labels)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

Currently, cmd-nsc config looks over-designed: https://github.com/networkservicemesh/cmd-nsc/blob/master/internal/config/config.go#L47
Moreover, this approach is not expandable. For building new NSC we need to copy a lot of stuff from cmd-nsc.

We should seek to make things simple.

This PR is the first part of reworking cmd-nsc.

