### PR TITLE
feat: Add mechanisms client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
-	github.com/hashicorp/go-multierror v1.0.0
 	github.com/nats-io/nats-streaming-server v0.17.0
 	github.com/nats-io/stan.go v0.6.0
 	github.com/networkservicemesh/api v0.0.0-20210202152048-ec956057eb3a

--- a/pkg/networkservice/common/mechanisms/client.go
+++ b/pkg/networkservice/common/mechanisms/client.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 )
 
 type mechanismsClient struct {

--- a/pkg/networkservice/common/mechanisms/client.go
+++ b/pkg/networkservice/common/mechanisms/client.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mechanisms
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+type mechanismsClient struct {
+	mechanisms map[string]networkservice.NetworkServiceClient
+}
+
+// NewClient - returns a new mechanisms networkservicemesh.NetworkServiceClient
+func NewClient(mechanisms map[string]networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
+	result := &mechanismsClient{
+		mechanisms: make(map[string]networkservice.NetworkServiceClient),
+	}
+	for m, c := range mechanisms {
+		result.mechanisms[m] = chain.NewNetworkServiceClient(c)
+	}
+
+	return result
+}
+
+func (mc *mechanismsClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	if request.GetConnection().GetMechanism() != nil {
+		srv, ok := mc.mechanisms[request.GetConnection().GetMechanism().GetType()]
+		if ok {
+			return srv.Request(ctx, request)
+		}
+		return nil, errUnsupportedMech
+	}
+	var err = errCannotSupportMech
+	for _, mechanism := range request.GetMechanismPreferences() {
+		cm, ok := mc.mechanisms[mechanism.GetType()]
+		if ok {
+			req := request.Clone()
+			req.GetConnection().Mechanism = mechanism
+			var resp *networkservice.Connection
+			resp, respErr := cm.Request(ctx, req)
+			if respErr == nil {
+				return resp, nil
+			}
+			err = errors.Wrap(err, respErr.Error())
+		}
+	}
+	return nil, err
+}
+
+func (mc *mechanismsClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	c, ok := mc.mechanisms[conn.GetMechanism().GetType()]
+	if ok {
+		return c.Close(ctx, conn)
+	}
+	return nil, errCannotSupportMech
+}

--- a/pkg/networkservice/common/mechanisms/common.go
+++ b/pkg/networkservice/common/mechanisms/common.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mechanisms
+
+import "github.com/pkg/errors"
+
+var errCannotSupportMech = errors.New("cannot support any of the requested mechanism")
+var errUnsupportedMech = errors.New("unsupported mechanism")

--- a/pkg/networkservice/common/mechanisms/server.go
+++ b/pkg/networkservice/common/mechanisms/server.go
@@ -25,8 +25,9 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 )
 
 type mechanismsServer struct {


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

1. This PR adds mechanisms client that can be used in nsc applications to simplify chains.

For example:

This https://github.com/networkservicemesh/cmd-nsc/blob/master/main.go#L125-L185 can be replaced to

```go
client.NewClient(..., 
    mechanisms.NewClient(map[string]networkservice.NetworkServiceClient {
        vfio.MECHANISM: chain.NewNetworkServiceClient(...),
        kernel.MECHANISM: chain.NewNetworkServiceClient(...),
})

```

2. It Fixes a few issues like adding the same error in error: https://github.com/networkservicemesh/sdk/blob/master/pkg/networkservice/common/mechanisms/server.go#L74
3. Removes recurrent dependency.