### PR TITLE
Update go-version 1.15.8 for github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.15.8
       - name: Build
         run: go build -race  ./...
       - name: Test
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.15.8
       - run: go mod tidy
       - name: Check for changes in go.mod or go.sum
         run: |
@@ -92,7 +92,7 @@ jobs:
           version: '3.8.0'
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.15.8
       - name: Install proto-gen-go
         run: go get -u github.com/golang/protobuf/protoc-gen-go@v1.4.2
       - name: Install go-syncmap
@@ -183,7 +183,7 @@ jobs:
           token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.15.8
       - name: Update ${{ github.repository }} locally
         working-directory: networkservicemesh/${{ matrix.repository }}
         run: |


### PR DESCRIPTION
go 1.15.8 has fixes for some major issues (for example issue with `time.After` on Windows platform)

Signed-off-by: Artem Belov <artem.belov@xored.com>