### PR TITLE
refactor: Remove Cleanup api from sandbox.Domain

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server_heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_heal_test.go
@@ -50,7 +50,7 @@ func TestNSMGR_HealEndpointRestored(t *testing.T) {
 }
 
 func testNSMGRHealEndpoint(t *testing.T, restored bool) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 
 	defer cancel()
@@ -59,7 +59,6 @@ func testNSMGRHealEndpoint(t *testing.T, restored bool) {
 		SetRegistryProxySupplier(nil).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	expireTime := timestamppb.New(time.Now().Add(time.Second))
 	nseReg := &registry.NetworkServiceEndpoint{
@@ -185,7 +184,7 @@ func TestNSMGR_HealRemoteForwarderRestored(t *testing.T) {
 }
 
 func testNSMGRHealForwarder(t *testing.T, nodeNum int, restored bool, customConfig []*sandbox.NodeConfig, forwarderCtxCancel context.CancelFunc) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -196,7 +195,6 @@ func testNSMGRHealForwarder(t *testing.T, nodeNum int, restored bool, customConf
 		SetContext(ctx).
 		SetCustomConfig(customConfig).
 		Build()
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",
@@ -295,7 +293,7 @@ func TestNSMGR_HealRemoteNSMgrRestored(t *testing.T) {
 }
 
 func testNSMGRHealNSMgr(t *testing.T, nodeNum int, customConfig []*sandbox.NodeConfig, nsmgrCtxCancel context.CancelFunc) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -306,7 +304,6 @@ func testNSMGRHealNSMgr(t *testing.T, nodeNum int, customConfig []*sandbox.NodeC
 		SetContext(ctx).
 		SetCustomConfig(customConfig).
 		Build()
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",
@@ -376,7 +373,7 @@ func testNSMGRHealNSMgr(t *testing.T, nodeNum int, customConfig []*sandbox.NodeC
 }
 
 func TestNSMGR_HealRemoteNSMgr(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsmgrCtx, nsmgrCtxCancel := context.WithTimeout(context.Background(), time.Second)
 	defer nsmgrCtxCancel()
@@ -399,7 +396,6 @@ func TestNSMGR_HealRemoteNSMgr(t *testing.T) {
 		SetContext(ctx).
 		SetCustomConfig(customConfig).
 		Build()
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",
@@ -456,7 +452,7 @@ func TestNSMGR_HealRemoteNSMgr(t *testing.T) {
 }
 
 func TestNSMGR_CloseHeal(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -466,7 +462,6 @@ func TestNSMGR_CloseHeal(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -51,7 +51,7 @@ import (
 )
 
 func TestNSMGR_RemoteUsecase_Parallel(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -61,7 +61,6 @@ func TestNSMGR_RemoteUsecase_Parallel(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	counter := &counterServer{}
 
@@ -112,7 +111,7 @@ func TestNSMGR_RemoteUsecase_Parallel(t *testing.T) {
 }
 
 func TestNSMGR_SelectsRestartingEndpoint(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -122,7 +121,6 @@ func TestNSMGR_SelectsRestartingEndpoint(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -172,7 +170,7 @@ func TestNSMGR_SelectsRestartingEndpoint(t *testing.T) {
 }
 
 func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -182,7 +180,6 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	counter := new(counterServer)
 
@@ -240,7 +237,7 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 }
 
 func TestNSMGR_RemoteUsecase(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -250,7 +247,6 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",
@@ -300,7 +296,7 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 }
 
 func TestNSMGR_ConnectToDeadNSE(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
@@ -309,7 +305,6 @@ func TestNSMGR_ConnectToDeadNSE(t *testing.T) {
 		SetContext(ctx).
 		SetRegistryProxySupplier(nil).
 		Build()
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",
@@ -352,7 +347,7 @@ func TestNSMGR_ConnectToDeadNSE(t *testing.T) {
 }
 
 func TestNSMGR_LocalUsecase(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -363,8 +358,6 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
 		Build()
-
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",
@@ -413,7 +406,7 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 }
 
 func TestNSMGR_PassThroughRemote(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -424,7 +417,6 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 		SetContext(ctx).
 		SetRegistryProxySupplier(nil).
 		Build()
-	defer domain.Cleanup()
 
 	for i := 0; i < nodesCount; i++ {
 		var additionalFunctionality []networkservice.NetworkServiceServer
@@ -473,7 +465,7 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 }
 
 func TestNSMGR_PassThroughLocal(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -484,7 +476,6 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 		SetContext(ctx).
 		SetRegistryProxySupplier(nil).
 		Build()
-	defer domain.Cleanup()
 
 	for i := 0; i < nsesCount; i++ {
 		var additionalFunctionality []networkservice.NetworkServiceServer
@@ -532,7 +523,7 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 }
 
 func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -544,7 +535,6 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	forwarderReg := &registry.NetworkServiceEndpoint{
 		Name: "forwarder",
@@ -590,7 +580,7 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 }
 
 func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -601,7 +591,6 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name: "endpoint",
@@ -647,7 +636,7 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 }
 
 func TestNSMGR_ShouldCleanAllClientAndEndpointGoroutines(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -657,11 +646,9 @@ func TestNSMGR_ShouldCleanAllClientAndEndpointGoroutines(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		SetContext(ctx).
 		Build()
-	defer domain.Cleanup()
 
 	// We have lazy initialization in some chain elements in both networkservice, registry chains. So registering an
 	// endpoint and requesting it from client can result in new endless NSMgr goroutines.
-
 	testNSEAndClient(ctx, t, domain, &registry.NetworkServiceEndpoint{
 		Name:                "endpoint-init",
 		NetworkServiceNames: []string{"service-init"},
@@ -672,9 +659,6 @@ func TestNSMGR_ShouldCleanAllClientAndEndpointGoroutines(t *testing.T) {
 	//   1. GRPC request context cancel
 	//   2. NSC connection close
 	//   3. NSE unregister
-
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
-
 	testNSEAndClient(ctx, t, domain, &registry.NetworkServiceEndpoint{
 		Name:                "endpoint-final",
 		NetworkServiceNames: []string{"service-final"},
@@ -822,7 +806,7 @@ func TestNSMGR_LocalUsecaseNoURL(t *testing.T) {
 		t.Skip("Unix sockets are not supported under windows, skipping")
 		return
 	}
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -834,8 +818,6 @@ func TestNSMGR_LocalUsecaseNoURL(t *testing.T) {
 		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
 		Build()
-
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestNSMGR_InterdomainUseCase(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	const remoteRegistryDomain = "domain2.local.registry"
 
@@ -47,14 +47,12 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		SetContext(ctx).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain1.Cleanup()
 
 	domain2 := sandbox.NewBuilder(t).
 		SetNodesCount(1).
 		SetDNSResolver(dnsServer).
 		SetContext(ctx).
 		Build()
-	defer domain2.Cleanup()
 
 	require.NoError(t, dnsServer.Register(remoteRegistryDomain, domain2.Registry.URL))
 

--- a/pkg/networkservice/common/authorize/server_test.go
+++ b/pkg/networkservice/common/authorize/server_test.go
@@ -59,7 +59,7 @@ func requestWithToken(token string) *networkservice.NetworkServiceRequest {
 }
 
 func TestAuthzEndpoint(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	suits := []struct {
 		name     string
 		policy   authorize.Policy

--- a/pkg/networkservice/common/clientinfo/client_test.go
+++ b/pkg/networkservice/common/clientinfo/client_test.go
@@ -50,7 +50,7 @@ func unsetEnvs(envs map[string]string) error {
 }
 
 func TestLabelsMapNotPresent(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	envs := map[string]string{
 		"NODE_NAME":    "AAA",
 		"POD_NAME":     "BBB",
@@ -79,7 +79,7 @@ func TestLabelsMapNotPresent(t *testing.T) {
 }
 
 func TestLabelsOverwritten(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	envs := map[string]string{
 		"NODE_NAME":    "AAA",
 		"POD_NAME":     "BBB",
@@ -116,7 +116,7 @@ func TestLabelsOverwritten(t *testing.T) {
 }
 
 func TestSomeEnvsNotPresent(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	envs := map[string]string{
 		"CLUSTER_NAME": "CCC",
 	}

--- a/pkg/networkservice/common/clienturl/server_test.go
+++ b/pkg/networkservice/common/clienturl/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,7 +34,7 @@ import (
 )
 
 func TestAddURLInEmptyContext(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	clientURL := &url.URL{
 		Scheme: "ipv4",
 		Path:   "192.168.0.1",
@@ -50,7 +50,7 @@ func TestAddURLInEmptyContext(t *testing.T) {
 }
 
 func TestOverwriteURL(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	clientURL := &url.URL{
 		Scheme: "ipv4",
 		Path:   "192.168.0.1",
@@ -73,7 +73,7 @@ func TestOverwriteURL(t *testing.T) {
 }
 
 func TestOverwriteURLByNil(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	var clientURL *url.URL = nil
 	previousURL := &url.URL{
 		Scheme: "unix",

--- a/pkg/networkservice/common/connect/server_test.go
+++ b/pkg/networkservice/common/connect/server_test.go
@@ -115,7 +115,7 @@ func waitServerStopped(target *url.URL) error {
 }
 
 func TestConnectServer_Request(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 1. Create connectServer
 
@@ -168,7 +168,7 @@ func TestConnectServer_Request(t *testing.T) {
 	require.NoError(t, waitServerStarted(urlA))
 	require.NoError(t, waitServerStarted(urlB))
 
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 4. Create request
 
@@ -247,7 +247,7 @@ func TestConnectServer_Request(t *testing.T) {
 }
 
 func TestConnectServer_RequestParallel(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 1. Create connectServer
 
@@ -281,7 +281,7 @@ func TestConnectServer_RequestParallel(t *testing.T) {
 
 	require.NoError(t, waitServerStarted(urlA))
 
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 4. Request A
 
@@ -342,7 +342,7 @@ func TestConnectServer_RequestParallel(t *testing.T) {
 }
 
 func TestConnectServer_RequestFail(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 1. Create connectServer
 
@@ -366,11 +366,11 @@ func TestConnectServer_RequestFail(t *testing.T) {
 
 	require.NoError(t, waitServerStarted(urlA))
 
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 3. Create request
 
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
@@ -388,7 +388,7 @@ func TestConnectServer_RequestFail(t *testing.T) {
 }
 
 func TestConnectServer_RequestNextServerError(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 1. Create connectServer
 
@@ -455,7 +455,7 @@ func TestConnectServer_RequestNextServerError(t *testing.T) {
 }
 
 func TestConnectServer_RemoteRestarted(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 1. Create connectServer
 
@@ -539,7 +539,7 @@ func TestConnectServer_RemoteRestarted(t *testing.T) {
 }
 
 func TestConnectServer_DialTimeout(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 1. Create connectServer
 

--- a/pkg/networkservice/common/discover/server_test.go
+++ b/pkg/networkservice/common/discover/server_test.go
@@ -155,7 +155,7 @@ func testServers(
 }
 
 func TestMatchEmptySourceSelector(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsName := networkServiceName()
 
@@ -186,7 +186,7 @@ func TestMatchEmptySourceSelector(t *testing.T) {
 }
 
 func TestMatchNonEmptySourceSelector(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsName := networkServiceName()
 
@@ -219,7 +219,7 @@ func TestMatchNonEmptySourceSelector(t *testing.T) {
 }
 
 func TestMatchEmptySourceSelectorGoingFirst(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsName := networkServiceName()
 
@@ -252,7 +252,7 @@ func TestMatchEmptySourceSelectorGoingFirst(t *testing.T) {
 }
 
 func TestMatchNothing(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsName := networkServiceName()
 
@@ -280,7 +280,7 @@ func TestMatchNothing(t *testing.T) {
 }
 
 func TestMatchSelectedNSE(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsName := networkServiceName()
 	nses := endpoints()
@@ -305,7 +305,7 @@ func TestMatchSelectedNSE(t *testing.T) {
 }
 
 func TestNoMatchServiceFound(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsName := networkServiceName()
 
@@ -340,7 +340,7 @@ func TestNoMatchServiceFound(t *testing.T) {
 }
 
 func TestNoMatchServiceEndpointFound(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsName := networkServiceName()
 
@@ -374,7 +374,7 @@ func TestNoMatchServiceEndpointFound(t *testing.T) {
 }
 
 func TestMatchExactService(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsServer, nseServer := testServers(t, "", []*registry.NetworkServiceEndpoint{})
 
@@ -435,7 +435,7 @@ func TestMatchExactService(t *testing.T) {
 }
 
 func TestMatchExactEndpoint(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nseServer := memory.NewNetworkServiceEndpointRegistryServer()
 
@@ -488,7 +488,7 @@ func TestMatchExactEndpoint(t *testing.T) {
 }
 
 func TestMatchSelectedNSESecondAttempt(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	nsServer := memory.NewNetworkServiceRegistryServer()
 	nseServer := registrynext.NewNetworkServiceEndpointRegistryServer(

--- a/pkg/networkservice/common/externalips/server_test.go
+++ b/pkg/networkservice/common/externalips/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -36,7 +36,7 @@ import (
 )
 
 func TestExternalIPsServer_SourceModifying(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	timeout := time.After(time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -78,7 +78,7 @@ func TestExternalIPsServer_SourceModifying(t *testing.T) {
 }
 
 func TestExternalIPsServer_NoFile(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tmpPath := path.Join(os.TempDir(), t.Name())

--- a/pkg/networkservice/common/heal/server_test.go
+++ b/pkg/networkservice/common/heal/server_test.go
@@ -55,7 +55,7 @@ func (t *testOnHeal) Close(ctx context.Context, in *networkservice.Connection, o
 }
 
 func TestHealClient_Request(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	eventCh := make(chan *networkservice.ConnectionEvent, 1)
 	defer close(eventCh)
 
@@ -113,7 +113,7 @@ func TestHealClient_Request(t *testing.T) {
 }
 
 func TestHealClient_EmptyInit(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	eventCh := make(chan *networkservice.ConnectionEvent, 1)
 	defer close(eventCh)
 

--- a/pkg/networkservice/common/mechanisms/client_test.go
+++ b/pkg/networkservice/common/mechanisms/client_test.go
@@ -54,7 +54,7 @@ func client() networkservice.NetworkServiceClient {
 }
 
 func Test_Client_DontSelectMechanismIfSet(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	c := client()
 	for _, request := range permuteOverMechanismPreferenceOrder(request()) {
 		request.Connection = &networkservice.Connection{Mechanism: request.GetMechanismPreferences()[len(request.GetMechanismPreferences())-1]}
@@ -67,7 +67,7 @@ func Test_Client_DontSelectMechanismIfSet(t *testing.T) {
 }
 
 func Test_Client_UnsupportedMechanismPreference(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	request := request()
 	request.MechanismPreferences = []*networkservice.Mechanism{
 		{Cls: "NOT_A_CLS", Type: "NOT_A_TYPE"},
@@ -80,7 +80,7 @@ func Test_Client_UnsupportedMechanismPreference(t *testing.T) {
 }
 
 func Test_Client_UnsupportedMechanism(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	request := request()
 	request.GetConnection().Mechanism = &networkservice.Mechanism{
 		Cls:  "NOT_A_CLS",
@@ -94,7 +94,7 @@ func Test_Client_UnsupportedMechanism(t *testing.T) {
 }
 
 func Test_Client_DownstreamError(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	request := request()
 	request.GetConnection().Mechanism = &networkservice.Mechanism{
 		Cls:  cls.LOCAL,
@@ -111,7 +111,7 @@ func Test_Client_DownstreamError(t *testing.T) {
 }
 
 func Test_Client_FewWrongMechanisms(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	var unsupportedErr = errors.New("unsupported")
 
@@ -148,7 +148,7 @@ func Test_Client_FewWrongMechanisms(t *testing.T) {
 }
 
 func Test_Client_DontCallNextByItself(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ch := make(chan struct{}, 10)
 	c := next.NewNetworkServiceClient(

--- a/pkg/networkservice/common/mechanisms/server_test.go
+++ b/pkg/networkservice/common/mechanisms/server_test.go
@@ -97,7 +97,7 @@ func permuteOverMechanismPreferenceOrder(request *networkservice.NetworkServiceR
 }
 
 func TestSelectMechanism(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	server := server()
 	for _, request := range permuteOverMechanismPreferenceOrder(request()) {
 		assert.Nil(t, request.GetConnection().GetMechanism(), "SelectMechanismContract requires request.GetConnection().GetMechanism() nil")
@@ -114,7 +114,7 @@ func TestSelectMechanism(t *testing.T) {
 }
 
 func TestDontSelectMechanismIfSet(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	server := server()
 	for _, request := range permuteOverMechanismPreferenceOrder(request()) {
 		request.Connection = &networkservice.Connection{Mechanism: request.GetMechanismPreferences()[len(request.GetMechanismPreferences())-1]}
@@ -128,7 +128,7 @@ func TestDontSelectMechanismIfSet(t *testing.T) {
 }
 
 func TestUnsupportedMechanismPreference(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	request := request()
 	request.MechanismPreferences = []*networkservice.Mechanism{
 		{Cls: "NOT_A_CLS", Type: "NOT_A_TYPE"},
@@ -141,7 +141,7 @@ func TestUnsupportedMechanismPreference(t *testing.T) {
 }
 
 func TestUnsupportedMechanism(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	request := request()
 	request.GetConnection().Mechanism = &networkservice.Mechanism{
 		Cls:  "NOT_A_CLS",
@@ -155,7 +155,7 @@ func TestUnsupportedMechanism(t *testing.T) {
 }
 
 func TestDownstreamError(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	request := request()
 	request.GetConnection().Mechanism = &networkservice.Mechanism{
 		Cls:  cls.LOCAL,
@@ -172,7 +172,7 @@ func TestDownstreamError(t *testing.T) {
 }
 
 func TestFewWrongMechanisms(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	var unsupportedErr = errors.New("unsupported")
 
@@ -206,7 +206,7 @@ func TestFewWrongMechanisms(t *testing.T) {
 }
 
 func TestDontCallNextByItself(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ch := make(chan struct{}, 10)
 	server := next.NewNetworkServiceServer(

--- a/pkg/networkservice/common/monitor/server_test.go
+++ b/pkg/networkservice/common/monitor/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2021 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -30,7 +30,7 @@ import (
 )
 
 func TestMonitor(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	// Specify pathSegments to test
 	segmentNames := []string{"local-nsm", "remote-nsm"}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -52,7 +52,7 @@ const (
 )
 
 func TestRefreshClient_ValidRefresh(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -92,7 +92,7 @@ func TestRefreshClient_ValidRefresh(t *testing.T) {
 }
 
 func TestRefreshClient_StopRefreshAtClose(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -126,7 +126,7 @@ func TestRefreshClient_StopRefreshAtClose(t *testing.T) {
 }
 
 func TestRefreshClient_RestartsRefreshAtAnotherRequest(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -171,7 +171,7 @@ type stressTestConfig struct {
 }
 
 func TestRefreshClient_CheckRaceConditions(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	conf := &stressTestConfig{
 		name:          "RaceConditions",
@@ -198,7 +198,7 @@ func TestRefreshClient_CheckRaceConditions(t *testing.T) {
 }
 
 func TestRefreshClient_Sandbox(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), sandboxTotalTimeout)
 	defer cancel()
@@ -209,7 +209,6 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		SetTokenGenerateFunc(sandbox.GenerateTestToken).
 		Build()
-	defer domain.Cleanup()
 
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint",

--- a/pkg/networkservice/common/roundrobin/round_robin_selector_test.go
+++ b/pkg/networkservice/common/roundrobin/round_robin_selector_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 VMware, Inc.
+// Copyright (c) 2019-2021 VMware, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -226,7 +226,7 @@ var tests = []rrtests{
 }
 
 func Test_roundRobinSelector_SelectEndpoint(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	rr := newRoundRobinSelector()
 	for _, tt := range tests {
 		if got := rr.selectEndpoint(tt.args.ns, tt.args.networkServiceEndpoints); !proto.Equal(got, tt.want) {

--- a/pkg/networkservice/common/serialize/server_test.go
+++ b/pkg/networkservice/common/serialize/server_test.go
@@ -48,7 +48,7 @@ func testRequest(id string) *networkservice.NetworkServiceRequest {
 }
 
 func TestSerializeServer_StressTest(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/networkservice/common/timeout/server_test.go
+++ b/pkg/networkservice/common/timeout/server_test.go
@@ -191,7 +191,7 @@ func TestTimeoutServer_StressTest(t *testing.T) {
 }
 
 func TestTimeoutServer_RefreshFailure(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/networkservice/common/updatepath/common_test.go
+++ b/pkg/networkservice/common/updatepath/common_test.go
@@ -97,7 +97,9 @@ var samples = []*sample{
 	{
 		name: "NoPathNoID",
 		test: func(t *testing.T, newUpdatePathServer func(name string) networkservice.NetworkServiceServer) {
-			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			t.Cleanup(func() {
+				goleak.VerifyNone(t)
+			})
 
 			server := newUpdatePathServer(nse1)
 
@@ -113,7 +115,9 @@ var samples = []*sample{
 	{
 		name: "NoPath",
 		test: func(t *testing.T, newUpdatePathServer func(name string) networkservice.NetworkServiceServer) {
-			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			t.Cleanup(func() {
+				goleak.VerifyNone(t)
+			})
 
 			server := newUpdatePathServer(nse1)
 
@@ -131,7 +135,9 @@ var samples = []*sample{
 	{
 		name: "SameNameDifferentID",
 		test: func(t *testing.T, newUpdatePathServer func(name string) networkservice.NetworkServiceServer) {
-			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			t.Cleanup(func() {
+				goleak.VerifyNone(t)
+			})
 
 			server := newUpdatePathServer(nse2)
 
@@ -147,7 +153,9 @@ var samples = []*sample{
 	{
 		name: "DifferentNameInvalidID",
 		test: func(t *testing.T, newUpdatePathServer func(name string) networkservice.NetworkServiceServer) {
-			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			t.Cleanup(func() {
+				goleak.VerifyNone(t)
+			})
 
 			server := newUpdatePathServer(nse3)
 
@@ -158,7 +166,9 @@ var samples = []*sample{
 	{
 		name: "InvalidIndex",
 		test: func(t *testing.T, newUpdatePathServer func(name string) networkservice.NetworkServiceServer) {
-			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			t.Cleanup(func() {
+				goleak.VerifyNone(t)
+			})
 
 			server := newUpdatePathServer(nse3)
 
@@ -169,7 +179,9 @@ var samples = []*sample{
 	{
 		name: "DifferentNextName",
 		test: func(t *testing.T, newUpdatePathServer func(name string) networkservice.NetworkServiceServer) {
-			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			t.Cleanup(func() {
+				goleak.VerifyNone(t)
+			})
 
 			var connPath *networkservice.Path
 			server := next.NewNetworkServiceServer(
@@ -198,7 +210,9 @@ var samples = []*sample{
 	{
 		name: "NoNextAvailable",
 		test: func(t *testing.T, newUpdatePathServer func(name string) networkservice.NetworkServiceServer) {
-			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			t.Cleanup(func() {
+				goleak.VerifyNone(t)
+			})
 
 			var connPath *networkservice.Path
 			server := next.NewNetworkServiceServer(
@@ -224,7 +238,9 @@ var samples = []*sample{
 	{
 		name: "SameNextName",
 		test: func(t *testing.T, newUpdatePathServer func(name string) networkservice.NetworkServiceServer) {
-			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+			t.Cleanup(func() {
+				goleak.VerifyNone(t)
+			})
 
 			server := next.NewNetworkServiceServer(
 				newUpdatePathServer(nse3),

--- a/pkg/networkservice/common/updatetoken/server_test.go
+++ b/pkg/networkservice/common/updatetoken/server_test.go
@@ -60,7 +60,7 @@ func (f *updateTokenServerSuite) SetupSuite() {
 
 func (f *updateTokenServerSuite) TestNewServer_EmptyPathInRequest() {
 	t := f.T()
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	server := next.NewNetworkServiceServer(updatepath.NewServer("nsc-1"), updatetoken.NewServer(TokenGenerator))
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
@@ -75,7 +75,7 @@ func (f *updateTokenServerSuite) TestNewServer_EmptyPathInRequest() {
 
 func (f *updateTokenServerSuite) TestNewServer_IndexInLastPositionAddNewSegment() {
 	t := f.T()
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
 			Id: "conn-1",
@@ -104,7 +104,7 @@ func (f *updateTokenServerSuite) TestNewServer_IndexInLastPositionAddNewSegment(
 
 func (f *updateTokenServerSuite) TestNewServer_ValidIndexOverwriteValues() {
 	t := f.T()
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
@@ -138,7 +138,7 @@ func (f *updateTokenServerSuite) TestNewServer_ValidIndexOverwriteValues() {
 }
 
 func TestNewServer_IndexGreaterThanArrayLength(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
 			Id: "conn-1",

--- a/pkg/registry/common/expire/ns_server_test.go
+++ b/pkg/registry/common/expire/ns_server_test.go
@@ -36,7 +36,7 @@ import (
 const testPeriod = time.Millisecond * 200
 
 func TestExpireNSServer_NSE_Expired(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -86,7 +86,7 @@ func TestExpireNSServer_NSE_Expired(t *testing.T) {
 }
 
 func TestExpireNSServer_NSE_UnregisterdBeforeExpired(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -140,7 +140,7 @@ func TestExpireNSServer_NSE_UnregisterdBeforeExpired(t *testing.T) {
 }
 
 func TestExpireNSServer_NSEServerSendsExpirationUpdate(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	nseMem := next.NewNetworkServiceEndpointRegistryServer(

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		expire.NewNetworkServiceEndpointRegistryServer(context.Background(), time.Hour),
@@ -53,7 +53,7 @@ func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testin
 }
 
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		expire.NewNetworkServiceEndpointRegistryServer(context.Background(), time.Hour),
@@ -82,7 +82,7 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing
 }
 
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		expire.NewNetworkServiceEndpointRegistryServer(context.Background(), time.Hour),
@@ -97,7 +97,7 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {
 }
 
 func TestExpireNSEServer_ShouldRemoveNSEAfterExpirationTime(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		expire.NewNetworkServiceEndpointRegistryServer(context.Background(), testPeriod*2),
@@ -129,7 +129,7 @@ func TestExpireNSEServer_ShouldRemoveNSEAfterExpirationTime(t *testing.T) {
 }
 
 func TestExpireNSEServer_DataRace(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 
@@ -161,7 +161,7 @@ func TestExpireNSEServer_DataRace(t *testing.T) {
 }
 
 func TestExpireNSEServer_RefreshFailure(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -191,7 +191,7 @@ func TestExpireNSEServer_RefreshFailure(t *testing.T) {
 }
 
 func TestExpireNSEServer_RefreshKeepsNoUnregister(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/registry/common/localbypass/server_test.go
+++ b/pkg/registry/common/localbypass/server_test.go
@@ -37,7 +37,7 @@ const (
 )
 
 func TestLocalBypassNSEServer(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 

--- a/pkg/registry/common/memory/ns_server_test.go
+++ b/pkg/registry/common/memory/ns_server_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func TestNetworkServiceRegistryServer_RegisterAndFind(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	s := next.NewNetworkServiceRegistryServer(memory.NewNetworkServiceRegistryServer())
 
 	_, err := s.Register(context.Background(), &registry.NetworkService{
@@ -71,7 +71,7 @@ func TestNetworkServiceRegistryServer_RegisterAndFind(t *testing.T) {
 }
 
 func TestNetworkServiceRegistryServer_RegisterAndFindWatch(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	s := next.NewNetworkServiceRegistryServer(memory.NewNetworkServiceRegistryServer())
 
 	_, err := s.Register(context.Background(), &registry.NetworkService{
@@ -114,7 +114,7 @@ func TestNetworkServiceRegistryServer_RegisterAndFindWatch(t *testing.T) {
 }
 
 func TestNetworkServiceRegistryServer_DataRace(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -168,7 +168,7 @@ func TestNetworkServiceRegistryServer_DataRace(t *testing.T) {
 }
 
 func TestNetworkServiceRegistryServer_SlowReceiver(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -205,7 +205,7 @@ func TestNetworkServiceRegistryServer_SlowReceiver(t *testing.T) {
 }
 
 func TestNetworkServiceRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/pkg/registry/common/memory/nse_server_test.go
+++ b/pkg/registry/common/memory/nse_server_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestNetworkServiceEndpointRegistryServer_RegisterAndFind(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	s := next.NewNetworkServiceEndpointRegistryServer(memory.NewNetworkServiceEndpointRegistryServer())
 
 	_, err := s.Register(context.Background(), &registry.NetworkServiceEndpoint{
@@ -69,7 +69,7 @@ func TestNetworkServiceEndpointRegistryServer_RegisterAndFind(t *testing.T) {
 }
 
 func TestNetworkServiceEndpointRegistryServer_RegisterAndFindWatch(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	s := next.NewNetworkServiceEndpointRegistryServer(memory.NewNetworkServiceEndpointRegistryServer())
 
 	_, err := s.Register(context.Background(), &registry.NetworkServiceEndpoint{
@@ -112,7 +112,7 @@ func TestNetworkServiceEndpointRegistryServer_RegisterAndFindWatch(t *testing.T)
 }
 
 func TestNetworkServiceEndpointRegistryServer_RegisterAndFindByLabel(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	s := next.NewNetworkServiceEndpointRegistryServer(memory.NewNetworkServiceEndpointRegistryServer())
 
 	_, err := s.Register(context.Background(), createLabeledNSE1())
@@ -144,7 +144,7 @@ func TestNetworkServiceEndpointRegistryServer_RegisterAndFindByLabel(t *testing.
 }
 
 func TestNetworkServiceEndpointRegistryServer_RegisterAndFindByLabelWatch(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	s := next.NewNetworkServiceEndpointRegistryServer(memory.NewNetworkServiceEndpointRegistryServer())
 
 	_, err := s.Register(context.Background(), createLabeledNSE1())
@@ -183,7 +183,7 @@ func TestNetworkServiceEndpointRegistryServer_RegisterAndFindByLabelWatch(t *tes
 }
 
 func TestNetworkServiceEndpointRegistryServer_DataRace(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -237,7 +237,7 @@ func TestNetworkServiceEndpointRegistryServer_DataRace(t *testing.T) {
 }
 
 func TestNetworkServiceEndpointRegistryServer_SlowReceiver(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -274,7 +274,7 @@ func TestNetworkServiceEndpointRegistryServer_SlowReceiver(t *testing.T) {
 }
 
 func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -315,7 +315,7 @@ func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllRegisters(t *testi
 }
 
 func TestNetworkServiceEndpointRegistryServer_ShouldReceiveAllUnregisters(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/pkg/registry/common/querycache/nse_client_test.go
+++ b/pkg/registry/common/querycache/nse_client_test.go
@@ -51,7 +51,7 @@ func testNSEQuery(nseName string) *registry.NetworkServiceEndpointQuery {
 }
 
 func Test_QueryCacheClient_ShouldCacheNSEs(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -72,7 +72,7 @@ func Test_QueryCacheClient_ShouldCacheNSEs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Goroutines should be cleaned up on NSE unregister
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 1. Find from memory
 	stream, err := c.Find(ctx, testNSEQuery(""))
@@ -124,7 +124,7 @@ func Test_QueryCacheClient_ShouldCacheNSEs(t *testing.T) {
 }
 
 func Test_QueryCacheClient_ShouldCleanUpOnTimeout(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -144,7 +144,7 @@ func Test_QueryCacheClient_ShouldCleanUpOnTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	// Goroutines should be cleaned up on cache entry expiration
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	// 1. Find from memory
 	stream, err := c.Find(ctx, testNSEQuery(""))

--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -46,7 +46,7 @@ func testNSE() *registry.NetworkServiceEndpoint {
 }
 
 func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -68,7 +68,7 @@ func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
 }
 
 func TestRefreshNSEClient_ShouldSetExpirationTime_BeforeCallNext(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	client := next.NewNetworkServiceEndpointRegistryClient(
 		refresh.NewNetworkServiceEndpointRegistryClient(refresh.WithDefaultExpiryDuration(time.Hour)),
@@ -85,7 +85,7 @@ func TestRefreshNSEClient_ShouldSetExpirationTime_BeforeCallNext(t *testing.T) {
 }
 
 func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -108,7 +108,7 @@ func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
 }
 
 func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	endpoint := &registry.NetworkServiceEndpoint{
 		Name: "nse-1",
@@ -146,7 +146,7 @@ func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 }
 
 func Test_RefreshNSEClient_SetsCorrectExpireTime(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	const expiryDuration = 100 * time.Millisecond
 	const timeoutDuration = 200 * time.Millisecond

--- a/pkg/registry/common/serialize/nse_server_test.go
+++ b/pkg/registry/common/serialize/nse_server_test.go
@@ -40,7 +40,7 @@ const (
 )
 
 func TestSerializeNSEServer_StressTest(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/registry/core/interdomain/interdomain_ns_test.go
+++ b/pkg/registry/core/interdomain/interdomain_ns_test.go
@@ -50,7 +50,7 @@ import (
 	____________________________________         ___________________
 */
 func TestInterdomainNetworkServiceRegistry(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	const localRegistryDomain = "domain1.local.registry"
 	const proxyRegistryDomain = "domain1.local.registry.proxy"
@@ -66,14 +66,12 @@ func TestInterdomainNetworkServiceRegistry(t *testing.T) {
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain1.Cleanup()
 
 	domain2 := sandbox.NewBuilder(t).
 		SetContext(ctx).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain2.Cleanup()
 
 	require.NoError(t, dnsServer.Register(localRegistryDomain, domain1.Registry.URL))
 	require.NoError(t, dnsServer.Register(proxyRegistryDomain, domain1.RegistryProxy.URL))
@@ -125,7 +123,7 @@ func TestInterdomainNetworkServiceRegistry(t *testing.T) {
 	_____________________________________
 */
 func TestLocalDomain_NetworkServiceRegistry(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	const localRegistryDomain = "domain1.local.registry"
 
@@ -140,7 +138,6 @@ func TestLocalDomain_NetworkServiceRegistry(t *testing.T) {
 		SetDNSDomainName(localRegistryDomain).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain1.Cleanup()
 
 	require.NoError(t, dnsServer.Register(localRegistryDomain, domain1.Registry.URL))
 
@@ -190,7 +187,7 @@ func TestLocalDomain_NetworkServiceRegistry(t *testing.T) {
 */
 
 func TestInterdomainFloatingNetworkServiceRegistry(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	const localRegistryDomain = "domain1.local.registry"
 	const proxyRegistryDomain = "domain1.proxy.registry"
@@ -208,14 +205,12 @@ func TestInterdomainFloatingNetworkServiceRegistry(t *testing.T) {
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain1.Cleanup()
 
 	domain2 := sandbox.NewBuilder(t).
 		SetContext(ctx).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain2.Cleanup()
 
 	domain3 := sandbox.NewBuilder(t).
 		SetNodesCount(0).
@@ -230,7 +225,6 @@ func TestInterdomainFloatingNetworkServiceRegistry(t *testing.T) {
 		}).
 		SetRegistryProxySupplier(nil).
 		Build()
-	defer domain3.Cleanup()
 
 	require.NoError(t, dnsServer.Register(localRegistryDomain, domain1.Registry.URL))
 	require.NoError(t, dnsServer.Register(proxyRegistryDomain, domain1.RegistryProxy.URL))

--- a/pkg/registry/core/interdomain/interdomain_nse_test.go
+++ b/pkg/registry/core/interdomain/interdomain_nse_test.go
@@ -53,7 +53,7 @@ import (
 	____________________________________         ___________________
 */
 func TestInterdomainNetworkServiceEndpointRegistry(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	const remoteRegistryDomain = "domain2.local.registry"
 
@@ -67,14 +67,12 @@ func TestInterdomainNetworkServiceEndpointRegistry(t *testing.T) {
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain1.Cleanup()
 
 	domain2 := sandbox.NewBuilder(t).
 		SetContext(ctx).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain2.Cleanup()
 
 	require.NoError(t, dnsServer.Register(remoteRegistryDomain, domain2.Registry.URL))
 
@@ -129,7 +127,7 @@ func TestInterdomainNetworkServiceEndpointRegistry(t *testing.T) {
 	_____________________________________
 */
 func TestLocalDomain_NetworkServiceEndpointRegistry(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	const localRegistryDomain = "domain1.local.registry"
 
@@ -144,7 +142,6 @@ func TestLocalDomain_NetworkServiceEndpointRegistry(t *testing.T) {
 		SetDNSDomainName(localRegistryDomain).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain1.Cleanup()
 
 	require.NoError(t, dnsServer.Register(localRegistryDomain, domain1.Registry.URL))
 
@@ -200,7 +197,7 @@ func TestLocalDomain_NetworkServiceEndpointRegistry(t *testing.T) {
 */
 
 func TestInterdomainFloatingNetworkServiceEndpointRegistry(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	const remoteRegistryDomain = "domain3.local.registry"
 	const remoteProxyRegistryDomain = "domain3.proxy.registry"
@@ -216,14 +213,12 @@ func TestInterdomainFloatingNetworkServiceEndpointRegistry(t *testing.T) {
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain1.Cleanup()
 
 	domain2 := sandbox.NewBuilder(t).
 		SetContext(ctx).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
-	defer domain2.Cleanup()
 
 	domain3 := sandbox.NewBuilder(t).
 		SetNodesCount(0).
@@ -238,7 +233,6 @@ func TestInterdomainFloatingNetworkServiceEndpointRegistry(t *testing.T) {
 		}).
 		SetRegistryProxySupplier(nil).
 		Build()
-	defer domain3.Cleanup()
 
 	require.NoError(t, dnsServer.Register(remoteRegistryDomain, domain2.Registry.URL))
 	require.NoError(t, dnsServer.Register(remoteProxyRegistryDomain, domain2.RegistryProxy.URL))

--- a/pkg/tools/clockmock/mock_test.go
+++ b/pkg/tools/clockmock/mock_test.go
@@ -35,7 +35,7 @@ const (
 )
 
 func TestMock_Timer(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -65,7 +65,7 @@ func TestMock_Timer(t *testing.T) {
 }
 
 func TestMock_Timer_Stop(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -84,7 +84,7 @@ func TestMock_Timer_Stop(t *testing.T) {
 }
 
 func TestMock_Timer_StopResult(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -97,7 +97,7 @@ func TestMock_Timer_StopResult(t *testing.T) {
 }
 
 func TestMock_Timer_Reset(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -126,7 +126,7 @@ func TestMock_Timer_Reset(t *testing.T) {
 }
 
 func TestMock_Timer_ResetExpired(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -156,7 +156,7 @@ func TestMock_Timer_ResetExpired(t *testing.T) {
 }
 
 func TestMock_AfterFunc(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -185,7 +185,7 @@ func TestMock_AfterFunc(t *testing.T) {
 }
 
 func TestMock_AfterFunc_Ticker(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -217,7 +217,7 @@ func TestMock_AfterFunc_Ticker(t *testing.T) {
 }
 
 func TestMock_WithDeadline(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -242,7 +242,7 @@ func TestMock_WithDeadline(t *testing.T) {
 }
 
 func TestMock_WithDeadline_Expired(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -258,7 +258,7 @@ func TestMock_WithDeadline_Expired(t *testing.T) {
 }
 
 func TestMock_WithDeadline_ParentCanceled(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 
@@ -285,7 +285,7 @@ func TestMock_WithDeadline_ParentCanceled(t *testing.T) {
 }
 
 func TestMock_WithTimeout(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	m := clockmock.NewMock()
 

--- a/pkg/tools/grpcutils/listen_and_serve_test.go
+++ b/pkg/tools/grpcutils/listen_and_serve_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -32,7 +32,7 @@ import (
 )
 
 func TestListenAndServe_NotExistsFolder(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	dir, err := ioutil.TempDir(os.TempDir(), t.Name())
 	require.NoError(t, err)
 	defer func() {
@@ -49,7 +49,7 @@ func TestListenAndServe_NotExistsFolder(t *testing.T) {
 }
 
 func TestListenAndServe_ExistSocket(t *testing.T) {
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	dir, err := ioutil.TempDir(os.TempDir(), t.Name())
 	require.NoError(t, err)
 	defer func() {

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -63,6 +63,7 @@ type Builder struct {
 	generateTokenFunc      token.GeneratorFunc
 	registryExpiryDuration time.Duration
 	ctx                    context.Context
+	t                      *testing.T
 
 	useUnixSockets bool
 	sockPath       string
@@ -83,6 +84,7 @@ func NewBuilder(t *testing.T) *Builder {
 		setupNode:              defaultSetupNode(t),
 		generateTokenFunc:      GenerateTestToken,
 		registryExpiryDuration: time.Minute,
+		t:                      t,
 
 		useUnixSockets: false,
 	}
@@ -123,6 +125,8 @@ func (b *Builder) Build() *Domain {
 	}
 
 	domain.resources, b.resources = b.resources, nil
+
+	b.t.Cleanup(domain.cleanup)
 
 	return domain
 }

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -91,7 +91,7 @@ func (d *Domain) AddResources(resources []context.CancelFunc) {
 }
 
 // Cleanup frees all resources related to the domain
-func (d *Domain) Cleanup() {
+func (d *Domain) cleanup() {
 	for _, r := range d.resources {
 		r()
 	}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

## Motivation

This PR:
1. Hides domain.Cleanup API, we do not need more to call `domain.Cleanup` in each test.
2. Removes use of the option `goleak.IgnoreCurrent()` because all tests currently should not produce goleaks.