### PR TITLE
fix: kernel client should not add new mechanism if kernel mechanism already added into preference list

### DIFF
--- a/pkg/networkservice/common/mechanisms/kernel/client.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client.go
@@ -37,8 +37,12 @@ type kernelMechanismClient struct {
 }
 
 // NewClient - returns client that sets kernel preferred mechanism
-func NewClient() networkservice.NetworkServiceClient {
-	return new(kernelMechanismClient)
+func NewClient(options ...Option) networkservice.NetworkServiceClient {
+	k := &kernelMechanismClient{}
+	for _, opt := range options {
+		opt(k)
+	}
+	return k
 }
 
 func (k *kernelMechanismClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
@@ -74,4 +78,14 @@ func updateMechanismPreferences(request *networkservice.NetworkServiceRequest) b
 	}
 
 	return updated
+}
+
+// Option for kernel mechanism client
+type Option func(k *kernelMechanismClient)
+
+// WithInterfaceName sets interface name
+func WithInterfaceName(interfaceName string) Option {
+	return func(k *kernelMechanismClient) {
+		k.interfaceName = interfaceName
+	}
 }

--- a/pkg/networkservice/common/mechanisms/kernel/client_test.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client_test.go
@@ -21,10 +21,24 @@ import (
 	"testing"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
 )
+
+func Test_KernelClient_ShouldSetInterfaceName(t *testing.T) {
+	expectedIfaceName := "myiface"
+
+	c := kernel.NewClient(kernel.WithInterfaceName(expectedIfaceName))
+
+	req := &networkservice.NetworkServiceRequest{}
+	_, err := c.Request(context.Background(), req)
+	require.NoError(t, err)
+
+	require.Len(t, req.MechanismPreferences, 1)
+	require.Equal(t, expectedIfaceName, req.MechanismPreferences[0].Parameters[common.InterfaceNameKey])
+}
 
 func Test_KernelClient_ShouldNotDoublingMechanims(t *testing.T) {
 	c := kernel.NewClient()

--- a/pkg/networkservice/common/mechanisms/kernel/client_test.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
+)
+
+func Test_KernelClient_ShouldNotDoublingMechanims(t *testing.T) {
+	c := kernel.NewClient()
+
+	req := &networkservice.NetworkServiceRequest{}
+
+	for i := 0; i < 10; i++ {
+		_, err := c.Request(context.Background(), req)
+		require.NoError(t, err)
+		require.Len(t, req.MechanismPreferences, 1)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

This PR fixes kernel client for #721 