### PR TITLE
Fix NSE registry expire refresh failure case

### DIFF
--- a/pkg/registry/common/expire/nse_server.go
+++ b/pkg/registry/common/expire/nse_server.go
@@ -115,10 +115,10 @@ func (n *expireNSEServer) newTimer(
 
 	t.timer = time.AfterFunc(time.Until(expirationTime), func() {
 		t.executor.AsyncExec(func() {
+			t.started = true
 			if t.canceled || n.ctx.Err() != nil {
 				return
 			}
-			t.started = true
 
 			unregisterCtx, cancel := context.WithCancel(n.ctx)
 			defer cancel()


### PR DESCRIPTION
# Issue
Closes #742.
# Solution
Unregister timer should set `started` flag on start.