### PR TITLE
Fix localbypass NSE registry server

### DIFF
--- a/pkg/registry/common/localbypass/server.go
+++ b/pkg/registry/common/localbypass/server.go
@@ -21,7 +21,6 @@ package localbypass
 import (
 	"context"
 	"net/url"
-	"sync"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
@@ -29,29 +28,28 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/stringurl"
 )
 
 type localBypassNSEServer struct {
-	url        string
-	nseURLs    stringurl.Map
-	processing int
-	cond       *sync.Cond
-	lock       *sync.RWMutex
+	nsmgrURL string
+	nseURLs  stringurl.Map
 }
 
 // NewNetworkServiceEndpointRegistryServer creates new instance of NetworkServiceEndpointRegistryServer which sets
 // NSMgr URL to endpoints on registration and sets back endpoints URLs on find
-func NewNetworkServiceEndpointRegistryServer(u string) registry.NetworkServiceEndpointRegistryServer {
-	lock := new(sync.RWMutex)
+func NewNetworkServiceEndpointRegistryServer(nsmgrURL string) registry.NetworkServiceEndpointRegistryServer {
 	return &localBypassNSEServer{
-		url:  u,
-		cond: sync.NewCond(lock.RLocker()),
-		lock: lock,
+		nsmgrURL: nsmgrURL,
 	}
 }
 
+// TODO: this is totally incorrect if there are concurrent events for the same nse.Name, think about adding
+//       serialize into the registry chain
 func (s *localBypassNSEServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	logger := log.FromContext(ctx).WithField("localBypassNSEServer", "Register")
+
 	u, err := url.Parse(nse.Url)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot register NSE with passed URL: %s", nse.Url)
@@ -60,32 +58,32 @@ func (s *localBypassNSEServer) Register(ctx context.Context, nse *registry.Netwo
 		return nil, errors.Errorf("cannot register NSE with passed URL: %s", nse.Url)
 	}
 
-	nse.Url = s.url
+	nse.Url = s.nsmgrURL
 
-	if _, ok := s.nseURLs.Load(nse.Name); !ok {
-		s.lock.Lock()
-		s.processing++
-		s.lock.Unlock()
-
-		defer func() {
-			s.lock.Lock()
-			s.processing--
-			s.lock.Unlock()
-
-			s.cond.Broadcast()
-		}()
-	}
-
-	nse, err = next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
+	// We cannot store `nse.Name` -> `nse.Url` mapping at the moment, because we will have `nse.Name` only after
+	// `next.Register` call.
+	reg, err := next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
 	if err != nil {
 		return nil, err
 	}
 
-	nse.Url = u.String()
+	name := reg.Name
+	s.nseURLs.Store(name, u)
 
-	s.nseURLs.Store(nse.Name, u)
+	// Now we already have nse registered and so we have `reg.Name` -> `nse.Url` mapping stored, but we possibly may
+	// have filtered out Register update event in `localBypassNSEFindServer.Send`, so we need to refresh the
+	// registration to produce such update event again.
+	reg, err = next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, reg)
+	if err != nil {
+		if _, unregisterErr := next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, reg); unregisterErr != nil {
+			logger.Errorf("failed to unregister endpoint on error: %s", unregisterErr.Error())
+		}
+		return nil, errors.Wrapf(err, "failed to refresh endpoint registration: %s", name)
+	}
 
-	return nse, nil
+	reg.Url = u.String()
+
+	return reg, nil
 }
 
 func (s *localBypassNSEServer) Find(query *registry.NetworkServiceEndpointQuery, server registry.NetworkServiceEndpointRegistry_FindServer) error {
@@ -96,7 +94,7 @@ func (s *localBypassNSEServer) Find(query *registry.NetworkServiceEndpointQuery,
 }
 
 func (s *localBypassNSEServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
-	nse.Url = s.url
+	nse.Url = s.nsmgrURL
 
 	_, err := next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
 


### PR DESCRIPTION
# Intro
When endpoint registers on NSMgr, NSMgr stores its URL locally and passes NSE registration with URL replaced to NSMgr URL in `localbypass` NSE server chain element.
```
Endpoint  -Register->  NSMgr    : { URL: nseURL }
NSMgr     -Register->  Registry : { URL: nsmgrURL }
```
When NSMgr needs to find the endpoint, localbypass replaces URL back:
```
NSMgr (localbypass)  <-Find-  Registry            : { URL: nsmgrURL }
NSMgr                <-Find-  NSMgr (localbypass) : { URL: nseURL }
```
`localbypass` can't store `name -> URL` mapping before passing NSE registration to the next, because it doesn't yet have `name`. So there is a moment in time when NSE is already stored in Registry but not yet exists in `localbypass` mappings.

# Issue
Sometimes we can get locally registered NSE with `{ URL: nsmgrURL }` from `Find`.

# Solution
#770 