### PR TITLE
Rework memory registry server

### DIFF
--- a/pkg/registry/common/memory/ns_server.go
+++ b/pkg/registry/common/memory/ns_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,113 +18,143 @@ package memory
 
 import (
 	"context"
-	"errors"
 	"io"
 
+	"github.com/edwarnicke/serialize"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/uuid"
-	"github.com/networkservicemesh/api/pkg/api/registry"
 
-	"github.com/edwarnicke/serialize"
+	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/matchutils"
 )
 
-type networkServiceRegistryServer struct {
+type memoryNSServer struct {
 	networkServices  NetworkServiceSyncMap
 	executor         serialize.Executor
 	eventChannels    map[string]chan *registry.NetworkService
 	eventChannelSize int
 }
 
-func (n *networkServiceRegistryServer) Register(ctx context.Context, ns *registry.NetworkService) (*registry.NetworkService, error) {
-	r, err := next.NetworkServiceRegistryServer(ctx).Register(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-	n.networkServices.Store(r.Name, r.Clone())
-	n.executor.AsyncExec(func() {
-		for _, ch := range n.eventChannels {
-			ch <- r.Clone()
-		}
-	})
-	return r, nil
-}
-
-func (n *networkServiceRegistryServer) Find(query *registry.NetworkServiceQuery, s registry.NetworkServiceRegistry_FindServer) error {
-	sendAllMatches := func(ns *registry.NetworkService) error {
-		var err error
-		n.networkServices.Range(func(key string, value *registry.NetworkService) bool {
-			if matchutils.MatchNetworkServices(ns, value) {
-				err = s.Send(value.Clone())
-				return err == nil
-			}
-			return true
-		})
-		return err
-	}
-	if query.Watch {
-		eventCh := make(chan *registry.NetworkService, n.eventChannelSize)
-		id := uuid.New().String()
-		n.executor.AsyncExec(func() {
-			n.eventChannels[id] = eventCh
-		})
-		defer n.executor.AsyncExec(func() {
-			delete(n.eventChannels, id)
-		})
-		err := sendAllMatches(query.NetworkService)
-		if err != nil {
-			return err
-		}
-		notifyChannel := func() error {
-			select {
-			case <-s.Context().Done():
-				return io.EOF
-			case event := <-eventCh:
-				if matchutils.MatchNetworkServices(query.NetworkService, event) {
-					if s.Context().Err() != nil {
-						return io.EOF
-					}
-					if err := s.Send(event); err != nil {
-						return err
-					}
-				}
-				return nil
-			}
-		}
-		for {
-			err := notifyChannel()
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if err != nil {
-				return err
-			}
-		}
-	} else if err := sendAllMatches(query.NetworkService); err != nil {
-		return err
-	}
-	return next.NetworkServiceRegistryServer(s.Context()).Find(query, s)
-}
-
-func (n *networkServiceRegistryServer) Unregister(ctx context.Context, ns *registry.NetworkService) (*empty.Empty, error) {
-	n.networkServices.Delete(ns.Name)
-	return next.NetworkServiceRegistryServer(ctx).Unregister(ctx, ns)
-}
-
-func (n *networkServiceRegistryServer) setEventChannelSize(l int) {
-	n.eventChannelSize = l
-}
-
 // NewNetworkServiceRegistryServer creates new memory based NetworkServiceRegistryServer
 func NewNetworkServiceRegistryServer(options ...Option) registry.NetworkServiceRegistryServer {
-	r := &networkServiceRegistryServer{
+	s := &memoryNSServer{
 		eventChannelSize: defaultEventChannelSize,
 		eventChannels:    make(map[string]chan *registry.NetworkService),
 	}
 	for _, o := range options {
-		o.apply(r)
+		o.apply(s)
 	}
-	return r
+	return s
+}
+
+func (s *memoryNSServer) setEventChannelSize(l int) {
+	s.eventChannelSize = l
+}
+
+func (s *memoryNSServer) Register(ctx context.Context, ns *registry.NetworkService) (*registry.NetworkService, error) {
+	r, err := next.NetworkServiceRegistryServer(ctx).Register(ctx, ns)
+	if err != nil {
+		return nil, err
+	}
+
+	s.networkServices.Store(r.Name, r.Clone())
+
+	s.sendEvent(r)
+
+	return r, nil
+}
+
+func (s *memoryNSServer) sendEvent(event *registry.NetworkService) {
+	event = event.Clone()
+	s.executor.AsyncExec(func() {
+		for _, ch := range s.eventChannels {
+			ch <- event.Clone()
+		}
+	})
+}
+
+func (s *memoryNSServer) Find(query *registry.NetworkServiceQuery, server registry.NetworkServiceRegistry_FindServer) error {
+	if !query.Watch {
+		for _, ns := range s.allMatches(query) {
+			if err := server.Send(ns); err != nil {
+				return err
+			}
+		}
+		return next.NetworkServiceRegistryServer(server.Context()).Find(query, server)
+	}
+
+	eventCh := make(chan *registry.NetworkService, s.eventChannelSize)
+	id := uuid.New().String()
+
+	s.executor.AsyncExec(func() {
+		s.eventChannels[id] = eventCh
+		for _, entity := range s.allMatches(query) {
+			eventCh <- entity
+		}
+	})
+	defer s.closeEventChannel(id, eventCh)
+
+	var err error
+	for ; err == nil; err = s.receiveEvent(query, server, eventCh) {
+	}
+	if err != io.EOF {
+		return err
+	}
+	return next.NetworkServiceRegistryServer(server.Context()).Find(query, server)
+}
+
+func (s *memoryNSServer) allMatches(query *registry.NetworkServiceQuery) (matches []*registry.NetworkService) {
+	s.networkServices.Range(func(_ string, ns *registry.NetworkService) bool {
+		if matchutils.MatchNetworkServices(query.NetworkService, ns) {
+			matches = append(matches, ns.Clone())
+		}
+		return true
+	})
+	return matches
+}
+
+func (s *memoryNSServer) closeEventChannel(id string, eventCh <-chan *registry.NetworkService) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s.executor.AsyncExec(func() {
+		delete(s.eventChannels, id)
+		cancel()
+	})
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-eventCh:
+		}
+	}
+}
+
+func (s *memoryNSServer) receiveEvent(
+	query *registry.NetworkServiceQuery,
+	server registry.NetworkServiceRegistry_FindServer,
+	eventCh <-chan *registry.NetworkService,
+) error {
+	select {
+	case <-server.Context().Done():
+		return io.EOF
+	case event := <-eventCh:
+		if matchutils.MatchNetworkServices(query.NetworkService, event) {
+			if server.Context().Err() != nil {
+				return io.EOF
+			}
+			if err := server.Send(event); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func (s *memoryNSServer) Unregister(ctx context.Context, ns *registry.NetworkService) (*empty.Empty, error) {
+	s.networkServices.Delete(ns.Name)
+
+	return next.NetworkServiceRegistryServer(ctx).Unregister(ctx, ns)
 }

--- a/pkg/registry/common/memory/ns_server_test.go
+++ b/pkg/registry/common/memory/ns_server_test.go
@@ -173,17 +173,13 @@ func TestNetworkServiceRegistryServer_SlowReceiver(t *testing.T) {
 	findCtx, findCancel := context.WithCancel(ctx)
 
 	stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{
-		NetworkService: &registry.NetworkService{Name: "ns-1"},
+		NetworkService: &registry.NetworkService{Name: "ns"},
 		Watch:          true,
 	})
 	require.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
-		var ns *registry.NetworkService
-		ns, err = s.Register(ctx, &registry.NetworkService{Name: "ns-1"})
-		require.NoError(t, err)
-
-		_, err = s.Unregister(ctx, ns)
+	for i := 0; i < 200; i++ {
+		_, err = s.Register(ctx, &registry.NetworkService{Name: fmt.Sprintf("ns-%d", i)})
 		require.NoError(t, err)
 	}
 

--- a/pkg/registry/common/memory/ns_server_test.go
+++ b/pkg/registry/common/memory/ns_server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,14 +18,20 @@ package memory_test
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
 )
@@ -105,4 +111,125 @@ func TestNetworkServiceRegistryServer_RegisterAndFindWatch(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, proto.Equal(expected, <-ch))
+}
+
+func TestNetworkServiceRegistryServer_DataRace(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := memory.NewNetworkServiceRegistryServer()
+
+	go func() {
+		for ctx.Err() == nil {
+			ns, err := s.Register(ctx, &registry.NetworkService{Name: "ns-1"})
+			require.NoError(t, err)
+
+			_, err = s.Unregister(ctx, ns)
+			require.NoError(t, err)
+		}
+	}()
+
+	c := adapters.NetworkServiceServerToClient(s)
+
+	wg := new(sync.WaitGroup)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			findCtx, findCancel := context.WithTimeout(ctx, time.Second)
+			defer findCancel()
+
+			stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{
+				NetworkService: &registry.NetworkService{Name: "ns-1"},
+				Watch:          true,
+			})
+			assert.NoError(t, err)
+
+			for j := 0; j < 100; j++ {
+				ns, err := stream.Recv()
+				assert.NoError(t, err)
+
+				ns.Name = ""
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestNetworkServiceRegistryServer_SlowReceiver(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := memory.NewNetworkServiceRegistryServer()
+
+	c := adapters.NetworkServiceServerToClient(s)
+
+	findCtx, findCancel := context.WithCancel(ctx)
+
+	stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{
+		NetworkService: &registry.NetworkService{Name: "ns-1"},
+		Watch:          true,
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 100; i++ {
+		var ns *registry.NetworkService
+		ns, err = s.Register(ctx, &registry.NetworkService{Name: "ns-1"})
+		require.NoError(t, err)
+
+		_, err = s.Unregister(ctx, ns)
+		require.NoError(t, err)
+	}
+
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	_, err = stream.Recv()
+	require.NoError(t, err)
+
+	findCancel()
+}
+
+func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := memory.NewNetworkServiceRegistryServer()
+
+	c := adapters.NetworkServiceServerToClient(s)
+
+	wg := new(sync.WaitGroup)
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		name := fmt.Sprintf("ns-%d", i)
+
+		go func() {
+			_, err := s.Register(ctx, &registry.NetworkService{Name: name})
+			require.NoError(t, err)
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			findCtx, findCancel := context.WithTimeout(ctx, time.Second)
+			defer findCancel()
+
+			stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{
+				NetworkService: &registry.NetworkService{Name: name},
+				Watch:          true,
+			})
+			assert.NoError(t, err)
+
+			_, err = stream.Recv()
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/registry/common/memory/nse_server.go
+++ b/pkg/registry/common/memory/nse_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,127 +18,149 @@ package memory
 
 import (
 	"context"
-	"errors"
 	"io"
 
+	"github.com/edwarnicke/serialize"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/uuid"
 
-	"github.com/golang/protobuf/ptypes/timestamp"
-
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
-
-	"github.com/edwarnicke/serialize"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/matchutils"
 )
 
-type networkServiceEndpointRegistryServer struct {
+type memoryNSEServer struct {
 	networkServiceEndpoints NetworkServiceEndpointSyncMap
 	executor                serialize.Executor
 	eventChannels           map[string]chan *registry.NetworkServiceEndpoint
 	eventChannelSize        int
 }
 
-func (n *networkServiceEndpointRegistryServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	r, err := next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
-	if err != nil {
-		return nil, err
-	}
-	n.networkServiceEndpoints.Store(r.Name, r.Clone())
-	n.sendEvent(r.Clone())
-	return r, err
-}
-
-func (n *networkServiceEndpointRegistryServer) Find(query *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
-	sendAllMatches := func(ns *registry.NetworkServiceEndpoint) error {
-		var err error
-		n.networkServiceEndpoints.Range(func(key string, value *registry.NetworkServiceEndpoint) bool {
-			if matchutils.MatchNetworkServiceEndpoints(ns, value) {
-				err = s.Send(value.Clone())
-				return err == nil
-			}
-			return true
-		})
-		return err
-	}
-	if query.Watch {
-		eventCh := make(chan *registry.NetworkServiceEndpoint, n.eventChannelSize)
-		id := uuid.New().String()
-		n.executor.AsyncExec(func() {
-			n.eventChannels[id] = eventCh
-		})
-		defer n.executor.AsyncExec(func() {
-			delete(n.eventChannels, id)
-		})
-		err := sendAllMatches(query.NetworkServiceEndpoint)
-		if err != nil {
-			return err
-		}
-		notifyChannel := func() error {
-			select {
-			case <-s.Context().Done():
-				return io.EOF
-			case event := <-eventCh:
-				if matchutils.MatchNetworkServiceEndpoints(query.NetworkServiceEndpoint, event) {
-					if s.Context().Err() != nil {
-						return io.EOF
-					}
-					if err := s.Send(event); err != nil {
-						return err
-					}
-				}
-				return nil
-			}
-		}
-		for {
-			err := notifyChannel()
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if err != nil {
-				return err
-			}
-		}
-	} else if err := sendAllMatches(query.NetworkServiceEndpoint); err != nil {
-		return err
-	}
-	return next.NetworkServiceEndpointRegistryServer(s.Context()).Find(query, s)
-}
-
-func (n *networkServiceEndpointRegistryServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
-	n.networkServiceEndpoints.Delete(nse.Name)
-	if nse.ExpirationTime == nil {
-		nse.ExpirationTime = &timestamp.Timestamp{}
-	}
-	<-n.executor.AsyncExec(func() {
-		nse.ExpirationTime.Seconds = -1
-	})
-	n.sendEvent(nse)
-	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
-}
-
-func (n *networkServiceEndpointRegistryServer) setEventChannelSize(l int) {
-	n.eventChannelSize = l
-}
-
-func (n *networkServiceEndpointRegistryServer) sendEvent(nse *registry.NetworkServiceEndpoint) {
-	n.executor.AsyncExec(func() {
-		for _, ch := range n.eventChannels {
-			ch <- nse
-		}
-	})
-}
-
 // NewNetworkServiceEndpointRegistryServer creates new memory based NetworkServiceEndpointRegistryServer
 func NewNetworkServiceEndpointRegistryServer(options ...Option) registry.NetworkServiceEndpointRegistryServer {
-	r := &networkServiceEndpointRegistryServer{
+	s := &memoryNSEServer{
 		eventChannelSize: defaultEventChannelSize,
 		eventChannels:    make(map[string]chan *registry.NetworkServiceEndpoint),
 	}
 	for _, o := range options {
-		o.apply(r)
+		o.apply(s)
 	}
-	return r
+	return s
+}
+
+func (s *memoryNSEServer) setEventChannelSize(l int) {
+	s.eventChannelSize = l
+}
+
+func (s *memoryNSEServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	r, err := next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
+	if err != nil {
+		return nil, err
+	}
+
+	s.networkServiceEndpoints.Store(r.Name, r.Clone())
+
+	s.sendEvent(r)
+
+	return r, err
+}
+
+func (s *memoryNSEServer) sendEvent(event *registry.NetworkServiceEndpoint) {
+	event = event.Clone()
+	s.executor.AsyncExec(func() {
+		for _, ch := range s.eventChannels {
+			ch <- event.Clone()
+		}
+	})
+}
+
+func (s *memoryNSEServer) Find(query *registry.NetworkServiceEndpointQuery, server registry.NetworkServiceEndpointRegistry_FindServer) error {
+	if !query.Watch {
+		for _, ns := range s.allMatches(query) {
+			if err := server.Send(ns); err != nil {
+				return err
+			}
+		}
+		return next.NetworkServiceEndpointRegistryServer(server.Context()).Find(query, server)
+	}
+
+	eventCh := make(chan *registry.NetworkServiceEndpoint, s.eventChannelSize)
+	id := uuid.New().String()
+
+	s.executor.AsyncExec(func() {
+		s.eventChannels[id] = eventCh
+		for _, entity := range s.allMatches(query) {
+			eventCh <- entity
+		}
+	})
+	defer s.closeEventChannel(id, eventCh)
+
+	var err error
+	for ; err == nil; err = s.receiveEvent(query, server, eventCh) {
+	}
+	if err != io.EOF {
+		return err
+	}
+	return next.NetworkServiceEndpointRegistryServer(server.Context()).Find(query, server)
+}
+
+func (s *memoryNSEServer) allMatches(query *registry.NetworkServiceEndpointQuery) (matches []*registry.NetworkServiceEndpoint) {
+	s.networkServiceEndpoints.Range(func(_ string, nse *registry.NetworkServiceEndpoint) bool {
+		if matchutils.MatchNetworkServiceEndpoints(query.NetworkServiceEndpoint, nse) {
+			matches = append(matches, nse.Clone())
+		}
+		return true
+	})
+	return matches
+}
+
+func (s *memoryNSEServer) closeEventChannel(id string, eventCh <-chan *registry.NetworkServiceEndpoint) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s.executor.AsyncExec(func() {
+		delete(s.eventChannels, id)
+		cancel()
+	})
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-eventCh:
+		}
+	}
+}
+
+func (s *memoryNSEServer) receiveEvent(
+	query *registry.NetworkServiceEndpointQuery,
+	server registry.NetworkServiceEndpointRegistry_FindServer,
+	eventCh <-chan *registry.NetworkServiceEndpoint,
+) error {
+	select {
+	case <-server.Context().Done():
+		return io.EOF
+	case event := <-eventCh:
+		if matchutils.MatchNetworkServiceEndpoints(query.NetworkServiceEndpoint, event) {
+			if server.Context().Err() != nil {
+				return io.EOF
+			}
+			if err := server.Send(event); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func (s *memoryNSEServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	s.networkServiceEndpoints.Delete(nse.Name)
+
+	nse.ExpirationTime = &timestamp.Timestamp{
+		Seconds: -1,
+	}
+	s.sendEvent(nse)
+
+	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
 }

--- a/pkg/registry/common/memory/nse_server_test.go
+++ b/pkg/registry/common/memory/nse_server_test.go
@@ -240,17 +240,13 @@ func TestNetworkServiceEndpointRegistryServer_SlowReceiver(t *testing.T) {
 	findCtx, findCancel := context.WithCancel(ctx)
 
 	stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{
-		NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: "nse-1"},
+		NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: "nse"},
 		Watch:                  true,
 	})
 	require.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
-		var nse *registry.NetworkServiceEndpoint
-		nse, err = s.Register(ctx, &registry.NetworkServiceEndpoint{Name: "nse-1"})
-		require.NoError(t, err)
-
-		_, err = s.Unregister(ctx, nse)
+	for i := 0; i < 200; i++ {
+		_, err = s.Register(ctx, &registry.NetworkServiceEndpoint{Name: fmt.Sprintf("nse-%d", i)})
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
# Issues
There are data races, deadlocks and invalid behavior in both NSE, NS memory registry servers.
# Solution
1. Add unit tests for data races, slow receiver, all Register/Unregister received.
2. Rework NSE, NS memory registry servers.