### PR TITLE
Fix data race in connect client

### DIFF
--- a/pkg/networkservice/common/connect/client.go
+++ b/pkg/networkservice/common/connect/client.go
@@ -56,8 +56,10 @@ func (u *connectClient) init() error {
 		ctx, cancel := context.WithTimeout(u.ctx, u.dialTimeout)
 		defer cancel()
 
+		dialOptions := append(append([]grpc.DialOption{}, u.dialOptions...), grpc.WithReturnConnectionError())
+
 		var cc *grpc.ClientConn
-		cc, u.dialErr = grpc.DialContext(ctx, grpcutils.URLToTarget(clientURL), append(u.dialOptions, grpc.WithReturnConnectionError())...)
+		cc, u.dialErr = grpc.DialContext(ctx, grpcutils.URLToTarget(clientURL), dialOptions...)
 		if u.dialErr != nil {
 			return
 		}


### PR DESCRIPTION
# Issue
Such code results in a data race, because `u.dialOptions` is the same slice for all connect clients.
```go
append(u.dialOptions, grpc.WithReturnConnectionError())
```

# Solution
```go
append(append([]grpc.DialOption{}, u.dialOptions...), grpc.WithReturnConnectionError())
```