### PR TITLE
Fix memory tests

### DIFF
--- a/pkg/registry/common/memory/common_test.go
+++ b/pkg/registry/common/memory/common_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func wgWait(ctx context.Context, t *testing.T, wg *sync.WaitGroup) {
+	ch := make(chan struct{}, 1)
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-ch:
+	}
+
+	require.NoError(t, ctx.Err())
+}

--- a/pkg/registry/common/memory/ns_server.go
+++ b/pkg/registry/common/memory/ns_server.go
@@ -142,10 +142,10 @@ func (s *memoryNSServer) receiveEvent(
 		return io.EOF
 	case event := <-eventCh:
 		if matchutils.MatchNetworkServices(query.NetworkService, event) {
-			if server.Context().Err() != nil {
-				return io.EOF
-			}
 			if err := server.Send(event); err != nil {
+				if server.Context().Err() != nil {
+					return io.EOF
+				}
 				return err
 			}
 		}

--- a/pkg/registry/common/memory/ns_server_test.go
+++ b/pkg/registry/common/memory/ns_server_test.go
@@ -211,7 +211,7 @@ func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
 	c := adapters.NetworkServiceServerToClient(s)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 300; i++ {
+	for i := 0; i < 200; i++ {
 		wg.Add(1)
 		name := fmt.Sprintf("ns-%d", i)
 
@@ -223,7 +223,7 @@ func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			findCtx, findCancel := context.WithTimeout(ctx, time.Second)
+			findCtx, findCancel := context.WithTimeout(ctx, 2*time.Second)
 			defer findCancel()
 
 			stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{

--- a/pkg/registry/common/memory/ns_server_test.go
+++ b/pkg/registry/common/memory/ns_server_test.go
@@ -203,7 +203,7 @@ func TestNetworkServiceRegistryServer_SlowReceiver(t *testing.T) {
 func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s := memory.NewNetworkServiceRegistryServer()
@@ -211,7 +211,7 @@ func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
 	c := adapters.NetworkServiceServerToClient(s)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 200; i++ {
+	for i := 0; i < 250; i++ {
 		wg.Add(1)
 		name := fmt.Sprintf("ns-%d", i)
 
@@ -223,7 +223,7 @@ func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			findCtx, findCancel := context.WithTimeout(ctx, 2*time.Second)
+			findCtx, findCancel := context.WithCancel(ctx)
 			defer findCancel()
 
 			stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{

--- a/pkg/registry/common/memory/ns_server_test.go
+++ b/pkg/registry/common/memory/ns_server_test.go
@@ -19,6 +19,7 @@ package memory_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -31,7 +32,6 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
-	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
 )
@@ -116,15 +116,13 @@ func TestNetworkServiceRegistryServer_RegisterAndFindWatch(t *testing.T) {
 func TestNetworkServiceRegistryServer_DataRace(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s := memory.NewNetworkServiceRegistryServer()
 
 	_, err := s.Register(ctx, &registry.NetworkService{Name: "ns"})
 	require.NoError(t, err)
-
-	c := adapters.NetworkServiceServerToClient(s)
 
 	var wgStart, wgEnd sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -133,64 +131,70 @@ func TestNetworkServiceRegistryServer_DataRace(t *testing.T) {
 		go func() {
 			defer wgEnd.Done()
 
-			findCtx, findCancel := context.WithTimeout(ctx, time.Second)
+			findCtx, findCancel := context.WithCancel(ctx)
 			defer findCancel()
 
-			stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{
-				NetworkService: &registry.NetworkService{Name: "ns"},
-				Watch:          true,
-			})
-			assert.NoError(t, err)
+			ch := make(chan *registry.NetworkService, 10)
+			go func() {
+				defer close(ch)
+				findErr := s.Find(&registry.NetworkServiceQuery{
+					NetworkService: &registry.NetworkService{Name: "ns"},
+					Watch:          true,
+				}, streamchannel.NewNetworkServiceFindServer(findCtx, ch))
+				assert.NoError(t, findErr)
+			}()
 
-			_, err = stream.Recv()
-			assert.NoError(t, err)
+			_, receiveErr := receiveNS(findCtx, ch)
+			assert.NoError(t, receiveErr)
 
 			wgStart.Done()
 
-			for j := 0; j < 100; j++ {
-				ns, err := stream.Recv()
-				assert.NoError(t, err)
+			for j := 0; j < 50; j++ {
+				nse, receiveErr := receiveNS(findCtx, ch)
+				assert.NoError(t, receiveErr)
 
-				ns.Name = ""
+				nse.Name = ""
 			}
 		}()
 	}
-	wgStart.Wait()
+	wgWait(ctx, t, &wgStart)
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 50; i++ {
 		_, err := s.Register(ctx, &registry.NetworkService{Name: fmt.Sprintf("ns-%d", i)})
 		require.NoError(t, err)
 	}
 
-	wgEnd.Wait()
+	wgWait(ctx, t, &wgEnd)
 }
 
 func TestNetworkServiceRegistryServer_SlowReceiver(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s := memory.NewNetworkServiceRegistryServer()
 
-	c := adapters.NetworkServiceServerToClient(s)
-
 	findCtx, findCancel := context.WithCancel(ctx)
 
-	stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{
-		NetworkService: &registry.NetworkService{Name: "ns"},
-		Watch:          true,
-	})
-	require.NoError(t, err)
+	ch := make(chan *registry.NetworkService, 10)
+	go func() {
+		defer close(ch)
+		findErr := s.Find(&registry.NetworkServiceQuery{
+			NetworkService: &registry.NetworkService{Name: "ns"},
+			Watch:          true,
+		}, streamchannel.NewNetworkServiceFindServer(findCtx, ch))
+		require.NoError(t, findErr)
+	}()
 
-	for i := 0; i < 1000; i++ {
-		_, err = s.Register(ctx, &registry.NetworkService{Name: fmt.Sprintf("ns-%d", i)})
+	for i := 0; i < 50; i++ {
+		_, err := s.Register(ctx, &registry.NetworkService{Name: fmt.Sprintf("ns-%d", i)})
 		require.NoError(t, err)
 	}
 
 	ignoreCurrent := goleak.IgnoreCurrent()
 
-	_, err = stream.Recv()
+	_, err := receiveNS(findCtx, ch)
 	require.NoError(t, err)
 
 	findCancel()
@@ -208,10 +212,8 @@ func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
 
 	s := memory.NewNetworkServiceRegistryServer()
 
-	c := adapters.NetworkServiceServerToClient(s)
-
 	var wg sync.WaitGroup
-	for i := 0; i < 250; i++ {
+	for i := 0; i < 50; i++ {
 		wg.Add(1)
 		name := fmt.Sprintf("ns-%d", i)
 
@@ -226,15 +228,31 @@ func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
 			findCtx, findCancel := context.WithCancel(ctx)
 			defer findCancel()
 
-			stream, err := c.Find(findCtx, &registry.NetworkServiceQuery{
-				NetworkService: &registry.NetworkService{Name: name},
-				Watch:          true,
-			})
-			assert.NoError(t, err)
+			ch := make(chan *registry.NetworkService, 10)
+			go func() {
+				defer close(ch)
+				err := s.Find(&registry.NetworkServiceQuery{
+					NetworkService: &registry.NetworkService{Name: name},
+					Watch:          true,
+				}, streamchannel.NewNetworkServiceFindServer(findCtx, ch))
+				assert.NoError(t, err)
+			}()
 
-			_, err = stream.Recv()
+			_, err := receiveNS(findCtx, ch)
 			assert.NoError(t, err)
 		}()
 	}
-	wg.Wait()
+	wgWait(ctx, t, &wg)
+}
+
+func receiveNS(ctx context.Context, ch <-chan *registry.NetworkService) (*registry.NetworkService, error) {
+	select {
+	case <-ctx.Done():
+		return nil, io.EOF
+	case ns, ok := <-ch:
+		if !ok {
+			return nil, io.EOF
+		}
+		return ns, nil
+	}
 }

--- a/pkg/registry/common/memory/nse_server.go
+++ b/pkg/registry/common/memory/nse_server.go
@@ -143,10 +143,10 @@ func (s *memoryNSEServer) receiveEvent(
 		return io.EOF
 	case event := <-eventCh:
 		if matchutils.MatchNetworkServiceEndpoints(query.NetworkServiceEndpoint, event) {
-			if server.Context().Err() != nil {
-				return io.EOF
-			}
 			if err := server.Send(event); err != nil {
+				if server.Context().Err() != nil {
+					return io.EOF
+				}
 				return err
 			}
 		}

--- a/pkg/registry/common/memory/nse_server_test.go
+++ b/pkg/registry/common/memory/nse_server_test.go
@@ -281,7 +281,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testi
 	c := adapters.NetworkServiceEndpointServerToClient(s)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 300; i++ {
+	for i := 0; i < 200; i++ {
 		wg.Add(1)
 		name := fmt.Sprintf("nse-%d", i)
 
@@ -293,7 +293,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testi
 		go func() {
 			defer wg.Done()
 
-			findCtx, findCancel := context.WithTimeout(ctx, time.Second)
+			findCtx, findCancel := context.WithTimeout(ctx, 2*time.Second)
 			defer findCancel()
 
 			stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{
@@ -317,7 +317,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *tes
 
 	s := memory.NewNetworkServiceEndpointRegistryServer()
 
-	for i := 0; i < 300; i++ {
+	for i := 0; i < 200; i++ {
 		_, err := s.Register(ctx, &registry.NetworkServiceEndpoint{Name: fmt.Sprintf("nse-%d", i)})
 		require.NoError(t, err)
 	}
@@ -325,7 +325,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *tes
 	c := adapters.NetworkServiceEndpointServerToClient(s)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 300; i++ {
+	for i := 0; i < 200; i++ {
 		wg.Add(1)
 		name := fmt.Sprintf("nse-%d", i)
 
@@ -337,7 +337,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *tes
 		go func() {
 			defer wg.Done()
 
-			findCtx, findCancel := context.WithTimeout(ctx, time.Second)
+			findCtx, findCancel := context.WithTimeout(ctx, 2*time.Second)
 			defer findCancel()
 
 			stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{

--- a/pkg/registry/common/memory/nse_server_test.go
+++ b/pkg/registry/common/memory/nse_server_test.go
@@ -273,7 +273,7 @@ func TestNetworkServiceEndpointRegistryServer_SlowReceiver(t *testing.T) {
 func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s := memory.NewNetworkServiceEndpointRegistryServer()
@@ -281,7 +281,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testi
 	c := adapters.NetworkServiceEndpointServerToClient(s)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 200; i++ {
+	for i := 0; i < 250; i++ {
 		wg.Add(1)
 		name := fmt.Sprintf("nse-%d", i)
 
@@ -293,7 +293,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testi
 		go func() {
 			defer wg.Done()
 
-			findCtx, findCancel := context.WithTimeout(ctx, 2*time.Second)
+			findCtx, findCancel := context.WithCancel(ctx)
 			defer findCancel()
 
 			stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{
@@ -312,12 +312,12 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testi
 func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s := memory.NewNetworkServiceEndpointRegistryServer()
 
-	for i := 0; i < 200; i++ {
+	for i := 0; i < 250; i++ {
 		_, err := s.Register(ctx, &registry.NetworkServiceEndpoint{Name: fmt.Sprintf("nse-%d", i)})
 		require.NoError(t, err)
 	}
@@ -325,7 +325,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *tes
 	c := adapters.NetworkServiceEndpointServerToClient(s)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 200; i++ {
+	for i := 0; i < 250; i++ {
 		wg.Add(1)
 		name := fmt.Sprintf("nse-%d", i)
 
@@ -337,7 +337,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *tes
 		go func() {
 			defer wg.Done()
 
-			findCtx, findCancel := context.WithTimeout(ctx, 2*time.Second)
+			findCtx, findCancel := context.WithCancel(ctx)
 			defer findCancel()
 
 			stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{

--- a/pkg/registry/common/memory/nse_server_test.go
+++ b/pkg/registry/common/memory/nse_server_test.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
-	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
 )
@@ -186,15 +185,13 @@ func TestNetworkServiceEndpointRegistryServer_RegisterAndFindByLabelWatch(t *tes
 func TestNetworkServiceEndpointRegistryServer_DataRace(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s := memory.NewNetworkServiceEndpointRegistryServer()
 
 	_, err := s.Register(ctx, &registry.NetworkServiceEndpoint{Name: "nse"})
 	require.NoError(t, err)
-
-	c := adapters.NetworkServiceEndpointServerToClient(s)
 
 	var wgStart, wgEnd sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -203,64 +200,70 @@ func TestNetworkServiceEndpointRegistryServer_DataRace(t *testing.T) {
 		go func() {
 			defer wgEnd.Done()
 
-			findCtx, findCancel := context.WithTimeout(ctx, time.Second)
+			findCtx, findCancel := context.WithCancel(ctx)
 			defer findCancel()
 
-			stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{
-				NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: "nse"},
-				Watch:                  true,
-			})
-			assert.NoError(t, err)
+			ch := make(chan *registry.NetworkServiceEndpoint, 10)
+			go func() {
+				defer close(ch)
+				findErr := s.Find(&registry.NetworkServiceEndpointQuery{
+					NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: "nse"},
+					Watch:                  true,
+				}, streamchannel.NewNetworkServiceEndpointFindServer(findCtx, ch))
+				assert.NoError(t, findErr)
+			}()
 
-			_, err = stream.Recv()
-			assert.NoError(t, err)
+			_, receiveErr := receiveNSE(findCtx, ch)
+			assert.NoError(t, receiveErr)
 
 			wgStart.Done()
 
-			for j := 0; j < 100; j++ {
-				nse, err := stream.Recv()
-				assert.NoError(t, err)
+			for j := 0; j < 50; j++ {
+				nse, receiveErr := receiveNSE(findCtx, ch)
+				assert.NoError(t, receiveErr)
 
 				nse.Name = ""
 			}
 		}()
 	}
-	wgStart.Wait()
+	wgWait(ctx, t, &wgStart)
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 50; i++ {
 		_, err := s.Register(ctx, &registry.NetworkServiceEndpoint{Name: fmt.Sprintf("nse-%d", i)})
 		require.NoError(t, err)
 	}
 
-	wgEnd.Wait()
+	wgWait(ctx, t, &wgEnd)
 }
 
 func TestNetworkServiceEndpointRegistryServer_SlowReceiver(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	s := memory.NewNetworkServiceEndpointRegistryServer()
 
-	c := adapters.NetworkServiceEndpointServerToClient(s)
-
 	findCtx, findCancel := context.WithCancel(ctx)
 
-	stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{
-		NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: "nse"},
-		Watch:                  true,
-	})
-	require.NoError(t, err)
+	ch := make(chan *registry.NetworkServiceEndpoint, 10)
+	go func() {
+		defer close(ch)
+		findErr := s.Find(&registry.NetworkServiceEndpointQuery{
+			NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: "nse"},
+			Watch:                  true,
+		}, streamchannel.NewNetworkServiceEndpointFindServer(findCtx, ch))
+		require.NoError(t, findErr)
+	}()
 
-	for i := 0; i < 1000; i++ {
-		_, err = s.Register(ctx, &registry.NetworkServiceEndpoint{Name: fmt.Sprintf("nse-%d", i)})
+	for i := 0; i < 50; i++ {
+		_, err := s.Register(ctx, &registry.NetworkServiceEndpoint{Name: fmt.Sprintf("nse-%d", i)})
 		require.NoError(t, err)
 	}
 
 	ignoreCurrent := goleak.IgnoreCurrent()
 
-	_, err = stream.Recv()
+	_, err := receiveNSE(findCtx, ch)
 	require.NoError(t, err)
 
 	findCancel()
@@ -278,10 +281,8 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testi
 
 	s := memory.NewNetworkServiceEndpointRegistryServer()
 
-	c := adapters.NetworkServiceEndpointServerToClient(s)
-
 	var wg sync.WaitGroup
-	for i := 0; i < 250; i++ {
+	for i := 0; i < 50; i++ {
 		wg.Add(1)
 		name := fmt.Sprintf("nse-%d", i)
 
@@ -296,17 +297,21 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testi
 			findCtx, findCancel := context.WithCancel(ctx)
 			defer findCancel()
 
-			stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{
-				NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: name},
-				Watch:                  true,
-			})
-			assert.NoError(t, err)
+			ch := make(chan *registry.NetworkServiceEndpoint, 10)
+			go func() {
+				defer close(ch)
+				err := s.Find(&registry.NetworkServiceEndpointQuery{
+					NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: name},
+					Watch:                  true,
+				}, streamchannel.NewNetworkServiceEndpointFindServer(findCtx, ch))
+				assert.NoError(t, err)
+			}()
 
-			_, err = stream.Recv()
+			_, err := receiveNSE(findCtx, ch)
 			assert.NoError(t, err)
 		}()
 	}
-	wg.Wait()
+	wgWait(ctx, t, &wg)
 }
 
 func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *testing.T) {
@@ -317,16 +322,12 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *tes
 
 	s := memory.NewNetworkServiceEndpointRegistryServer()
 
-	for i := 0; i < 250; i++ {
+	for i := 0; i < 50; i++ {
 		_, err := s.Register(ctx, &registry.NetworkServiceEndpoint{Name: fmt.Sprintf("nse-%d", i)})
 		require.NoError(t, err)
 	}
 
-	c := adapters.NetworkServiceEndpointServerToClient(s)
-
-	var wg sync.WaitGroup
-	for i := 0; i < 250; i++ {
-		wg.Add(1)
+	for i := 0; i < 50; i++ {
 		name := fmt.Sprintf("nse-%d", i)
 
 		go func() {
@@ -335,21 +336,24 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *tes
 		}()
 
 		go func() {
-			defer wg.Done()
-
 			findCtx, findCancel := context.WithCancel(ctx)
 			defer findCancel()
 
-			stream, err := c.Find(findCtx, &registry.NetworkServiceEndpointQuery{
-				NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: name},
-				Watch:                  true,
-			})
-			assert.NoError(t, err)
+			ch := make(chan *registry.NetworkServiceEndpoint, 10)
+			go func() {
+				defer close(ch)
+				err := s.Find(&registry.NetworkServiceEndpointQuery{
+					NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: name},
+					Watch:                  true,
+				}, streamchannel.NewNetworkServiceEndpointFindServer(findCtx, ch))
+				assert.NoError(t, err)
+			}()
 
+			var err error
 			exists := false
 			for err == nil {
 				var nse *registry.NetworkServiceEndpoint
-				nse, err = stream.Recv()
+				nse, err = receiveNSE(findCtx, ch)
 				switch {
 				case err != nil:
 					assert.Equal(t, io.EOF, err)
@@ -362,7 +366,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *tes
 			assert.False(t, exists)
 		}()
 	}
-	wg.Wait()
+	<-ctx.Done()
 }
 
 func createLabeledNSE1() *registry.NetworkServiceEndpoint {
@@ -421,5 +425,17 @@ func createLabeledNSE3() *registry.NetworkServiceEndpoint {
 			"Service1",
 		},
 		NetworkServiceLabels: labels,
+	}
+}
+
+func receiveNSE(ctx context.Context, ch <-chan *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	select {
+	case <-ctx.Done():
+		return nil, io.EOF
+	case nse, ok := <-ch:
+		if !ok {
+			return nil, io.EOF
+		}
+		return nse, nil
 	}
 }


### PR DESCRIPTION
# Issue
Sometimes `TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters`, `TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters` fail due to the huge amount of NSEs, low timeout.
# Solution
Reduce amount, increase timeout.