### PR TITLE
Rework setid to call on backward

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -262,3 +262,7 @@ issues:
       linters:
         - structcheck
       text: "is unused"
+    - path: pkg/networkservice/common/discover/server_test.go
+      linters:
+        - dupl
+      text: "lines are duplicate of"

--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -88,7 +88,10 @@ func NewServer(ctx context.Context, nsmRegistration *registryapi.NetworkServiceE
 
 	nseRegistry := newRemoteNSEServer(registryCC)
 	if nseRegistry == nil {
-		nseRegistry = memory.NewNetworkServiceEndpointRegistryServer() // Memory registry to store result inside.
+		nseRegistry = registrychain.NewNetworkServiceEndpointRegistryServer(
+			memory.NewNetworkServiceEndpointRegistryServer(), // Memory registry to store result inside
+			setid.NewNetworkServiceEndpointRegistryServer(),  // Assign ID
+		)
 	}
 
 	localBypassRegistryServer := localbypass.NewNetworkServiceEndpointRegistryServer(nsmRegistration.Url)
@@ -131,12 +134,11 @@ func NewServer(ctx context.Context, nsmRegistration *registryapi.NetworkServiceE
 	nseChain := registrychain.NewNamedNetworkServiceEndpointRegistryServer(
 		nsmRegistration.Name+".NetworkServiceEndpointRegistry",
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
-		setid.NewNetworkServiceEndpointRegistryServer(),          // Assign ID
 		registryrecvfd.NewNetworkServiceEndpointRegistryServer(), // Allow to receive a passed files
 		urlsRegistryServer,        // Store endpoints URLs
 		interposeRegistryServer,   // Store cross connect NSEs
 		localBypassRegistryServer, // Perform URL transformations
-		nseRegistry,               // Register NSE inside Remote registry with ID assigned
+		nseRegistry,               // Register NSE inside Remote registry
 	)
 	rv.Registry = registry.NewServer(nsChain, nseChain)
 

--- a/pkg/registry/chains/memory/server.go
+++ b/pkg/registry/chains/memory/server.go
@@ -38,9 +38,9 @@ import (
 // NewServer creates new registry server based on memory storage
 func NewServer(ctx context.Context, expiryDuration time.Duration, proxyRegistryURL *url.URL, options ...grpc.DialOption) registryserver.Registry {
 	nseChain := chain.NewNetworkServiceEndpointRegistryServer(
-		setid.NewNetworkServiceEndpointRegistryServer(),
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, expiryDuration),
 		memory.NewNetworkServiceEndpointRegistryServer(),
+		setid.NewNetworkServiceEndpointRegistryServer(),
 		proxy.NewNetworkServiceEndpointRegistryServer(proxyRegistryURL),
 		connect.NewNetworkServiceEndpointRegistryServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceEndpointRegistryClient {
 			return chain.NewNetworkServiceEndpointRegistryClient(

--- a/pkg/registry/common/interpose/server.go
+++ b/pkg/registry/common/interpose/server.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -44,6 +45,10 @@ func NewNetworkServiceEndpointRegistryServer(interposeURLs *stringurl.Map) regis
 func (s *interposeRegistryServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
 	if !Is(nse.Name) {
 		return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
+	}
+
+	if _, ok := s.interposeURLs.Load(nse.Name); !ok {
+		nse.Name = interposeName(uuid.New().String())
 	}
 
 	u, err := url.Parse(nse.Url)

--- a/pkg/registry/common/setid/server.go
+++ b/pkg/registry/common/setid/server.go
@@ -39,16 +39,18 @@ func NewNetworkServiceEndpointRegistryServer() registry.NetworkServiceEndpointRe
 }
 
 func (s *setIDServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	if _, ok := s.names.Load(nse.Name); !ok {
-		if nse.Name == "" {
-			nse.Name = strings.Join(nse.NetworkServiceNames, "-")
-		}
-		nse.Name = uuid.New().String() + "-" + nse.Name
-	}
+	name := nse.Name
 
 	reg, err := next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
 	if err != nil {
 		return nil, err
+	}
+
+	if _, ok := s.names.Load(reg.Name); !ok && reg.Name == name {
+		if reg.Name == "" {
+			reg.Name = strings.Join(reg.NetworkServiceNames, "-")
+		}
+		reg.Name = uuid.New().String() + "-" + reg.Name
 	}
 
 	s.names.Store(reg.Name, struct{}{})

--- a/pkg/registry/core/interdomain/interdomain_ns_test.go
+++ b/pkg/registry/core/interdomain/interdomain_ns_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/registry"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/setid"
+	registrychain "github.com/networkservicemesh/sdk/pkg/registry/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
@@ -218,7 +220,13 @@ func TestInterdomainFloatingNetworkServiceRegistry(t *testing.T) {
 	domain3 := sandbox.NewBuilder(t).
 		SetNodesCount(0).
 		SetRegistrySupplier(func(context.Context, time.Duration, *url.URL, ...grpc.DialOption) registry.Registry {
-			return registry.NewServer(memory.NewNetworkServiceRegistryServer(), memory.NewNetworkServiceEndpointRegistryServer())
+			return registry.NewServer(
+				memory.NewNetworkServiceRegistryServer(),
+				registrychain.NewNetworkServiceEndpointRegistryServer(
+					memory.NewNetworkServiceEndpointRegistryServer(),
+					setid.NewNetworkServiceEndpointRegistryServer(),
+				),
+			)
 		}).
 		SetRegistryProxySupplier(nil).
 		Build()

--- a/pkg/registry/core/interdomain/interdomain_nse_test.go
+++ b/pkg/registry/core/interdomain/interdomain_nse_test.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/registry"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/setid"
+	registrychain "github.com/networkservicemesh/sdk/pkg/registry/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
@@ -226,7 +228,13 @@ func TestInterdomainFloatingNetworkServiceEndpointRegistry(t *testing.T) {
 	domain3 := sandbox.NewBuilder(t).
 		SetNodesCount(0).
 		SetRegistrySupplier(func(context.Context, time.Duration, *url.URL, ...grpc.DialOption) registry.Registry {
-			return registry.NewServer(memory.NewNetworkServiceRegistryServer(), memory.NewNetworkServiceEndpointRegistryServer())
+			return registry.NewServer(
+				memory.NewNetworkServiceRegistryServer(),
+				registrychain.NewNetworkServiceEndpointRegistryServer(
+					memory.NewNetworkServiceEndpointRegistryServer(),
+					setid.NewNetworkServiceEndpointRegistryServer(),
+				),
+			)
 		}).
 		SetRegistryProxySupplier(nil).
 		Build()


### PR DESCRIPTION
# Issue
Closes #726.
# Solution
1. Set `nse.Name` on backward if it is unchanged.
2. `interpose` should generate unique names by itself.