### PR TITLE
Fix TestNSMGR_PassThroughLocal

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -516,13 +516,11 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	const registryExpiryDuration = time.Second
-
 	domain := sandbox.NewBuilder(t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
 		SetNodeSetup(nil).
-		SetRegistryExpiryDuration(registryExpiryDuration).
+		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
 		SetContext(ctx).
 		Build()
 	defer domain.Cleanup()
@@ -550,7 +548,7 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. Wait for refresh
-	<-time.After(registryExpiryDuration)
+	<-time.After(sandbox.RegistryExpiryDuration)
 
 	testNSEAndClient(ctx, t, domain, nseReg.Clone())
 
@@ -576,12 +574,10 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	const registryExpiryDuration = time.Second
-
 	domain := sandbox.NewBuilder(t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
-		SetRegistryExpiryDuration(registryExpiryDuration).
+		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
 		SetContext(ctx).
 		Build()
 	defer domain.Cleanup()
@@ -604,7 +600,7 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. Wait for refresh
-	<-time.After(registryExpiryDuration)
+	<-time.After(sandbox.RegistryExpiryDuration)
 
 	// 3. Request
 	_, err = nsc.Request(ctx, &networkservice.NetworkServiceRequest{

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -516,10 +516,13 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
+	const registryExpiryDuration = time.Second
+
 	domain := sandbox.NewBuilder(t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
 		SetNodeSetup(nil).
+		SetRegistryExpiryDuration(registryExpiryDuration).
 		SetContext(ctx).
 		Build()
 	defer domain.Cleanup()
@@ -547,7 +550,7 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. Wait for refresh
-	<-time.After(sandbox.DefaultRegistryExpiryDuration)
+	<-time.After(registryExpiryDuration)
 
 	testNSEAndClient(ctx, t, domain, nseReg.Clone())
 
@@ -573,9 +576,12 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
+	const registryExpiryDuration = time.Second
+
 	domain := sandbox.NewBuilder(t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
+		SetRegistryExpiryDuration(registryExpiryDuration).
 		SetContext(ctx).
 		Build()
 	defer domain.Cleanup()
@@ -598,7 +604,7 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. Wait for refresh
-	<-time.After(sandbox.DefaultRegistryExpiryDuration)
+	<-time.After(registryExpiryDuration)
 
 	// 3. Request
 	_, err = nsc.Request(ctx, &networkservice.NetworkServiceRequest{

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -42,11 +42,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
-const (
-	defaultContextTimeout         = time.Second * 5
-	defaultRegistryExpiryDuration = time.Minute
-)
-
 // Builder implements builder pattern for building NSM Domain
 type Builder struct {
 	require                *require.Assertions
@@ -77,7 +72,7 @@ func NewBuilder(t *testing.T) *Builder {
 		supplyNSMgrProxy:       nsmgrproxy.NewServer,
 		setupNode:              defaultSetupNode(t),
 		generateTokenFunc:      GenerateTestToken,
-		registryExpiryDuration: defaultRegistryExpiryDuration,
+		registryExpiryDuration: time.Minute,
 	}
 }
 
@@ -86,7 +81,7 @@ func (b *Builder) Build() *Domain {
 	ctx := b.ctx
 	if ctx == nil {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), defaultContextTimeout)
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 		b.resources = append(b.resources, cancel)
 	}
 	ctx = log.Join(ctx, log.Empty())

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	defaultContextTimeout         = time.Second * 15
+	defaultContextTimeout         = time.Second * 5
 	defaultRegistryExpiryDuration = time.Minute
 )
 

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -31,6 +31,9 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
+// RegistryExpiryDuration is a duration that should be used for expire tests
+const RegistryExpiryDuration = time.Second
+
 // GenerateTestToken generates test token
 func GenerateTestToken(_ credentials.AuthInfo) (tokenValue string, expireTime time.Time, err error) {
 	return "TestToken", time.Date(3000, 1, 1, 1, 1, 1, 1, time.UTC), nil


### PR DESCRIPTION
# Issue
`expire` timeout is too small for windows, macos - sometimes endpoint becomes unregistered.
# Solution
Increase timeout for most sandbox tests.

Closes #710 