### PR TITLE
fix: authorize client should check tokens on backward

### DIFF
--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -93,12 +93,12 @@ func NewClient(ctx context.Context, cc grpc.ClientConnInterface, clientOpts ...O
 		append(
 			append([]networkservice.NetworkServiceClient{
 				updatepath.NewClient(opts.name),
-				opts.authorizeClient,
 				serialize.NewClient(),
 				heal.NewClient(ctx, networkservice.NewMonitorConnectionClient(cc), opts.onHeal),
 				refresh.NewClient(ctx),
 				metadata.NewClient(),
 			}, opts.additionalFunctionality...),
+			opts.authorizeClient,
 			networkservice.NewNetworkServiceClient(cc),
 		)...)
 	return rv

--- a/pkg/networkservice/common/authorize/client.go
+++ b/pkg/networkservice/common/authorize/client.go
@@ -55,12 +55,11 @@ func (a *authorizeClient) Request(ctx context.Context, request *networkservice.N
 	if *p != (peer.Peer{}) {
 		ctx = peer.NewContext(ctx, p)
 	}
-	if err := a.policies.check(ctx, resp); err != nil {
+	if err = a.policies.check(ctx, resp); err != nil {
 		_, _ = next.Client(ctx).Close(ctx, resp, opts...)
 		return nil, err
 	}
 	return resp, err
-
 }
 
 func (a *authorizeClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {

--- a/pkg/tools/opa/last_token_signed_policy.go
+++ b/pkg/tools/opa/last_token_signed_policy.go
@@ -26,10 +26,20 @@ default index = 0
 index = input.index
 
 last_token_signed {	
+	next_index = index + 1
+	next_index < count(input.path_segments)
+	token := input.path_segments[next_index].token	
+	cert := input.auth_info.certificate	
+	io.jwt.verify_es256(token, cert) = true
+}
+
+last_token_signed {
+	index < count(input.path_segments)
 	token := input.path_segments[index].token	
 	cert := input.auth_info.certificate	
 	io.jwt.verify_es256(token, cert) = true
 }
+
 `
 
 // WithLastTokenSignedPolicy returns default policy for checking that last token in path is signed.

--- a/pkg/tools/opa/last_token_signed_policy_test.go
+++ b/pkg/tools/opa/last_token_signed_policy_test.go
@@ -77,7 +77,6 @@ func Test_LastTokenShouldBeSigned_Server(t *testing.T) {
 	ctx := peer.NewContext(context.Background(), peerAuth)
 
 	for i, input := range samples {
-
 		peerAuth.AuthInfo.(*credentials.TLSInfo).State.PeerCertificates[0] = validX509crt
 
 		err = p.Check(ctx, input)

--- a/pkg/tools/opa/last_token_signed_policy_test.go
+++ b/pkg/tools/opa/last_token_signed_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -31,7 +31,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/opa"
 )
 
-func TestVerifyToken(t *testing.T) {
+func Test_LastTokenShouldBeSigned_Server(t *testing.T) {
 	ca, err := generateCA()
 	require.Nil(t, err)
 
@@ -41,15 +41,25 @@ func TestVerifyToken(t *testing.T) {
 	token, err := jwt.New(jwt.SigningMethodES256).SignedString(cert.PrivateKey)
 	require.Nil(t, err)
 
-	x509crt, err := x509.ParseCertificate(cert.Certificate[0])
+	validX509crt, err := x509.ParseCertificate(cert.Certificate[0])
 	require.Nil(t, err)
 
 	p := opa.WithLastTokenSignedPolicy()
 
-	input := &networkservice.Path{
-		PathSegments: []*networkservice.PathSegment{
-			{
-				Token: token,
+	samples := []*networkservice.Path{
+		{
+			PathSegments: []*networkservice.PathSegment{
+				{
+					Token: token,
+				},
+			},
+		},
+		{
+			PathSegments: []*networkservice.PathSegment{
+				{},
+				{
+					Token: token,
+				},
 			},
 		},
 	}
@@ -58,7 +68,7 @@ func TestVerifyToken(t *testing.T) {
 		AuthInfo: &credentials.TLSInfo{
 			State: tls.ConnectionState{
 				PeerCertificates: []*x509.Certificate{
-					x509crt,
+					validX509crt,
 				},
 			},
 		},
@@ -66,14 +76,19 @@ func TestVerifyToken(t *testing.T) {
 
 	ctx := peer.NewContext(context.Background(), peerAuth)
 
-	err = p.Check(ctx, input)
-	require.Nil(t, err)
+	for i, input := range samples {
 
-	invalidX509crt, err := x509.ParseCertificate(ca.Certificate[0])
-	require.Nil(t, err)
+		peerAuth.AuthInfo.(*credentials.TLSInfo).State.PeerCertificates[0] = validX509crt
 
-	peerAuth.AuthInfo.(*credentials.TLSInfo).State.PeerCertificates[0] = invalidX509crt
+		err = p.Check(ctx, input)
+		require.NoError(t, err, i)
 
-	err = p.Check(ctx, input)
-	require.NotNil(t, err)
+		invalidX509crt, err := x509.ParseCertificate(ca.Certificate[0])
+		require.NoError(t, err)
+
+		peerAuth.AuthInfo.(*credentials.TLSInfo).State.PeerCertificates[0] = invalidX509crt
+
+		err = p.Check(ctx, input)
+		require.Error(t, err)
+	}
 }


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Issue
authorize client should check tokens on backward because on forward it have not server's cert and also it will cover much more cases.
