### PR TITLE
Refactor chains/memoryregistry to use Option pattern

### DIFF
--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -32,6 +32,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgrproxy"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
+	"github.com/networkservicemesh/sdk/pkg/registry"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/memory"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/proxydns"
@@ -67,7 +68,7 @@ func NewBuilder(t *testing.T) *Builder {
 		Resolver:               net.DefaultResolver,
 		supplyNSMgr:            nsmgr.NewServer,
 		DNSDomainName:          "cluster.local",
-		supplyRegistry:         memory.NewServer,
+		supplyRegistry:         supplyRegistryMemory(),
 		supplyRegistryProxy:    proxydns.NewServer,
 		supplyNSMgrProxy:       nsmgrproxy.NewServer,
 		setupNode:              defaultSetupNode(t),
@@ -299,5 +300,13 @@ func defaultSetupNode(t *testing.T) SetupNodeFunc {
 		}
 		_, err := node.NewForwarder(ctx, nseReg, GenerateTestToken)
 		require.NoError(t, err)
+	}
+}
+
+func supplyRegistryMemory() SupplyRegistryFunc {
+	return func(ctx context.Context, expiryDuration time.Duration, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry {
+		return memory.NewServer(ctx, proxyRegistryURL,
+			memory.WithExpiryDuration(expiryDuration),
+			memory.WithDialOptions(options...))
 	}
 }


### PR DESCRIPTION
Refactor `chains/memoryregistry` to use Option pattern
Closes #735.

Signed-off-by: Anatoly Loskutnikov <anatoly.loskutnikov@gmail.com>