### PR TITLE
Rework registry NSE expire with timer.AfterFunc

### DIFF
--- a/pkg/registry/common/expire/doc.go
+++ b/pkg/registry/common/expire/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -14,5 +14,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package expire provides wrappers for handling resources time expiration
+// Package expire provides registry server chain elements for unregistering expired endpoints, services
 package expire

--- a/pkg/registry/common/expire/ns_server.go
+++ b/pkg/registry/common/expire/ns_server.go
@@ -43,6 +43,12 @@ type nsState struct {
 	sync.Mutex
 }
 
+// NewNetworkServiceServer monitors endpoints using passed nseClient and unregisters services on all corresponding
+// endpoints expiration
+func NewNetworkServiceServer(ctx context.Context, nseClient registry.NetworkServiceEndpointRegistryClient) registry.NetworkServiceRegistryServer {
+	return &expireNSServer{nseClient: nseClient, chainCtx: ctx}
+}
+
 func (n *expireNSServer) checkUpdates(eventCh <-chan *registry.NetworkServiceEndpoint) {
 	for event := range eventCh {
 		nse := event
@@ -153,9 +159,4 @@ func (n *expireNSServer) Unregister(ctx context.Context, request *registry.Netwo
 	}
 
 	return next.NetworkServiceRegistryServer(ctx).Unregister(ctx, request)
-}
-
-// NewNetworkServiceServer wraps passed NetworkServiceRegistryServer and monitor NetworkServiceEndpoints via passed NetworkServiceEndpointRegistryClient
-func NewNetworkServiceServer(ctx context.Context, nseClient registry.NetworkServiceEndpointRegistryClient) registry.NetworkServiceRegistryServer {
-	return &expireNSServer{nseClient: nseClient, chainCtx: ctx}
 }


### PR DESCRIPTION
# Motivation
`time.AfterFunc` has few issues that have made registry NSE expire overcomplicated. `timer.AfterFunc` was designed to reduce such complicities.