### PR TITLE
Fix data race in refresh test

### DIFF
--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -123,7 +123,7 @@ func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 	client := next.NewNetworkServiceEndpointRegistryClient(
 		refresh.NewNetworkServiceEndpointRegistryClient(refresh.WithDefaultExpiryDuration(time.Hour)),
 		checknse.NewClient(t, func(t *testing.T, nse *registry.NetworkServiceEndpoint) {
-			if countClient.requestCount > 0 {
+			if atomic.LoadInt32(&countClient.requestCount) > 0 {
 				require.Equal(t, registryServer.name, nse.Name)
 				require.Equal(t, endpoint.Url, nse.Url)
 			}


### PR DESCRIPTION
# Issue
```
==================
WARNING: DATA RACE
Read at 0x00c00000e0e0 by goroutine 20:
  github.com/networkservicemesh/sdk/pkg/registry/common/refresh_test.Test_RefreshNSEClient_ShouldOverrideNameAndDuration.func1()
      /Users/runner/work/sdk/sdk/pkg/registry/common/refresh/nse_registry_client_test.go:126 +0x5e
  github.com/networkservicemesh/sdk/pkg/registry/utils/checks/checknse.(*checkNSEClient).Unregister()
      /Users/runner/work/sdk/sdk/pkg/registry/utils/checks/checknse/nse_client.go:56 +0x8a
  github.com/networkservicemesh/sdk/pkg/registry/core/next.(*nextNetworkServiceEndpointRegistryClient).Unregister()
      /Users/runner/work/sdk/sdk/pkg/registry/core/next/nse_registry_client.go:73 +0x5b7
  github.com/networkservicemesh/sdk/pkg/registry/common/refresh.(*refreshNSEClient).Unregister()
      /Users/runner/work/sdk/sdk/pkg/registry/common/refresh/nse_registry_client.go:139 +0x17d
  github.com/networkservicemesh/sdk/pkg/registry/core/next.(*nextNetworkServiceEndpointRegistryClient).Unregister()
      /Users/runner/work/sdk/sdk/pkg/registry/core/next/nse_registry_client.go:73 +0x5b7
  github.com/networkservicemesh/sdk/pkg/registry/common/refresh_test.Test_RefreshNSEClient_ShouldOverrideNameAndDuration()
      /Users/runner/work/sdk/sdk/pkg/registry/common/refresh/nse_registry_client_test.go:144 +0x8b2
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.15.8/x64/src/testing/testing.go:1123 +0x202

Previous write at 0x00c00000e0e0 by goroutine 21:
  sync/atomic.AddInt32()
      /Users/runner/hostedtoolcache/go/1.15.8/x64/src/runtime/race_amd64.s:269 +0xb
  github.com/networkservicemesh/sdk/pkg/registry/common/refresh_test.(*requestCountClient).Register()
      /Users/runner/work/sdk/sdk/pkg/registry/common/refresh/nse_registry_client_test.go:182 +0x46
  github.com/networkservicemesh/sdk/pkg/registry/core/next.(*nextNetworkServiceEndpointRegistryClient).Register()
      /Users/runner/work/sdk/sdk/pkg/registry/core/next/nse_registry_client.go:60 +0x5b7
  github.com/networkservicemesh/sdk/pkg/registry/utils/checks/checknse.(*checkNSEClient).Register()
      /Users/runner/work/sdk/sdk/pkg/registry/utils/checks/checknse/nse_client.go:48 +0x10a
  github.com/networkservicemesh/sdk/pkg/registry/core/next.(*nextNetworkServiceEndpointRegistryClient).Register()
      /Users/runner/work/sdk/sdk/pkg/registry/core/next/nse_registry_client.go:60 +0x5b7
  github.com/networkservicemesh/sdk/pkg/registry/common/refresh.(*refreshNSEClient).startRefresh.func1()
      /Users/runner/work/sdk/sdk/pkg/registry/common/refresh/nse_registry_client.go:71 +0x3b4

Goroutine 20 (running) created at:
  testing.(*T).Run()
      /Users/runner/hostedtoolcache/go/1.15.8/x64/src/testing/testing.go:1168 +0x5bb
  testing.runTests.func1()
      /Users/runner/hostedtoolcache/go/1.15.8/x64/src/testing/testing.go:1439 +0xa6
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.15.8/x64/src/testing/testing.go:1123 +0x202
  testing.runTests()
      /Users/runner/hostedtoolcache/go/1.15.8/x64/src/testing/testing.go:1437 +0x612
  testing.(*M).Run()
      /Users/runner/hostedtoolcache/go/1.15.8/x64/src/testing/testing.go:1345 +0x3b3
  main.main()
      _testmain.go:53 +0x236

Goroutine 21 (finished) created at:
  github.com/networkservicemesh/sdk/pkg/registry/common/refresh.(*refreshNSEClient).startRefresh()
      /Users/runner/work/sdk/sdk/pkg/registry/common/refresh/nse_registry_client.go:63 +0x2d9
  github.com/networkservicemesh/sdk/pkg/registry/common/refresh.(*refreshNSEClient).Register()
      /Users/runner/work/sdk/sdk/pkg/registry/common/refresh/nse_registry_client.go:116 +0x4d3
  github.com/networkservicemesh/sdk/pkg/registry/core/next.(*nextNetworkServiceEndpointRegistryClient).Register()
      /Users/runner/work/sdk/sdk/pkg/registry/core/next/nse_registry_client.go:60 +0x5b7
  github.com/networkservicemesh/sdk/pkg/registry/common/refresh_test.Test_RefreshNSEClient_ShouldOverrideNameAndDuration()
      /Users/runner/work/sdk/sdk/pkg/registry/common/refresh/nse_registry_client_test.go:135 +0x6da
  testing.tRunner()
      /Users/runner/hostedtoolcache/go/1.15.8/x64/src/testing/testing.go:1123 +0x202
==================
--- FAIL: Test_RefreshNSEClient_ShouldOverrideNameAndDuration (0.39s)
```