### PR TITLE
Refactor chains/nsmgrproxy to use Option pattern

### DIFF
--- a/pkg/networkservice/chains/nsmgrproxy/server.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server.go
@@ -22,10 +22,12 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/google/uuid"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/externalips"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/interdomainurl"
@@ -33,18 +35,60 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
+type serverOptions struct {
+	name            string
+	authorizeServer networkservice.NetworkServiceServer
+	dialOptions     []grpc.DialOption
+}
+
+// Option modifies option value
+type Option func(o *serverOptions)
+
+// WithName sets name for the server
+func WithName(name string) Option {
+	return func(o *serverOptions) {
+		o.name = name
+	}
+}
+
+// WithAuthorizeServer sets authorize server for the server
+func WithAuthorizeServer(authorizeServer networkservice.NetworkServiceServer) Option {
+	if authorizeServer == nil {
+		panic("Authorize server cannot be nil")
+	}
+
+	return func(o *serverOptions) {
+		o.authorizeServer = authorizeServer
+	}
+}
+
+// WithDialOptions sets gRPC Dial Options for the server
+func WithDialOptions(options ...grpc.DialOption) Option {
+	return func(o *serverOptions) {
+		o.dialOptions = options
+	}
+}
+
 // NewServer creates new proxy NSMgr
-func NewServer(ctx context.Context, name string, authorizeServer networkservice.NetworkServiceServer, tokenGenerator token.GeneratorFunc, options ...grpc.DialOption) endpoint.Endpoint {
+func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...Option) endpoint.Endpoint {
+	opts := &serverOptions{
+		name:            "nsmgr-proxy-" + uuid.New().String(),
+		authorizeServer: authorize.NewServer(authorize.Any()),
+	}
+	for _, opt := range options {
+		opt(opts)
+	}
+
 	return endpoint.NewServer(ctx, tokenGenerator,
-		endpoint.WithName(name),
-		endpoint.WithAuthorizeServer(authorizeServer),
+		endpoint.WithName(opts.name),
+		endpoint.WithAuthorizeServer(opts.authorizeServer),
 		endpoint.WithAdditionalFunctionality(
 			interdomainurl.NewServer(),
 			externalips.NewServer(ctx),
 			swapip.NewServer(),
 			connect.NewServer(ctx,
-				client.NewClientFactory(client.WithName(name)),
-				connect.WithDialOptions(options...),
+				client.NewClientFactory(client.WithName(opts.name)),
+				connect.WithDialOptions(opts.dialOptions...),
 			),
 		),
 	)

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -188,7 +188,9 @@ func (b *Builder) newNSMgrProxy(ctx context.Context) *EndpointEntry {
 		return nil
 	}
 	name := "nsmgr-proxy-" + uuid.New().String()
-	mgr := b.supplyNSMgrProxy(ctx, name, authorize.NewServer(authorize.Any()), b.generateTokenFunc, DefaultDialOptions(b.generateTokenFunc)...)
+	mgr := b.supplyNSMgrProxy(ctx, b.generateTokenFunc,
+		nsmgrproxy.WithName(name),
+		nsmgrproxy.WithDialOptions(DefaultDialOptions(b.generateTokenFunc)...))
 	serveURL := &url.URL{Scheme: "tcp", Host: "127.0.0.1:0"}
 	serve(ctx, serveURL, mgr.Register)
 	log.FromContext(ctx).Infof("%v listen on: %v", name, serveURL)

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -27,13 +27,14 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgrproxy"
 	"github.com/networkservicemesh/sdk/pkg/registry"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/dnsresolve"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
 // SupplyNSMgrProxyFunc nsmgr proxy
-type SupplyNSMgrProxyFunc func(context.Context, string, networkservice.NetworkServiceServer, token.GeneratorFunc, ...grpc.DialOption) endpoint.Endpoint
+type SupplyNSMgrProxyFunc func(context.Context, token.GeneratorFunc, ...nsmgrproxy.Option) endpoint.Endpoint
 
 // SupplyNSMgrFunc supplies NSMGR
 type SupplyNSMgrFunc func(context.Context, *registryapi.NetworkServiceEndpoint, networkservice.NetworkServiceServer, token.GeneratorFunc, grpc.ClientConnInterface, ...grpc.DialOption) nsmgr.Nsmgr


### PR DESCRIPTION
Refactor `chains/nsmgrproxy` to use Option pattern
Closes #736.

Signed-off-by: Anatoly Loskutnikov <anatoly.loskutnikov@gmail.com>