### PR TITLE
[sdk#740] Rework sandbox

### DIFF
--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -71,7 +71,9 @@ func testNSMGRHealEndpoint(t *testing.T, nodeNum int) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
-	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
@@ -155,7 +157,9 @@ func testNSMGRHealForwarder(t *testing.T, nodeNum int) {
 		}).
 		Build()
 
-	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	counter := &counterServer{}
@@ -249,7 +253,9 @@ func testNSMGRHealNSMgr(t *testing.T, nodeNum int, restored bool) {
 		}).
 		Build()
 
-	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
@@ -338,7 +344,9 @@ func TestNSMGR_CloseHeal(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
-	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseCtx, nseCtxCancel := context.WithCancel(ctx)

--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -14,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package nsmgr_test define a tests for NSMGR chain element.
 package nsmgr_test
 
 import (
@@ -23,10 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
@@ -36,16 +37,38 @@ const (
 	timeout = 10 * time.Second
 )
 
-func TestNSMGRHealEndpoint(t *testing.T) {
+func TestNSMGR_HealEndpoint(t *testing.T) {
+	var samples = []struct {
+		name    string
+		nodeNum int
+	}{
+		{
+			name:    "Local New",
+			nodeNum: 0,
+		},
+		{
+			name:    "Remote New",
+			nodeNum: 1,
+		},
+	}
+
+	for _, sample := range samples {
+		t.Run(sample.name, func(t *testing.T) {
+			// nolint:scopelint
+			testNSMGRHealEndpoint(t, sample.nodeNum)
+		})
+	}
+}
+
+func testNSMGRHealEndpoint(t *testing.T, nodeNum int) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
-		SetNodesCount(2).
+	defer cancel()
+	domain := sandbox.NewBuilder(ctx, t).
+		SetNodesCount(nodeNum + 1).
+		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
@@ -56,12 +79,11 @@ func TestNSMGRHealEndpoint(t *testing.T) {
 	nseCtx, nseCtxCancel := context.WithCancel(context.Background())
 
 	counter := &counterServer{}
-	_, err = domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[nodeNum].NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, counter)
 
 	request := defaultRequest(nsReg.Name)
 
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -71,8 +93,7 @@ func TestNSMGRHealEndpoint(t *testing.T) {
 
 	nseReg2 := defaultRegistryEndpoint(nsReg.Name)
 	nseReg2.Name += "-2"
-	_, err = domain.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[nodeNum].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, counter)
 
 	// Wait reconnecting to the new NSE
 	require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
@@ -91,59 +112,58 @@ func TestNSMGRHealEndpoint(t *testing.T) {
 	require.Equal(t, 1, counter.UniqueCloses())
 }
 
-func TestNSMGR_HealLocalForwarder(t *testing.T) {
-	forwarderCtx, forwarderCtxCancel := context.WithCancel(context.Background())
-	defer forwarderCtxCancel()
-
-	customConfig := []*sandbox.NodeConfig{
-		nil,
+func TestNSMGR_HealForwarder(t *testing.T) {
+	var samples = []struct {
+		name    string
+		nodeNum int
+	}{
 		{
-			ForwarderCtx:               forwarderCtx,
-			ForwarderGenerateTokenFunc: sandbox.GenerateTestToken,
+			name:    "Local New",
+			nodeNum: 0,
+		},
+		{
+			name:    "Remote New",
+			nodeNum: 1,
 		},
 	}
 
-	testNSMGRHealForwarder(t, 1, customConfig, forwarderCtxCancel)
-}
-
-func TestNSMGR_HealRemoteForwarder(t *testing.T) {
-	forwarderCtx, forwarderCtxCancel := context.WithCancel(context.Background())
-	defer forwarderCtxCancel()
-
-	customConfig := []*sandbox.NodeConfig{
-		{
-			ForwarderCtx:               forwarderCtx,
-			ForwarderGenerateTokenFunc: sandbox.GenerateTestToken,
-		},
+	for _, sample := range samples {
+		t.Run(sample.name, func(t *testing.T) {
+			// nolint:scopelint
+			testNSMGRHealForwarder(t, sample.nodeNum)
+		})
 	}
-
-	testNSMGRHealForwarder(t, 0, customConfig, forwarderCtxCancel)
 }
 
-func testNSMGRHealForwarder(t *testing.T, nodeNum int, customConfig []*sandbox.NodeConfig, forwarderCtxCancel context.CancelFunc) {
+func testNSMGRHealForwarder(t *testing.T, nodeNum int) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	builder := sandbox.NewBuilder(t)
-	domain := builder.
+	var forwarderCtxCancel context.CancelFunc
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
+		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
-		SetCustomConfig(customConfig).
+		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, nodeN int) {
+			if nodeN != nodeNum {
+				sandbox.SetupDefaultNode(ctx, node, nsmgr.NewServer)
+			} else {
+				forwarderCtxCancel = setupCancelableForwarderNode(ctx, node)
+			}
+		}).
 		Build()
 
 	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	counter := &counterServer{}
-	_, err = domain.Nodes[0].NewEndpoint(ctx, defaultRegistryEndpoint(nsReg.Name), sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[1].NewEndpoint(ctx, defaultRegistryEndpoint(nsReg.Name), sandbox.GenerateTestToken, counter)
 
 	request := defaultRequest(nsReg.Name)
 
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -151,10 +171,10 @@ func testNSMGRHealForwarder(t *testing.T, nodeNum int, customConfig []*sandbox.N
 
 	forwarderCtxCancel()
 
-	_, err = domain.Nodes[nodeNum].NewForwarder(ctx, &registry.NetworkServiceEndpoint{
-		Name: "forwarder-restored",
-	}, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	forwarderReg := &registry.NetworkServiceEndpoint{
+		Name: sandbox.UniqueName("forwarder-2"),
+	}
+	domain.Nodes[nodeNum].NewForwarder(ctx, forwarderReg, sandbox.GenerateTestToken)
 
 	// Wait reconnecting through the new Forwarder
 	require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
@@ -173,62 +193,108 @@ func testNSMGRHealForwarder(t *testing.T, nodeNum int, customConfig []*sandbox.N
 	require.Equal(t, 1, counter.UniqueCloses())
 }
 
-func TestNSMGR_HealLocalNSMgrRestored(t *testing.T) {
+func setupCancelableForwarderNode(ctx context.Context, node *sandbox.Node) context.CancelFunc {
+	node.NewNSMgr(ctx, sandbox.UniqueName("nsmgr"), nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+
+	forwarderCtx, forwarderCtxCancel := context.WithCancel(ctx)
+	node.NewForwarder(forwarderCtx, &registry.NetworkServiceEndpoint{
+		Name: sandbox.UniqueName("forwarder"),
+	}, sandbox.GenerateTestToken)
+
+	return forwarderCtxCancel
+}
+
+func TestNSMGR_HealNSMgr(t *testing.T) {
+	var samples = []struct {
+		name     string
+		nodeNum  int
+		restored bool
+	}{
+		{
+			name:     "Local Restored",
+			nodeNum:  0,
+			restored: true,
+		},
+		{
+			name:    "Remote New",
+			nodeNum: 1,
+		},
+	}
+
+	for _, sample := range samples {
+		t.Run(sample.name, func(t *testing.T) {
+			// nolint:scopelint
+			testNSMGRHealNSMgr(t, sample.nodeNum, sample.restored)
+		})
+	}
+}
+
+func testNSMGRHealNSMgr(t *testing.T, nodeNum int, restored bool) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	nsmgrCtx, nsmgrCtxCancel := context.WithCancel(ctx)
-
-	customConfig := []*sandbox.NodeConfig{
-		nil,
-		{
-			NsmgrCtx:               nsmgrCtx,
-			NsmgrGenerateTokenFunc: sandbox.GenerateTestToken,
-		},
-	}
-
-	builder := sandbox.NewBuilder(t)
-	domain := builder.
-		SetNodesCount(2).
+	var nsmgrCtxCancel context.CancelFunc
+	domain := sandbox.NewBuilder(ctx, t).
+		SetNodesCount(3).
+		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
-		SetCustomConfig(customConfig).
+		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, nodeN int) {
+			if nodeN != nodeNum {
+				sandbox.SetupDefaultNode(ctx, node, nsmgr.NewServer)
+			} else {
+				nsmgrCtxCancel = setupCancellableNSMgrNode(ctx, node)
+			}
+		}).
 		Build()
 
 	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
+	nseReg := defaultRegistryEndpoint(nsReg.Name)
+
 	counter := &counterServer{}
-	_, err = domain.Nodes[0].NewEndpoint(ctx, defaultRegistryEndpoint(nsReg.Name), sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	request := defaultRequest(nsReg.Name)
 
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+
+	if !restored {
+		nseReg2 := defaultRegistryEndpoint(nsReg.Name)
+		nseReg2.Name += "-2"
+
+		domain.Nodes[2].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, counter)
+	}
 
 	nsmgrCtxCancel()
 
-	// Wait grpc unblock the port
-	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(domain.Nodes[1].NSMgr.URL)
-	}, timeout, tick)
+	if restored {
+		mgr := domain.Nodes[nodeNum].NSMgr
 
-	restoredNSMgrEntry, restoredNSMgrResources := builder.NewNSMgr(ctx, domain.Nodes[1], domain.Nodes[1].NSMgr.URL.Host, domain.Registry.URL, sandbox.GenerateTestToken)
-	domain.Nodes[1].NSMgr = restoredNSMgrEntry
-	domain.AddResources(restoredNSMgrResources)
+		// Wait grpc unblock the port
+		require.Eventually(t, func() bool {
+			return grpcutils.CheckURLFree(domain.Nodes[0].NSMgr.URL)
+		}, timeout, tick)
 
-	// Wait NSC restore the connection
-	require.Eventually(t, checkSecondRequestsReceived(func() int {
-		return int(atomic.LoadInt32(&counter.Requests))
-	}), timeout, tick)
-	require.Equal(t, int32(2), counter.Requests)
-	require.Equal(t, 1, counter.UniqueRequests())
+		domain.Nodes[nodeNum].NewNSMgr(ctx, mgr.Name, mgr.URL, sandbox.GenerateTestToken, nsmgr.NewServer)
+	}
+
+	if restored {
+		// Wait reconnecting through the restored NSMgr
+		require.Eventually(t, checkSecondRequestsReceived(func() int {
+			return int(atomic.LoadInt32(&counter.Requests))
+		}), timeout, tick)
+		require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+	} else {
+		// Wait reconnecting through the new NSMgr
+		require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
+		require.Equal(t, 2, counter.UniqueRequests())
+	}
 
 	// Check refresh
 	request.Connection = conn
@@ -239,73 +305,25 @@ func TestNSMGR_HealLocalNSMgrRestored(t *testing.T) {
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
 
-	require.Equal(t, int32(3), atomic.LoadInt32(&counter.Requests))
-	require.Equal(t, 1, counter.UniqueRequests())
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+	if restored {
+		require.Equal(t, int32(3), atomic.LoadInt32(&counter.Requests))
+		require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+	} else {
+		require.Equal(t, 2, counter.UniqueRequests())
+		require.Equal(t, 1, counter.UniqueCloses())
+	}
 }
 
-func TestNSMGR_HealRemoteNSMgr(t *testing.T) {
-	t.Cleanup(func() { goleak.VerifyNone(t) })
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
+func setupCancellableNSMgrNode(ctx context.Context, node *sandbox.Node) context.CancelFunc {
 	nsmgrCtx, nsmgrCtxCancel := context.WithCancel(ctx)
 
-	customConfig := []*sandbox.NodeConfig{
-		{
-			NsmgrCtx:               nsmgrCtx,
-			NsmgrGenerateTokenFunc: sandbox.GenerateTestToken,
-		},
-	}
+	node.NewNSMgr(nsmgrCtx, sandbox.UniqueName("nsmgr"), nil, sandbox.GenerateTestToken, nsmgr.NewServer)
 
-	builder := sandbox.NewBuilder(t)
-	domain := builder.
-		SetNodesCount(3).
-		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
-		SetCustomConfig(customConfig).
-		Build()
+	node.NewForwarder(ctx, &registry.NetworkServiceEndpoint{
+		Name: sandbox.UniqueName("forwarder"),
+	}, sandbox.GenerateTestToken)
 
-	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
-	require.NoError(t, err)
-
-	counter := &counterServer{}
-	_, err = domain.Nodes[0].NewEndpoint(ctx, defaultRegistryEndpoint(nsReg.Name), sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
-
-	request := defaultRequest(nsReg.Name)
-
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
-
-	conn, err := nsc.Request(ctx, request.Clone())
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	require.Equal(t, 1, counter.UniqueRequests())
-	require.Equal(t, 8, len(conn.Path.PathSegments))
-
-	nsmgrCtxCancel()
-
-	nseReg2 := defaultRegistryEndpoint(nsReg.Name)
-	nseReg2.Name += "-2"
-	_, err = domain.Nodes[2].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
-
-	// Wait through the new NSMgr
-	require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
-	require.Equal(t, 2, counter.UniqueRequests())
-
-	// Check refresh
-	request.Connection = conn
-	_, err = nsc.Request(ctx, request.Clone())
-	require.NoError(t, err)
-
-	// Close
-	_, err = nsc.Close(ctx, conn)
-	require.NoError(t, err)
-
-	require.Equal(t, 2, counter.UniqueRequests())
-	require.Equal(t, 1, counter.UniqueCloses())
+	return nsmgrCtxCancel
 }
 
 func TestNSMGR_CloseHeal(t *testing.T) {
@@ -314,10 +332,10 @@ func TestNSMGR_CloseHeal(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
+		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
@@ -325,8 +343,7 @@ func TestNSMGR_CloseHeal(t *testing.T) {
 
 	nseCtx, nseCtxCancel := context.WithCancel(ctx)
 
-	_, err = domain.Nodes[0].NewEndpoint(nseCtx, defaultRegistryEndpoint(nsReg.Name), sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(nseCtx, defaultRegistryEndpoint(nsReg.Name), sandbox.GenerateTestToken)
 
 	request := defaultRequest(nsReg.Name)
 

--- a/pkg/networkservice/chains/nsmgr/scale_test.go
+++ b/pkg/networkservice/chains/nsmgr/scale_test.go
@@ -45,6 +45,8 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
 	nsReg := &registry.NetworkService{
 		Name: "ns-1",
 		Matches: []*registry.Match{
@@ -58,7 +60,7 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 		},
 	}
 
-	_, err := domain.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
+	_, err := nsRegistryClient.Register(ctx, nsReg)
 	require.NoError(t, err)
 
 	nseReg := &registry.NetworkServiceEndpoint{

--- a/pkg/networkservice/chains/nsmgr/scale_test.go
+++ b/pkg/networkservice/chains/nsmgr/scale_test.go
@@ -40,10 +40,9 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 
 	defer cancel()
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	nsReg := &registry.NetworkService{
@@ -94,8 +93,7 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 		},
 	}
 
-	_, err = domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, makerServer)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, makerServer)
 
 	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -139,10 +137,7 @@ func (m *nseMaker) Request(_ context.Context, _ *networkservice.NetworkServiceRe
 		return nil, errors.New("can't create new endpoint")
 	}
 
-	_, err := m.domain.Nodes[1].NewEndpoint(m.ctx, m.nseReg, sandbox.GenerateTestToken, endpoint)
-	if err != nil {
-		return nil, err
-	}
+	m.domain.Nodes[1].NewEndpoint(m.ctx, m.nseReg, sandbox.GenerateTestToken, endpoint)
 
 	return nil, errors.New("can't provide requested network service")
 }

--- a/pkg/networkservice/chains/nsmgr/single_test.go
+++ b/pkg/networkservice/chains/nsmgr/single_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/dnscontext"
 	"github.com/networkservicemesh/sdk/pkg/tools/clientinfo"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
@@ -42,11 +43,10 @@ func Test_DNSUsecase(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
@@ -54,7 +54,7 @@ func Test_DNSUsecase(t *testing.T) {
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 
-	_, err = domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, dnscontext.NewServer(
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, dnscontext.NewServer(
 		&networkservice.DNSConfig{
 			DnsServerIps:  []string{"8.8.8.8"},
 			SearchDomains: []string{"my.domain1"},
@@ -64,7 +64,6 @@ func Test_DNSUsecase(t *testing.T) {
 			SearchDomains: []string{"my.domain1"},
 		},
 	))
-	require.NoError(t, err)
 
 	corefilePath := filepath.Join(t.TempDir(), "corefile")
 	resolveConfigPath := filepath.Join(t.TempDir(), "resolv.conf")
@@ -105,12 +104,13 @@ func Test_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
-		SetNodeSetup(nil).
+		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, _ int) {
+			node.NewNSMgr(ctx, "nsmgr", nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+		}).
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
-		SetContext(ctx).
 		Build()
 
 	nsReg, err := domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
@@ -122,16 +122,13 @@ func Test_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 
 	// 1. Add forwarders
 	forwarder1Reg := forwarderReg.Clone()
-	_, err = domain.Nodes[0].NewForwarder(ctx, forwarder1Reg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewForwarder(ctx, forwarder1Reg, sandbox.GenerateTestToken)
 
 	forwarder2Reg := forwarderReg.Clone()
-	_, err = domain.Nodes[0].NewForwarder(ctx, forwarder2Reg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewForwarder(ctx, forwarder2Reg, sandbox.GenerateTestToken)
 
 	forwarder3Reg := forwarderReg.Clone()
-	_, err = domain.Nodes[0].NewForwarder(ctx, forwarder3Reg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewForwarder(ctx, forwarder3Reg, sandbox.GenerateTestToken)
 
 	// 2. Wait for refresh
 	<-time.After(sandbox.RegistryExpiryDuration)
@@ -162,11 +159,10 @@ func Test_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
-		SetContext(ctx).
 		Build()
 
 	// 1. Add endpoints
@@ -178,8 +174,7 @@ func Test_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 		nseRegs[i] = defaultRegistryEndpoint(nsReg.Name)
 		nseRegs[i].NetworkServiceNames[0] = nsReg.Name
 
-		_, err = domain.Nodes[0].NewEndpoint(ctx, nseRegs[i], sandbox.GenerateTestToken)
-		require.NoError(t, err)
+		domain.Nodes[0].NewEndpoint(ctx, nseRegs[i], sandbox.GenerateTestToken)
 
 		nseRegs = append(nseRegs, nseRegs[i])
 	}
@@ -212,10 +207,9 @@ func Test_Local_NoURLUsecase(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		UseUnixSockets().
-		SetContext(ctx).
 		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
 		SetRegistrySupplier(nil).
@@ -228,8 +222,7 @@ func Test_Local_NoURLUsecase(t *testing.T) {
 	request := defaultRequest(nsReg.Name)
 	counter := &counterServer{}
 
-	_, err = domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -274,11 +267,10 @@ func Test_ShouldParseNetworkServiceLabelsTemplate(t *testing.T) {
 	want := map[string]string{}
 	clientinfo.AddClientInfo(ctx, want)
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
 		SetNSMgrProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	nsReg := defaultRegistryService()
@@ -300,8 +292,7 @@ func Test_ShouldParseNetworkServiceLabelsTemplate(t *testing.T) {
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 	nseReg.NetworkServiceLabels = map[string]*registry.NetworkServiceLabels{nsReg.Name: {}}
 
-	_, err = domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 	require.NoError(t, err)

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/replacelabels"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injecterror"
+	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -56,7 +57,8 @@ const (
 type nsmgrSuite struct {
 	suite.Suite
 
-	domain *sandbox.Domain
+	domain           *sandbox.Domain
+	nsRegistryClient registry.NetworkServiceRegistryClient
 }
 
 func TestNsmgr(t *testing.T) {
@@ -80,6 +82,8 @@ func (s *nsmgrSuite) SetupSuite() {
 		SetRegistryProxySupplier(nil).
 		SetNSMgrProxySupplier(nil).
 		Build()
+
+	s.nsRegistryClient = s.domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
 }
 
 func (s *nsmgrSuite) Test_Remote_ParallelUsecase() {
@@ -88,19 +92,20 @@ func (s *nsmgrSuite) Test_Remote_ParallelUsecase() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsReg, err := s.nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 	counter := &counterServer{}
 
 	var unregisterWG sync.WaitGroup
+	var nse *sandbox.EndpointEntry
 	unregisterWG.Add(1)
 	go func() {
 		defer unregisterWG.Done()
 
 		time.Sleep(time.Millisecond * 100)
-		s.domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+		nse = s.domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 	}()
 	nsc := s.domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -129,7 +134,7 @@ func (s *nsmgrSuite) Test_Remote_ParallelUsecase() {
 
 	// Endpoint unregister
 	unregisterWG.Wait()
-	_, err = s.domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nseReg)
+	_, err = nse.Unregister(ctx, nseReg)
 	require.NoError(t, err)
 }
 
@@ -139,7 +144,7 @@ func (s *nsmgrSuite) Test_SelectsRestartingEndpointUsecase() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsReg, err := s.nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
@@ -150,13 +155,16 @@ func (s *nsmgrSuite) Test_SelectsRestartingEndpointUsecase() {
 	defer func() { _ = netListener.Close() }()
 	nseReg.Url = "tcp://" + netListener.Addr().String()
 
-	_, err = s.domain.Nodes[0].NSRegistryClient.Register(ctx, &registry.NetworkService{
+	_, err = s.nsRegistryClient.Register(ctx, &registry.NetworkService{
 		Name:    nseReg.NetworkServiceNames[0],
 		Payload: payload.IP,
 	})
 	require.NoError(t, err)
 
-	nseReg, err = s.domain.Nodes[0].EndpointRegistryClient.Register(ctx, nseReg)
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, s.domain.Nodes[0].NSMgr.URL,
+		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
+
+	nseReg, err = nseRegistryClient.Register(ctx, nseReg)
 	require.NoError(t, err)
 
 	// 2. Postpone endpoint start
@@ -181,7 +189,7 @@ func (s *nsmgrSuite) Test_SelectsRestartingEndpointUsecase() {
 	require.NoError(t, err)
 
 	// Endpoint unregister
-	_, err = s.domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nseReg)
+	_, err = nseRegistryClient.Unregister(ctx, nseReg)
 	require.NoError(t, err)
 }
 
@@ -191,20 +199,21 @@ func (s *nsmgrSuite) Test_Remote_BusyEndpointsUsecase() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsReg, err := s.nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	counter := &counterServer{}
 
 	var wg sync.WaitGroup
-	var nsesReg [4]*registry.NetworkServiceEndpoint
+	var nseRegs [4]*registry.NetworkServiceEndpoint
+	var nses [4]*sandbox.EndpointEntry
 	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		go func(id int) {
-			nsesReg[id] = defaultRegistryEndpoint(nsReg.Name)
-			nsesReg[id].Name += strconv.Itoa(id)
+			nseRegs[id] = defaultRegistryEndpoint(nsReg.Name)
+			nseRegs[id].Name += strconv.Itoa(id)
 
-			s.domain.Nodes[1].NewEndpoint(ctx, nsesReg[id], sandbox.GenerateTestToken, injecterror.NewServer())
+			nses[id] = s.domain.Nodes[1].NewEndpoint(ctx, nseRegs[id], sandbox.GenerateTestToken, injecterror.NewServer())
 			wg.Done()
 		}(i)
 	}
@@ -216,10 +225,10 @@ func (s *nsmgrSuite) Test_Remote_BusyEndpointsUsecase() {
 
 		wg.Wait()
 		time.Sleep(time.Second / 2)
-		nsesReg[3] = defaultRegistryEndpoint(nsReg.Name)
-		nsesReg[3].Name += strconv.Itoa(3)
+		nseRegs[3] = defaultRegistryEndpoint(nsReg.Name)
+		nseRegs[3].Name += strconv.Itoa(3)
 
-		s.domain.Nodes[1].NewEndpoint(ctx, nsesReg[3], sandbox.GenerateTestToken, counter)
+		nses[3] = s.domain.Nodes[1].NewEndpoint(ctx, nseRegs[3], sandbox.GenerateTestToken, counter)
 	}()
 	nsc := s.domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -248,8 +257,8 @@ func (s *nsmgrSuite) Test_Remote_BusyEndpointsUsecase() {
 
 	// Endpoint unregister
 	unregisterWG.Wait()
-	for i := 0; i < len(nsesReg); i++ {
-		_, err = s.domain.Nodes[1].EndpointRegistryClient.Unregister(ctx, nsesReg[i])
+	for i, nseReg := range nseRegs {
+		_, err = nses[i].Unregister(ctx, nseReg)
 		require.NoError(t, err)
 	}
 }
@@ -260,13 +269,13 @@ func (s *nsmgrSuite) Test_RemoteUsecase() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsReg, err := s.nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 	counter := &counterServer{}
 
-	s.domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+	nse := s.domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	nsc := s.domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -294,7 +303,7 @@ func (s *nsmgrSuite) Test_RemoteUsecase() {
 	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
 
 	// Endpoint unregister
-	_, err = s.domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nseReg)
+	_, err = nse.Unregister(ctx, nseReg)
 	require.NoError(t, err)
 }
 
@@ -305,7 +314,7 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	nseCtx, killNse := context.WithCancel(ctx)
 	defer cancel()
 
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsReg, err := s.nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
@@ -333,7 +342,7 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	require.NoError(t, ctx.Err())
 
 	// Endpoint unregister
-	_, err = s.domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nseReg)
+	_, err = s.domain.Nodes[0].NSMgr.NetworkServiceEndpointRegistryServer().Unregister(ctx, nseReg)
 	require.NoError(t, err)
 }
 
@@ -343,13 +352,13 @@ func (s *nsmgrSuite) Test_LocalUsecase() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsReg, err := s.nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 	counter := &counterServer{}
 
-	s.domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+	nse := s.domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	nsc := s.domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -377,7 +386,7 @@ func (s *nsmgrSuite) Test_LocalUsecase() {
 	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
 
 	// Endpoint unregister
-	_, err = s.domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nseReg)
+	_, err = nse.Unregister(ctx, nseReg)
 	require.NoError(t, err)
 }
 
@@ -390,15 +399,23 @@ func (s *nsmgrSuite) Test_PassThroughRemoteUsecase() {
 	counterClose := &counterServer{}
 
 	nsReg := linearNS(nodesCount)
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
+	nsReg, err := s.nsRegistryClient.Register(ctx, nsReg)
 	require.NoError(t, err)
 
-	var nsesReg []*registry.NetworkServiceEndpoint
-	for i := 0; i < nodesCount; i++ {
-		labels := map[string]string{
-			step: fmt.Sprintf("%v", i),
-		}
-		nsesReg = append(nsesReg, newPassThroughEndpoint(ctx, s.domain.Nodes[i], labels, fmt.Sprintf("%v", i), nsReg.Name, i != nodesCount-1, counterClose))
+	var nseRegs [nodesCount]*registry.NetworkServiceEndpoint
+	var nses [nodesCount]*sandbox.EndpointEntry
+	for i := range nseRegs {
+		nseRegs[i], nses[i] = newPassThroughEndpoint(
+			ctx,
+			s.domain.Nodes[i],
+			map[string]string{
+				step: fmt.Sprintf("%v", i),
+			},
+			fmt.Sprintf("%v", i),
+			nsReg.Name,
+			i != nodesCount-1,
+			counterClose,
+		)
 	}
 
 	nsc := s.domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
@@ -413,8 +430,8 @@ func (s *nsmgrSuite) Test_PassThroughRemoteUsecase() {
 	// Path length to first endpoint is 5
 	// Path length from NSE client to other remote endpoint is 8
 	require.Equal(t, 8*(nodesCount-1)+5, len(conn.Path.PathSegments))
-	for i := 0; i < len(nsesReg); i++ {
-		require.Contains(t, nsesReg[i].Name, conn.Path.PathSegments[i*8+4].Name)
+	for i := 0; i < len(nseRegs); i++ {
+		require.Contains(t, nseRegs[i].Name, conn.Path.PathSegments[i*8+4].Name)
 	}
 
 	// Refresh
@@ -427,8 +444,8 @@ func (s *nsmgrSuite) Test_PassThroughRemoteUsecase() {
 	require.Equal(t, int32(nodesCount), atomic.LoadInt32(&counterClose.Closes))
 
 	// Endpoint unregister
-	for i := 0; i < len(nsesReg); i++ {
-		_, err = s.domain.Nodes[i].EndpointRegistryClient.Unregister(ctx, nsesReg[i])
+	for i, nseReg := range nseRegs {
+		_, err = nses[i].Unregister(ctx, nseReg)
 		require.NoError(t, err)
 	}
 }
@@ -442,17 +459,23 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecase() {
 
 	counterClose := &counterServer{}
 
-	nsReg := linearNS(nsesCount)
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
+	nsReg, err := s.nsRegistryClient.Register(ctx, linearNS(nsesCount))
 	require.NoError(t, err)
 
-	var nsesReg []*registry.NetworkServiceEndpoint
-	for i := 0; i < nsesCount; i++ {
-		labels := map[string]string{
-			step: fmt.Sprintf("%v", i),
-		}
-
-		nsesReg = append(nsesReg, newPassThroughEndpoint(ctx, s.domain.Nodes[0], labels, fmt.Sprintf("%v", i), nsReg.Name, i != nsesCount-1, counterClose))
+	var nseRegs [nsesCount]*registry.NetworkServiceEndpoint
+	var nses [nsesCount]*sandbox.EndpointEntry
+	for i := range nseRegs {
+		nseRegs[i], nses[i] = newPassThroughEndpoint(
+			ctx,
+			s.domain.Nodes[0],
+			map[string]string{
+				step: fmt.Sprintf("%v", i),
+			},
+			fmt.Sprintf("%v", i),
+			nsReg.Name,
+			i != nsesCount-1,
+			counterClose,
+		)
 	}
 
 	nsc := s.domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
@@ -466,8 +489,8 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecase() {
 	// Path length to first endpoint is 5
 	// Path length from NSE client to other local endpoint is 5
 	require.Equal(t, 5*(nsesCount-1)+5, len(conn.Path.PathSegments))
-	for i := 0; i < len(nsesReg); i++ {
-		require.Contains(t, nsesReg[i].Name, conn.Path.PathSegments[(i+1)*5-1].Name)
+	for i := 0; i < len(nseRegs); i++ {
+		require.Contains(t, nseRegs[i].Name, conn.Path.PathSegments[(i+1)*5-1].Name)
 	}
 
 	// Refresh
@@ -480,8 +503,8 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecase() {
 	require.Equal(t, int32(nsesCount), atomic.LoadInt32(&counterClose.Closes))
 
 	// Endpoint unregister
-	for i := 0; i < len(nsesReg); i++ {
-		_, err = s.domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nsesReg[i])
+	for i, nseReg := range nseRegs {
+		_, err = nses[i].Unregister(ctx, nseReg)
 		require.NoError(t, err)
 	}
 }
@@ -494,23 +517,28 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecaseMultiLabel() {
 
 	counterClose := &counterServer{}
 
-	nsReg := multiLabelNS()
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
+	nsReg, err := s.nsRegistryClient.Register(ctx, multiLabelNS())
 	require.NoError(t, err)
 
 	var labelAvalue, labelBvalue string
-	nsesReg := []*registry.NetworkServiceEndpoint{}
+	var nseRegs [3 * 3]*registry.NetworkServiceEndpoint
+	var nses [3 * 3]*sandbox.EndpointEntry
 	for i := 0; i < 3; i++ {
 		labelAvalue += "a"
 		for j := 0; j < 3; j++ {
 			labelBvalue += "b"
-
-			labels := map[string]string{
-				labelA: labelAvalue,
-				labelB: labelBvalue,
-			}
-
-			nsesReg = append(nsesReg, newPassThroughEndpoint(ctx, s.domain.Nodes[0], labels, labelAvalue+labelBvalue, nsReg.Name, i != 2 || j != 2, counterClose))
+			nseRegs[i*3+j], nses[i*3+j] = newPassThroughEndpoint(
+				ctx,
+				s.domain.Nodes[0],
+				map[string]string{
+					labelA: labelAvalue,
+					labelB: labelBvalue,
+				},
+				labelAvalue+labelBvalue,
+				nsReg.Name,
+				i != 2 || j != 2,
+				counterClose,
+			)
 		}
 		labelBvalue = ""
 	}
@@ -540,8 +568,8 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecaseMultiLabel() {
 	require.Equal(t, int32(len(expectedPath)), atomic.LoadInt32(&counterClose.Closes))
 
 	// Endpoint unregister
-	for i := 0; i < len(nsesReg); i++ {
-		_, err = s.domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nsesReg[i])
+	for i, nseReg := range nseRegs {
+		_, err = nses[i].Unregister(ctx, nseReg)
 		require.NoError(t, err)
 	}
 }
@@ -552,7 +580,7 @@ func (s *nsmgrSuite) Test_ShouldCleanAllClientAndEndpointGoroutines() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, defaultRegistryService())
+	nsReg, err := s.nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
@@ -677,7 +705,14 @@ func additionalFunctionalityChain(ctx context.Context, clientURL *url.URL, clien
 	}
 }
 
-func newPassThroughEndpoint(ctx context.Context, node *sandbox.Node, labels map[string]string, name, nsRegName string, hasClientFunctionality bool, counter networkservice.NetworkServiceServer) *registry.NetworkServiceEndpoint {
+func newPassThroughEndpoint(
+	ctx context.Context,
+	node *sandbox.Node,
+	labels map[string]string,
+	name, nsRegName string,
+	hasClientFunctionality bool,
+	counter networkservice.NetworkServiceServer,
+) (*registry.NetworkServiceEndpoint, *sandbox.EndpointEntry) {
 	nseReg := &registry.NetworkServiceEndpoint{
 		Name:                fmt.Sprintf("endpoint-%v", name),
 		NetworkServiceNames: []string{nsRegName},
@@ -697,7 +732,5 @@ func newPassThroughEndpoint(ctx context.Context, node *sandbox.Node, labels map[
 		additionalFunctionality = append(additionalFunctionality, counter)
 	}
 
-	node.NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
-
-	return nseReg
+	return nseReg, node.NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
 }

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -161,7 +161,7 @@ func (s *nsmgrSuite) Test_SelectsRestartingEndpointUsecase() {
 	})
 	require.NoError(t, err)
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, s.domain.Nodes[0].NSMgr.URL,
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, s.domain.Nodes[0].URL(),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nseReg, err = nseRegistryClient.Register(ctx, nseReg)
@@ -725,7 +725,7 @@ func newPassThroughEndpoint(
 
 	var additionalFunctionality []networkservice.NetworkServiceServer
 	if hasClientFunctionality {
-		additionalFunctionality = additionalFunctionalityChain(ctx, node.NSMgr.URL, name, labels)
+		additionalFunctionality = additionalFunctionalityChain(ctx, node.URL(), name, labels)
 	}
 
 	if counter != nil {

--- a/pkg/networkservice/chains/nsmgr/utils_test.go
+++ b/pkg/networkservice/chains/nsmgr/utils_test.go
@@ -69,8 +69,7 @@ func testNSEAndClient(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	_, err := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 

--- a/pkg/networkservice/chains/nsmgr/utils_test.go
+++ b/pkg/networkservice/chains/nsmgr/utils_test.go
@@ -69,7 +69,7 @@ func testNSEAndClient(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
+	nse := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -81,7 +81,7 @@ func testNSEAndClient(
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
 
-	_, err = domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nseReg)
+	_, err = nse.Unregister(ctx, nseReg)
 	require.NoError(t, err)
 }
 

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -64,11 +64,13 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		SetDNSResolver(dnsServer).
 		Build()
 
+	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
 	nsReg := &registry.NetworkService{
 		Name: "my-service-interdomain",
 	}
 
-	_, err := cluster2.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
+	_, err := nsRegistryClient.Register(ctx, nsReg)
 	require.NoError(t, err)
 
 	nseReg := &registry.NetworkServiceEndpoint{
@@ -136,12 +138,14 @@ func TestNSMGR_Interdomain_TwoNodesNSEs(t *testing.T) {
 		SetDNSResolver(dnsServer).
 		Build()
 
-	_, err := cluster2.Nodes[0].NSRegistryClient.Register(ctx, &registry.NetworkService{
+	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	_, err := nsRegistryClient.Register(ctx, &registry.NetworkService{
 		Name: "my-service-interdomain-1",
 	})
 	require.NoError(t, err)
 
-	_, err = cluster2.Nodes[1].NSRegistryClient.Register(ctx, &registry.NetworkService{
+	_, err = nsRegistryClient.Register(ctx, &registry.NetworkService{
 		Name: "my-service-interdomain-2",
 	})
 	require.NoError(t, err)
@@ -246,11 +250,13 @@ func TestNSMGR_FloatingInterdomainUseCase(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
+	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
 	nsReg := &registry.NetworkService{
 		Name: "my-service-interdomain@" + floating.Name,
 	}
 
-	_, err := cluster2.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
+	_, err := nsRegistryClient.Register(ctx, nsReg)
 	require.NoError(t, err)
 
 	nseReg := &registry.NetworkServiceEndpoint{
@@ -337,11 +343,13 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 
 	// register first ednpoint
 
+	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
 	nsReg1 := &registry.NetworkService{
 		Name: "my-service-interdomain-1@" + floating.Name,
 	}
 
-	_, err := cluster2.Nodes[0].NSRegistryClient.Register(ctx, nsReg1)
+	_, err := nsRegistryClient.Register(ctx, nsReg1)
 	require.NoError(t, err)
 
 	nseReg1 := &registry.NetworkServiceEndpoint{
@@ -357,7 +365,9 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 
 	// register second ednpoint
 
-	_, err = cluster3.Nodes[0].NSRegistryClient.Register(ctx, nsReg2)
+	nsRegistryClient = cluster3.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	_, err = nsRegistryClient.Register(ctx, nsReg2)
 	require.NoError(t, err)
 
 	nseReg2 := &registry.NetworkServiceEndpoint{
@@ -491,7 +501,9 @@ func Test_Interdomain_PassThroughUsecase(t *testing.T) {
 			}
 		}
 
-		nsReg, err := clusters[i].Nodes[0].NSRegistryClient.Register(ctx, &registry.NetworkService{
+		nsRegistryClient := clusters[i].NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+		nsReg, err := nsRegistryClient.Register(ctx, &registry.NetworkService{
 			Name: fmt.Sprintf("my-service-remote-%v", i),
 		})
 		require.NoError(t, err)

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -52,18 +52,16 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 
 	var dnsServer = new(sandbox.FakeDNSResolver)
 
-	cluster1 := sandbox.NewBuilder(t).
+	cluster1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
-		SetContext(ctx).
 		SetDNSResolver(dnsServer).
 		SetDNSDomainName("cluster1").
 		Build()
 
-	cluster2 := sandbox.NewBuilder(t).
+	cluster2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetDNSDomainName("cluster2").
 		SetDNSResolver(dnsServer).
-		SetContext(ctx).
 		Build()
 
 	nsReg := &registry.NetworkService{
@@ -78,8 +76,7 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		NetworkServiceNames: []string{nsReg.Name},
 	}
 
-	_, err = cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
 
 	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -127,18 +124,16 @@ func TestNSMGR_Interdomain_TwoNodesNSEs(t *testing.T) {
 
 	var dnsServer = new(sandbox.FakeDNSResolver)
 
-	cluster1 := sandbox.NewBuilder(t).
+	cluster1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
-		SetContext(ctx).
 		SetDNSResolver(dnsServer).
 		SetDNSDomainName("cluster1").
 		Build()
 
-	cluster2 := sandbox.NewBuilder(t).
+	cluster2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
 		SetDNSDomainName("cluster2").
 		SetDNSResolver(dnsServer).
-		SetContext(ctx).
 		Build()
 
 	_, err := cluster2.Nodes[0].NSRegistryClient.Register(ctx, &registry.NetworkService{
@@ -155,15 +150,13 @@ func TestNSMGR_Interdomain_TwoNodesNSEs(t *testing.T) {
 		Name:                "final-endpoint-1",
 		NetworkServiceNames: []string{"my-service-interdomain-1"},
 	}
-	_, err = cluster2.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.GenerateTestToken)
 
 	nseReg2 := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint-2",
 		NetworkServiceNames: []string{"my-service-interdomain-2"},
 	}
-	_, err = cluster2.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken)
 
 	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -233,27 +226,24 @@ func TestNSMGR_FloatingInterdomainUseCase(t *testing.T) {
 
 	var dnsServer = new(sandbox.FakeDNSResolver)
 
-	cluster1 := sandbox.NewBuilder(t).
+	cluster1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
-		SetContext(ctx).
 		SetDNSResolver(dnsServer).
 		SetDNSDomainName("cluster1").
 		Build()
 
-	cluster2 := sandbox.NewBuilder(t).
+	cluster2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetDNSDomainName("cluster2").
 		SetDNSResolver(dnsServer).
-		SetContext(ctx).
 		Build()
 
-	floating := sandbox.NewBuilder(t).
+	floating := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSDomainName("floating.domain").
 		SetDNSResolver(dnsServer).
 		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	nsReg := &registry.NetworkService{
@@ -268,8 +258,7 @@ func TestNSMGR_FloatingInterdomainUseCase(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain"},
 	}
 
-	_, err = cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
 
 	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -320,34 +309,30 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 
 	// setup clusters
 
-	cluster1 := sandbox.NewBuilder(t).
+	cluster1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
-		SetContext(ctx).
 		SetDNSResolver(dnsServer).
 		SetDNSDomainName("cluster1").
 		Build()
 
-	cluster2 := sandbox.NewBuilder(t).
+	cluster2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetDNSDomainName("cluster2").
 		SetDNSResolver(dnsServer).
-		SetContext(ctx).
 		Build()
 
-	cluster3 := sandbox.NewBuilder(t).
+	cluster3 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetDNSDomainName("cluster3").
 		SetDNSResolver(dnsServer).
-		SetContext(ctx).
 		Build()
 
-	floating := sandbox.NewBuilder(t).
+	floating := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSDomainName("floating.domain").
 		SetDNSResolver(dnsServer).
 		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	// register first ednpoint
@@ -364,8 +349,7 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain-1"},
 	}
 
-	_, err = cluster2.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.GenerateTestToken)
 
 	nsReg2 := &registry.NetworkService{
 		Name: "my-service-interdomain-1@" + floating.Name,
@@ -381,8 +365,7 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain-2"},
 	}
 
-	_, err = cluster3.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	cluster3.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken)
 
 	// connect to first endpoint from cluster2
 
@@ -485,9 +468,8 @@ func Test_Interdomain_PassThroughUsecase(t *testing.T) {
 	var clusters = make([]*sandbox.Domain, clusterCount)
 
 	for i := 0; i < clusterCount; i++ {
-		clusters[i] = sandbox.NewBuilder(t).
+		clusters[i] = sandbox.NewBuilder(ctx, t).
 			SetNodesCount(1).
-			SetContext(ctx).
 			SetDNSResolver(dnsServer).
 			SetDNSDomainName("cluster" + fmt.Sprint(i)).
 			Build()
@@ -518,8 +500,7 @@ func Test_Interdomain_PassThroughUsecase(t *testing.T) {
 			Name:                fmt.Sprintf("endpoint-%v", i),
 			NetworkServiceNames: []string{nsReg.Name},
 		}
-		_, err = clusters[i].Nodes[0].NewEndpoint(ctx, nsesReg, sandbox.GenerateTestToken, additionalFunctionality...)
-		require.NoError(t, err)
+		clusters[i].Nodes[0].NewEndpoint(ctx, nsesReg, sandbox.GenerateTestToken, additionalFunctionality...)
 	}
 
 	nsc := clusters[clusterCount-1].Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -488,7 +488,7 @@ func Test_Interdomain_PassThroughUsecase(t *testing.T) {
 			// Passtrough to the node i-1
 			additionalFunctionality = []networkservice.NetworkServiceServer{
 				chain.NewNetworkServiceServer(
-					clienturl.NewServer(clusters[i].Nodes[0].NSMgr.URL),
+					clienturl.NewServer(clusters[i].Nodes[0].URL()),
 					connect.NewServer(ctx,
 						client.NewClientFactory(client.WithAdditionalFunctionality(
 							newPassTroughClient(fmt.Sprintf("my-service-remote-%v@cluster%v", i-1, i-1)),

--- a/pkg/networkservice/common/connect/server_cancel_test.go
+++ b/pkg/networkservice/common/connect/server_cancel_test.go
@@ -102,7 +102,7 @@ func TestConnect_CancelDuringRequest(t *testing.T) {
 	}
 	domain.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken,
 		chain.NewNetworkServiceServer(
-			clienturl.NewServer(domain.Nodes[0].NSMgr.URL),
+			clienturl.NewServer(domain.Nodes[0].URL()),
 			connect.NewServer(ctx,
 				clientFactory,
 				connect.WithDialTimeout(sandbox.DialTimeout),

--- a/pkg/networkservice/common/connect/server_cancel_test.go
+++ b/pkg/networkservice/common/connect/server_cancel_test.go
@@ -56,14 +56,16 @@ func TestConnect_CancelDuringRequest(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
 	service1Name := "my-service-endpoint"
-	_, err = domain.Nodes[0].NSRegistryClient.Register(ctx, &registry.NetworkService{
+	_, err = nsRegistryClient.Register(ctx, &registry.NetworkService{
 		Name: service1Name,
 	})
 	require.NoError(t, err)
 
 	service2Name := "my-service-with-passthrough"
-	_, err = domain.Nodes[0].NSRegistryClient.Register(ctx, &registry.NetworkService{
+	_, err = nsRegistryClient.Register(ctx, &registry.NetworkService{
 		Name: service2Name,
 	})
 	require.NoError(t, err)

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -231,9 +231,8 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), sandboxTotalTimeout)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
-		SetContext(ctx).
 		SetRegistryProxySupplier(nil).
 		SetTokenGenerateFunc(sandbox.GenerateTestToken).
 		Build()
@@ -251,8 +250,7 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	}
 
 	refreshSrv := newRefreshTesterServer(t, sandboxMinDuration, sandboxExpireTimeout)
-	_, err = domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, refreshSrv)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, refreshSrv)
 
 	nscTokenGenerator := sandbox.GenerateExpiringToken(sandboxExpireTimeout)
 	nsc := domain.Nodes[1].NewClient(ctx, nscTokenGenerator)

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -237,11 +237,13 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 		SetTokenGenerateFunc(sandbox.GenerateTestToken).
 		Build()
 
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
 	nsReg := &registry.NetworkService{
 		Name: "my-service-remote",
 	}
 
-	_, err := domain.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
+	_, err := nsRegistryClient.Register(ctx, nsReg)
 	require.NoError(t, err)
 
 	nseReg := &registry.NetworkServiceEndpoint{

--- a/pkg/registry/chains/memory/server_test.go
+++ b/pkg/registry/chains/memory/server_test.go
@@ -41,11 +41,10 @@ func Test_RegistryMemory_ShouldSetDefaultPayload(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetRegistryProxySupplier(nil).
 		SetNSMgrProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	// start grpc client connection and register it

--- a/pkg/registry/chains/proxydns/server_ns_test.go
+++ b/pkg/registry/chains/proxydns/server_ns_test.go
@@ -54,14 +54,12 @@ func TestInterdomainNetworkServiceRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		SetDNSDomainName("cluster.remote").
@@ -121,8 +119,7 @@ func TestLocalDomain_NetworkServiceRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSDomainName("cluster.local").
 		SetDNSResolver(dnsServer).
@@ -182,19 +179,17 @@ func TestInterdomainFloatingNetworkServiceRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain3 := sandbox.NewBuilder(t).
+	domain3 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetRegistryProxySupplier(nil).
 		SetNSMgrProxySupplier(nil).

--- a/pkg/registry/chains/proxydns/server_nse_test.go
+++ b/pkg/registry/chains/proxydns/server_nse_test.go
@@ -57,14 +57,12 @@ func TestInterdomainNetworkServiceEndpointRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		SetDNSDomainName("domain2").
@@ -128,8 +126,7 @@ func TestLocalDomain_NetworkServiceEndpointRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSDomainName("cluster.local").
 		SetDNSResolver(dnsServer).
@@ -193,20 +190,17 @@ func TestInterdomainFloatingNetworkServiceEndpointRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain3 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain3 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		SetNSMgrProxySupplier(nil).

--- a/pkg/registry/common/heal/find_test.go
+++ b/pkg/registry/common/heal/find_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
@@ -39,16 +40,16 @@ func TestHealClient_FindTest(t *testing.T) {
 	nsmgrCtx, nsmgrCancel := context.WithCancel(ctx)
 	defer nsmgrCancel()
 
-	nodeConfig := []*sandbox.NodeConfig{{
-		NsmgrCtx: nsmgrCtx,
-	}}
-
-	builder := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetRegistryProxySupplier(nil).
 		SetNSMgrProxySupplier(nil).
-		SetContext(ctx).
-		SetCustomConfig(nodeConfig)
-	domain := builder.Build()
+		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, nodeNum int) {
+			node.NewNSMgr(nsmgrCtx, sandbox.UniqueName("nsmgr"), nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+			node.NewForwarder(ctx, &registry.NetworkServiceEndpoint{
+				Name: sandbox.UniqueName("forwarder"),
+			}, sandbox.GenerateTestToken)
+		}).
+		Build()
 
 	// 1. Create NS, NSE find clients
 	findCtx, findCancel := context.WithCancel(ctx)
@@ -66,15 +67,14 @@ func TestHealClient_FindTest(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. Restart NSMgr
-	nsmgrURL := domain.Nodes[0].NSMgr.URL
+	mgr := domain.Nodes[0].NSMgr
 
 	nsmgrCancel()
 	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(nsmgrURL)
+		return grpcutils.CheckURLFree(mgr.URL)
 	}, time.Second, 100*time.Millisecond)
 
-	mgr, resources := builder.NewNSMgr(ctx, domain.Nodes[0], grpcutils.URLToTarget(nsmgrURL), domain.Registry.URL, sandbox.GenerateTestToken)
-	domain.AddResources(resources)
+	mgr = domain.Nodes[0].NewNSMgr(ctx, mgr.Name, mgr.URL, sandbox.GenerateTestToken, nsmgr.NewServer)
 
 	// 3. Register new NS, NSE
 	_, err = mgr.NetworkServiceRegistryServer().Register(ctx, &registry.NetworkService{

--- a/pkg/registry/common/heal/find_test.go
+++ b/pkg/registry/common/heal/find_test.go
@@ -55,7 +55,7 @@ func TestHealClient_FindTest(t *testing.T) {
 	// 1. Create NS, NSE find clients
 	findCtx, findCancel := context.WithCancel(ctx)
 
-	nsRegistryClient := registryclient.NewNetworkServiceRegistryClient(ctx, domain.Nodes[0].NSMgr.URL,
+	nsRegistryClient := registryclient.NewNetworkServiceRegistryClient(ctx, domain.Nodes[0].URL(),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nsStream, err := nsRegistryClient.Find(findCtx, &registry.NetworkServiceQuery{
@@ -64,7 +64,7 @@ func TestHealClient_FindTest(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, domain.Nodes[0].NSMgr.URL,
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, domain.Nodes[0].URL(),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nseStream, err := nseRegistryClient.Find(findCtx, &registry.NetworkServiceEndpointQuery{

--- a/pkg/registry/common/heal/find_test.go
+++ b/pkg/registry/common/heal/find_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
+	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
@@ -54,13 +55,19 @@ func TestHealClient_FindTest(t *testing.T) {
 	// 1. Create NS, NSE find clients
 	findCtx, findCancel := context.WithCancel(ctx)
 
-	nsStream, err := domain.Nodes[0].NSRegistryClient.Find(findCtx, &registry.NetworkServiceQuery{
+	nsRegistryClient := registryclient.NewNetworkServiceRegistryClient(ctx, domain.Nodes[0].NSMgr.URL,
+		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
+
+	nsStream, err := nsRegistryClient.Find(findCtx, &registry.NetworkServiceQuery{
 		NetworkService: new(registry.NetworkService),
 		Watch:          true,
 	})
 	require.NoError(t, err)
 
-	nseStream, err := domain.Nodes[0].EndpointRegistryClient.Find(findCtx, &registry.NetworkServiceEndpointQuery{
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, domain.Nodes[0].NSMgr.URL,
+		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
+
+	nseStream, err := nseRegistryClient.Find(findCtx, &registry.NetworkServiceEndpointQuery{
 		NetworkServiceEndpoint: new(registry.NetworkServiceEndpoint),
 		Watch:                  true,
 	})

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -27,239 +27,69 @@ import (
 	"testing"
 	"time"
 
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
-
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
-	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgrproxy"
-	"github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/memory"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/proxydns"
 	registryconnect "github.com/networkservicemesh/sdk/pkg/registry/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/dnsresolve"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
-	"github.com/networkservicemesh/sdk/pkg/tools/opentracing"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
 // Builder implements builder pattern for building NSM Domain
 type Builder struct {
-	require                *require.Assertions
-	resources              []context.CancelFunc
-	nodesCount             int
-	nodesConfig            []*NodeConfig
-	DNSDomainName          string
-	resolver               dnsresolve.Resolver
-	supplyNSMgr            SupplyNSMgrFunc
-	supplyNSMgrProxy       SupplyNSMgrProxyFunc
-	supplyRegistry         SupplyRegistryFunc
-	supplyRegistryProxy    SupplyRegistryProxyFunc
-	setupNode              SetupNodeFunc
+	t   *testing.T
+	ctx context.Context
+
+	nodesCount int
+
+	supplyNSMgr         SupplyNSMgrFunc
+	supplyNSMgrProxy    SupplyNSMgrProxyFunc
+	supplyRegistry      SupplyRegistryFunc
+	supplyRegistryProxy SupplyRegistryProxyFunc
+	setupNode           SetupNodeFunc
+
+	name                   string
+	dnsResolver            dnsresolve.Resolver
 	generateTokenFunc      token.GeneratorFunc
 	registryExpiryDuration time.Duration
-	ctx                    context.Context
-	t                      *testing.T
 
 	useUnixSockets bool
-	sockPath       string
-	usedAddress    int
+
+	domain *Domain
 }
 
 // NewBuilder creates new SandboxBuilder
-func NewBuilder(t *testing.T) *Builder {
-	return &Builder{
+func NewBuilder(ctx context.Context, t *testing.T) *Builder {
+	b := &Builder{
+		t:                      t,
+		ctx:                    ctx,
 		nodesCount:             1,
-		require:                require.New(t),
 		supplyNSMgr:            nsmgr.NewServer,
-		DNSDomainName:          "cluster.local",
+		supplyNSMgrProxy:       nsmgrproxy.NewServer,
 		supplyRegistry:         memory.NewServer,
 		supplyRegistryProxy:    proxydns.NewServer,
-		supplyNSMgrProxy:       nsmgrproxy.NewServer,
-		setupNode:              defaultSetupNode(t),
+		name:                   "cluster.local",
+		dnsResolver:            new(FakeDNSResolver),
 		generateTokenFunc:      GenerateTestToken,
 		registryExpiryDuration: time.Minute,
-		resolver:               new(FakeDNSResolver),
-		t:                      t,
-
-		useUnixSockets: false,
-	}
-}
-
-// Build builds Domain and Supplier
-func (b *Builder) Build() *Domain {
-	ctx := b.ctx
-	if ctx == nil {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-		b.resources = append(b.resources, cancel)
-	}
-	ctx = log.Join(ctx, log.Empty())
-
-	domain := new(Domain)
-
-	if b.useUnixSockets {
-		var err error
-		b.sockPath, err = ioutil.TempDir(os.TempDir(), "nsm-domain-temp")
-		b.require.NoError(err)
-		domain.domainTemp = b.sockPath
 	}
 
-	domain.RegistryProxy = b.newRegistryProxy(ctx)
-
-	var nsmgrProxyURL = new(url.URL)
-
-	if domain.RegistryProxy == nil {
-		domain.Registry = b.newRegistry(ctx, nil)
-	} else {
-		domain.Registry = b.newRegistry(ctx, nsmgrProxyURL)
+	b.setupNode = func(ctx context.Context, node *Node, _ int) {
+		SetupDefaultNode(ctx, node, b.supplyNSMgr)
 	}
 
-	if domain.RegistryProxy != nil {
-		domain.NSMgrProxy = b.newNSMgrProxy(ctx, domain.Registry.URL, domain.RegistryProxy.URL)
-		*nsmgrProxyURL = *domain.NSMgrProxy.URL
-	}
-
-	var registryURL *url.URL
-	if domain.Registry != nil {
-		registryURL = domain.Registry.URL
-	}
-
-	for i := 0; i < b.nodesCount; i++ {
-		domain.Nodes = append(domain.Nodes, b.newNode(ctx, registryURL, b.nodesConfig[i]))
-	}
-
-	domain.resources, b.resources = b.resources, nil
-
-	b.t.Cleanup(domain.cleanup)
-
-	b.buildDNSServer(domain)
-	domain.Name = b.DNSDomainName
-
-	return domain
-}
-
-func (b *Builder) buildDNSServer(d *Domain) {
-	resolver, ok := b.resolver.(*FakeDNSResolver)
-	if !ok {
-		return
-	}
-
-	if d.Registry != nil {
-		resolver.AddSRVEntry(b.DNSDomainName, dnsresolve.DefaultRegistryService, d.Registry.URL)
-	}
-	if d.NSMgrProxy != nil {
-		resolver.AddSRVEntry(b.DNSDomainName, dnsresolve.DefaultNsmgrProxyService, d.NSMgrProxy.URL)
-	}
-}
-
-// SetContext sets default context for all chains
-func (b *Builder) SetContext(ctx context.Context) *Builder {
-	b.ctx = ctx
-	b.SetCustomConfig([]*NodeConfig{})
-	return b
-}
-
-// SetCustomConfig sets custom configuration for nodes
-func (b *Builder) SetCustomConfig(config []*NodeConfig) *Builder {
-	oldConfig := b.nodesConfig
-	b.nodesConfig = nil
-
-	for i := 0; i < b.nodesCount; i++ {
-		nodeConfig := &NodeConfig{}
-		if i < len(config) && config[i] != nil {
-			*nodeConfig = *oldConfig[i]
-		}
-
-		customConfig := &NodeConfig{}
-		if i < len(config) && config[i] != nil {
-			*customConfig = *config[i]
-		}
-
-		if customConfig.NsmgrCtx != nil {
-			nodeConfig.NsmgrCtx = customConfig.NsmgrCtx
-		} else if nodeConfig.NsmgrCtx == nil {
-			nodeConfig.NsmgrCtx = b.ctx
-		}
-
-		if customConfig.NsmgrGenerateTokenFunc != nil {
-			nodeConfig.NsmgrGenerateTokenFunc = customConfig.NsmgrGenerateTokenFunc
-		} else if nodeConfig.NsmgrGenerateTokenFunc == nil {
-			nodeConfig.NsmgrGenerateTokenFunc = b.generateTokenFunc
-		}
-
-		if customConfig.ForwarderCtx != nil {
-			nodeConfig.ForwarderCtx = customConfig.ForwarderCtx
-		} else if nodeConfig.ForwarderCtx == nil {
-			nodeConfig.ForwarderCtx = b.ctx
-		}
-
-		if customConfig.ForwarderGenerateTokenFunc != nil {
-			nodeConfig.ForwarderGenerateTokenFunc = customConfig.ForwarderGenerateTokenFunc
-		} else if nodeConfig.ForwarderGenerateTokenFunc == nil {
-			nodeConfig.ForwarderGenerateTokenFunc = b.generateTokenFunc
-		}
-
-		b.nodesConfig = append(b.nodesConfig, nodeConfig)
-	}
 	return b
 }
 
 // SetNodesCount sets nodes count
 func (b *Builder) SetNodesCount(nodesCount int) *Builder {
 	b.nodesCount = nodesCount
-	b.SetCustomConfig([]*NodeConfig{})
-	return b
-}
-
-// UseUnixSockets sets 1 node and mark it to use unix socket to listen on.
-func (b *Builder) UseUnixSockets() *Builder {
-	if runtime.GOOS == "windows" {
-		panic("Unix sockets are not available for windows")
-	}
-	b.useUnixSockets = true
-	return b
-}
-
-// SetDNSResolver sets DNS resolver for proxy registries
-func (b *Builder) SetDNSResolver(d dnsresolve.Resolver) *Builder {
-	b.resolver = d
-	return b
-}
-
-// SetTokenGenerateFunc sets function for the token generation
-func (b *Builder) SetTokenGenerateFunc(f token.GeneratorFunc) *Builder {
-	b.generateTokenFunc = f
-	return b
-}
-
-// SetRegistryProxySupplier replaces default memory registry supplier to custom function
-func (b *Builder) SetRegistryProxySupplier(f SupplyRegistryProxyFunc) *Builder {
-	b.supplyRegistryProxy = f
-	return b
-}
-
-// SetRegistrySupplier replaces default memory registry supplier to custom function
-func (b *Builder) SetRegistrySupplier(f SupplyRegistryFunc) *Builder {
-	b.supplyRegistry = f
-	return b
-}
-
-// SetDNSDomainName sets DNS domain name for the building NSM domain
-func (b *Builder) SetDNSDomainName(name string) *Builder {
-	b.DNSDomainName = name
-	return b
-}
-
-// SetNSMgrProxySupplier replaces default nsmgr-proxy supplier to custom function
-func (b *Builder) SetNSMgrProxySupplier(f SupplyNSMgrProxyFunc) *Builder {
-	b.supplyNSMgrProxy = f
 	return b
 }
 
@@ -269,9 +99,47 @@ func (b *Builder) SetNSMgrSupplier(f SupplyNSMgrFunc) *Builder {
 	return b
 }
 
+// SetNSMgrProxySupplier replaces default nsmgr-proxy supplier to custom function
+func (b *Builder) SetNSMgrProxySupplier(f SupplyNSMgrProxyFunc) *Builder {
+	b.supplyNSMgrProxy = f
+	return b
+}
+
+// SetRegistrySupplier replaces default memory registry supplier to custom function
+func (b *Builder) SetRegistrySupplier(f SupplyRegistryFunc) *Builder {
+	b.supplyRegistry = f
+	return b
+}
+
+// SetRegistryProxySupplier replaces default memory registry supplier to custom function
+func (b *Builder) SetRegistryProxySupplier(f SupplyRegistryProxyFunc) *Builder {
+	b.supplyRegistryProxy = f
+	return b
+}
+
 // SetNodeSetup replaces default node setup to custom function
 func (b *Builder) SetNodeSetup(f SetupNodeFunc) *Builder {
+	require.NotNil(b.t, f)
+
 	b.setupNode = f
+	return b
+}
+
+// SetDNSDomainName sets DNS domain name for the building NSM domain
+func (b *Builder) SetDNSDomainName(name string) *Builder {
+	b.name = name
+	return b
+}
+
+// SetDNSResolver sets DNS resolver for proxy registries
+func (b *Builder) SetDNSResolver(d dnsresolve.Resolver) *Builder {
+	b.dnsResolver = d
+	return b
+}
+
+// SetTokenGenerateFunc sets function for the token generation
+func (b *Builder) SetTokenGenerateFunc(f token.GeneratorFunc) *Builder {
+	b.generateTokenFunc = f
 	return b
 }
 
@@ -281,26 +149,136 @@ func (b *Builder) SetRegistryExpiryDuration(registryExpiryDuration time.Duration
 	return b
 }
 
-func (b *Builder) dialContext(ctx context.Context, u *url.URL) *grpc.ClientConn {
-	conn, err := grpc.DialContext(ctx, grpcutils.URLToTarget(u), DefaultDialOptions(b.generateTokenFunc)...)
-	b.resources = append(b.resources, func() {
-		_ = conn.Close()
-	})
-	b.require.NoError(err, "Can not dial to %v", u)
-	return conn
+// UseUnixSockets sets 1 node and mark it to use unix socket to listen on.
+func (b *Builder) UseUnixSockets() *Builder {
+	require.NotEqual(b.t, "windows", runtime.GOOS, "Unix sockets are not available for windows")
+
+	b.nodesCount = 1
+	b.supplyNSMgrProxy = nil
+	b.supplyRegistry = nil
+	b.supplyRegistryProxy = nil
+	b.useUnixSockets = true
+	return b
 }
 
-func (b *Builder) newNSMgrProxy(ctx context.Context, registryURL, registryProxyURL *url.URL) *EndpointEntry {
-	if b.supplyRegistryProxy == nil {
-		return nil
+// Build builds Domain and Supplier
+func (b *Builder) Build() *Domain {
+	b.domain = &Domain{
+		Name:        b.name,
+		DNSResolver: b.dnsResolver,
 	}
-	name := "nsmgr-proxy-" + uuid.New().String()
-	serveURL := grpcutils.TargetToURL(b.newAddress("nsmgr-proxy"))
-	mgr := b.supplyNSMgrProxy(ctx,
-		registryURL,
-		registryProxyURL,
+
+	if b.useUnixSockets {
+		msg := "Unix sockets are available only for local tests with no external registry"
+		require.Equal(b.t, b.nodesCount, 1, msg)
+		require.Nil(b.t, b.supplyNSMgrProxy, msg)
+		require.Nil(b.t, b.supplyRegistry, msg)
+		require.Nil(b.t, b.supplyRegistryProxy, msg)
+
+		sockPath, err := ioutil.TempDir(os.TempDir(), "nsm-domain-temp")
+		require.NoError(b.t, err)
+
+		go func() {
+			<-b.ctx.Done()
+			_ = os.RemoveAll(sockPath)
+		}()
+
+		b.domain.supplyURL = b.supplyUnixAddress(sockPath, new(int))
+	} else {
+		b.domain.supplyURL = b.supplyTCPAddress()
+	}
+
+	if b.supplyRegistryProxy != nil {
+		require.NotNil(b.t, b.supplyNSMgrProxy, "NSMgr proxy supplier should be set if registry proxy supplier is set")
+		b.domain.NSMgrProxy = &EndpointEntry{
+			URL: b.domain.supplyURL("nsmgr-proxy"),
+		}
+	}
+
+	b.newRegistryProxy()
+	b.newRegistry()
+	b.newNSMgrProxy()
+	for i := 0; i < b.nodesCount; i++ {
+		b.newNode(i)
+	}
+
+	b.buildDNSServer()
+
+	return b.domain
+}
+
+func (b *Builder) supplyUnixAddress(sockPath string, usedAddress *int) func(prefix string) *url.URL {
+	return func(prefix string) *url.URL {
+		defer func() { *usedAddress++ }()
+		return &url.URL{
+			Scheme: "unix",
+			Path:   fmt.Sprintf("%s/%s_%d.sock", sockPath, prefix, *usedAddress),
+		}
+	}
+}
+
+func (b *Builder) supplyTCPAddress() func(prefix string) *url.URL {
+	return func(_ string) *url.URL {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(b.t, err)
+		defer func() { _ = l.Close() }()
+
+		return grpcutils.AddressToURL(l.Addr())
+	}
+}
+
+func (b *Builder) newRegistryProxy() {
+	if b.supplyRegistryProxy == nil {
+		return
+	}
+
+	registryProxy := b.supplyRegistryProxy(b.ctx, b.dnsResolver, DefaultDialOptions(b.generateTokenFunc)...)
+	serveURL := b.domain.supplyURL("reg-proxy")
+
+	serve(b.ctx, b.t, serveURL, registryProxy.Register)
+
+	log.FromContext(b.ctx).Debugf("%s: registry-proxy-dns on: %v", b.name, serveURL)
+
+	b.domain.RegistryProxy = &RegistryEntry{
+		URL:      serveURL,
+		Registry: registryProxy,
+	}
+}
+
+func (b *Builder) newRegistry() {
+	if b.supplyRegistry == nil {
+		return
+	}
+
+	var nsmgrProxyURL *url.URL
+	if b.domain.NSMgrProxy != nil {
+		nsmgrProxyURL = b.domain.NSMgrProxy.URL
+	}
+
+	registry := b.supplyRegistry(b.ctx, b.registryExpiryDuration, nsmgrProxyURL, DefaultDialOptions(b.generateTokenFunc)...)
+	serveURL := b.domain.supplyURL("reg")
+
+	serve(b.ctx, b.t, serveURL, registry.Register)
+
+	log.FromContext(b.ctx).Debugf("%s: registry on: %v", b.name, serveURL)
+
+	b.domain.Registry = &RegistryEntry{
+		URL:      serveURL,
+		Registry: registry,
+	}
+}
+
+func (b *Builder) newNSMgrProxy() {
+	if b.supplyRegistryProxy == nil {
+		return
+	}
+
+	name := UniqueName("nsmgr-proxy")
+	mgr := b.supplyNSMgrProxy(b.ctx,
+		b.domain.Registry.URL,
+		b.domain.RegistryProxy.URL,
 		b.generateTokenFunc,
-		nsmgrproxy.WithListenOn(serveURL),
+		nsmgrproxy.WithListenOn(b.domain.NSMgrProxy.URL),
 		nsmgrproxy.WithName(name),
 		nsmgrproxy.WithConnectOptions(
 			connect.WithDialTimeout(DialTimeout),
@@ -310,162 +288,36 @@ func (b *Builder) newNSMgrProxy(ctx context.Context, registryURL, registryProxyU
 		),
 	)
 
-	serve(ctx, serveURL, mgr.Register)
-	log.FromContext(ctx).Debugf("%v: %v listen on: %v", b.DNSDomainName, name, serveURL)
-	return &EndpointEntry{
-		Endpoint: mgr,
-		URL:      serveURL,
-	}
+	serve(b.ctx, b.t, b.domain.NSMgrProxy.URL, mgr.Register)
+
+	log.FromContext(b.ctx).Debugf("%s: NSMgr proxy %s on: %v", b.name, name, b.domain.NSMgrProxy.URL)
+
+	b.domain.NSMgrProxy.Endpoint = mgr
 }
 
-// NewNSMgr - starts new Network Service Manager
-func (b *Builder) NewNSMgr(ctx context.Context, node *Node, address string, registryURL *url.URL, generateTokenFunc token.GeneratorFunc) (entry *NSMgrEntry, resources []context.CancelFunc) {
-	nsmgrCtx, nsmgrCancel := context.WithCancel(ctx)
-	b.resources = append(b.resources, nsmgrCancel)
-
-	entry = b.newNSMgr(nsmgrCtx, address, registryURL, generateTokenFunc)
-
-	b.SetupRegistryClients(ctx, node)
-
-	resources, b.resources = b.resources, nil
-	return
-}
-
-func (b *Builder) newNSMgr(ctx context.Context, address string, registryURL *url.URL, generateTokenFunc token.GeneratorFunc) *NSMgrEntry {
-	if b.supplyNSMgr == nil {
-		return nil
-	}
-
-	var serveURL *url.URL
-	if b.useUnixSockets {
-		serveURL = grpcutils.TargetToURL(address)
-	} else {
-		listener, err := net.Listen("tcp", address)
-		b.require.NoError(err)
-		serveURL = grpcutils.AddressToURL(listener.Addr())
-		b.require.NoError(listener.Close())
-	}
-
-	nsmgrName := "nsmgr-" + uuid.New().String()
-
-	options := []nsmgr.Option{
-		nsmgr.WithName(nsmgrName),
-		nsmgr.WithAuthorizeServer(authorize.NewServer(authorize.Any())),
-		nsmgr.WithConnectOptions(
-			connect.WithDialTimeout(DialTimeout),
-			connect.WithDialOptions(DefaultDialOptions(generateTokenFunc)...)),
-	}
-
-	if registryURL != nil {
-		options = append(options, nsmgr.WithRegistry(registryURL, DefaultDialOptions(generateTokenFunc)...))
-	}
-
-	if serveURL.Scheme == "tcp" {
-		options = append(options, nsmgr.WithURL(serveURL.String()))
-	}
-
-	mgr := b.supplyNSMgr(ctx, generateTokenFunc, options...)
-
-	serve(ctx, serveURL, mgr.Register)
-	log.FromContext(ctx).Debugf("%v: %v listen on: %v", b.DNSDomainName, nsmgrName, serveURL)
-	return &NSMgrEntry{
-		URL:   serveURL,
-		Nsmgr: mgr,
-	}
-}
-
-func serve(ctx context.Context, u *url.URL, register func(server *grpc.Server)) {
-	server := grpc.NewServer(opentracing.WithTracing()...)
-	register(server)
-	errCh := grpcutils.ListenAndServe(ctx, u, server)
-	go func() {
-		select {
-		case <-ctx.Done():
-			log.FromContext(ctx).Debugf("Stop serve: %v", u.String())
-			return
-		case err := <-errCh:
-			if err != nil {
-				log.FromContext(ctx).Fatalf("An error during serve: %v", err.Error())
-			}
-		}
-	}()
-}
-
-func (b *Builder) newRegistryProxy(ctx context.Context) *RegistryEntry {
-	if b.supplyRegistryProxy == nil {
-		return nil
-	}
-	result := b.supplyRegistryProxy(ctx, b.resolver, DefaultDialOptions(b.generateTokenFunc)...)
-	serveURL := grpcutils.TargetToURL(b.newAddress("reg-proxy"))
-	serve(ctx, serveURL, result.Register)
-	log.FromContext(ctx).Debugf("%v: registry-proxy-dns listen on: %v", b.DNSDomainName, serveURL)
-	return &RegistryEntry{
-		URL:      serveURL,
-		Registry: result,
-	}
-}
-
-func (b *Builder) newRegistry(ctx context.Context, proxyRegistryURL *url.URL) *RegistryEntry {
-	if b.supplyRegistry == nil {
-		return nil
-	}
-	result := b.supplyRegistry(ctx, b.registryExpiryDuration, proxyRegistryURL, DefaultDialOptions(b.generateTokenFunc)...)
-	serveURL := grpcutils.TargetToURL(b.newAddress("reg"))
-	serve(ctx, serveURL, result.Register)
-	log.FromContext(ctx).Debugf("%v: registry listen on: %v", b.DNSDomainName, serveURL)
-	return &RegistryEntry{
-		URL:      serveURL,
-		Registry: result,
-	}
-}
-
-func (b *Builder) newNode(ctx context.Context, registryURL *url.URL, nodeConfig *NodeConfig) *Node {
-	address := b.newAddress("nsmgr")
-	nsmgrEntry := b.newNSMgr(nodeConfig.NsmgrCtx, address, registryURL, nodeConfig.NsmgrGenerateTokenFunc)
-
+func (b *Builder) newNode(nodeNum int) {
 	node := &Node{
-		ctx:   b.ctx,
-		NSMgr: nsmgrEntry,
+		t:      b.t,
+		domain: b.domain,
 	}
 
-	b.SetupRegistryClients(ctx, node)
+	b.setupNode(b.ctx, node, nodeNum)
 
-	if b.setupNode != nil {
-		b.setupNode(ctx, node, nodeConfig)
-	}
+	require.NotNil(b.t, node.NSMgr, "NSMgr should be set for the node")
 
-	return node
+	b.domain.Nodes = append(b.domain.Nodes, node)
 }
 
-// SetupRegistryClients - creates Network Service Registry Clients
-func (b *Builder) SetupRegistryClients(ctx context.Context, node *Node) {
-	if node.NSMgr == nil {
+func (b *Builder) buildDNSServer() {
+	resolver, ok := b.dnsResolver.(*FakeDNSResolver)
+	if !ok {
 		return
 	}
 
-	dialOptions := DefaultDialOptions(b.generateTokenFunc)
-
-	node.ForwarderRegistryClient = client.NewNetworkServiceEndpointRegistryInterposeClient(ctx, node.NSMgr.URL, client.WithDialOptions(dialOptions...))
-	node.EndpointRegistryClient = client.NewNetworkServiceEndpointRegistryClient(ctx, node.NSMgr.URL, client.WithDialOptions(dialOptions...))
-	node.NSRegistryClient = client.NewNetworkServiceRegistryClient(ctx, node.NSMgr.URL, client.WithDialOptions(dialOptions...))
-}
-
-// newAddress - will return a new public address, if unixSockets are used prefix will be used to make uniq files.
-func (b *Builder) newAddress(prefix string) string {
-	if !b.useUnixSockets {
-		return "127.0.0.1:0"
+	if b.domain.Registry != nil {
+		resolver.AddSRVEntry(b.name, dnsresolve.DefaultRegistryService, b.domain.Registry.URL)
 	}
-
-	b.usedAddress++
-	return fmt.Sprintf("unix:%s/%s_%d.sock", b.sockPath, prefix, b.usedAddress)
-}
-
-func defaultSetupNode(t *testing.T) SetupNodeFunc {
-	return func(ctx context.Context, node *Node, nodeConfig *NodeConfig) {
-		nseReg := &registryapi.NetworkServiceEndpoint{
-			Name: "forwarder",
-		}
-		_, err := node.NewForwarder(nodeConfig.ForwarderCtx, nseReg, nodeConfig.ForwarderGenerateTokenFunc)
-		require.NoError(t, err)
+	if b.domain.NSMgrProxy != nil {
+		resolver.AddSRVEntry(b.name, dnsresolve.DefaultNsmgrProxyService, b.domain.NSMgrProxy.URL)
 	}
 }

--- a/pkg/tools/sandbox/grpc_utils.go
+++ b/pkg/tools/sandbox/grpc_utils.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/networkservicemesh/sdk/pkg/tools/opentracing"
+)
+
+func serve(ctx context.Context, t *testing.T, u *url.URL, register func(server *grpc.Server)) {
+	server := grpc.NewServer(append([]grpc.ServerOption{
+		grpc.Creds(grpcfdTransportCredentials(insecure.NewCredentials())),
+	}, opentracing.WithTracing()...)...)
+	register(server)
+
+	errCh := grpcutils.ListenAndServe(ctx, u, server)
+	go func() {
+		select {
+		case <-ctx.Done():
+			log.FromContext(ctx).Infof("Stop serve: %v", u.String())
+			return
+		case err := <-errCh:
+			require.NoError(t, err)
+		}
+	}()
+}

--- a/pkg/tools/sandbox/grpc_utils_notwindows.go
+++ b/pkg/tools/sandbox/grpc_utils_notwindows.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sandbox
+
+import (
+	"github.com/edwarnicke/grpcfd"
+	"google.golang.org/grpc/credentials"
+)
+
+// grpcfdTransportCredentials is a wrapper for grpcfd.TransportCredentials.
+func grpcfdTransportCredentials(cred credentials.TransportCredentials) credentials.TransportCredentials {
+	return grpcfd.TransportCredentials(cred)
+}

--- a/pkg/tools/sandbox/grpc_utils_windows.go
+++ b/pkg/tools/sandbox/grpc_utils_windows.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package sandbox
+
+import "google.golang.org/grpc/credentials"
+
+// grpcfdTransportCredentials is a wrapper for grpcfd.TransportCredentials. Since grpcfd is not defined for windows, it
+// simply returns cred.
+func grpcfdTransportCredentials(cred credentials.TransportCredentials) credentials.TransportCredentials {
+	return cred
+}

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -48,6 +48,13 @@ type Node struct {
 	NSMgr *NSMgrEntry
 }
 
+// URL returns node NSMgr URL
+func (n *Node) URL() *url.URL {
+	u := new(url.URL)
+	*u = *n.NSMgr.URL
+	return u
+}
+
 // NewNSMgr creates a new NSMgr
 func (n *Node) NewNSMgr(
 	ctx context.Context,
@@ -108,7 +115,7 @@ func (n *Node) NewForwarder(
 
 	entry := new(EndpointEntry)
 	additionalFunctionality = append(additionalFunctionality,
-		clienturl.NewServer(n.NSMgr.URL),
+		clienturl.NewServer(n.URL()),
 		heal.NewServer(ctx,
 			heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(entry))),
 			heal.WithOnRestore(heal.OnRestoreIgnore)),
@@ -128,7 +135,7 @@ func (n *Node) NewForwarder(
 		ctx,
 		nse,
 		generatorFunc,
-		registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, n.NSMgr.URL,
+		registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, n.URL(),
 			registryclient.WithDialOptions(dialOptions...)),
 		additionalFunctionality...,
 	)
@@ -151,7 +158,7 @@ func (n *Node) NewEndpoint(
 		ctx,
 		nse,
 		generatorFunc,
-		registryclient.NewNetworkServiceEndpointRegistryClient(ctx, n.NSMgr.URL,
+		registryclient.NewNetworkServiceEndpointRegistryClient(ctx, n.URL(),
 			registryclient.WithDialOptions(DefaultDialOptions(generatorFunc)...)),
 		additionalFunctionality...,
 	)
@@ -200,7 +207,7 @@ func (n *Node) NewClient(
 ) networkservice.NetworkServiceClient {
 	return client.NewClient(
 		ctx,
-		n.NSMgr.URL,
+		n.URL(),
 		client.WithDialOptions(DefaultDialOptions(generatorFunc)...),
 		client.WithDialTimeout(DialTimeout),
 		client.WithAuthorizeClient(authorize.NewClient(authorize.Any())),

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -19,18 +19,22 @@ package sandbox
 import (
 	"context"
 	"net/url"
+	"testing"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/heal"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanismtranslation"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
+	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
@@ -38,12 +42,67 @@ import (
 
 // Node is a NSMgr with Forwarder, NSE registry clients
 type Node struct {
-	ctx                     context.Context
+	t      *testing.T
+	domain *Domain
+
 	NSMgr                   *NSMgrEntry
-	Forwarder               []*EndpointEntry
 	ForwarderRegistryClient registryapi.NetworkServiceEndpointRegistryClient
 	EndpointRegistryClient  registryapi.NetworkServiceEndpointRegistryClient
 	NSRegistryClient        registryapi.NetworkServiceRegistryClient
+}
+
+// NewNSMgr creates a new NSMgr
+func (n *Node) NewNSMgr(
+	ctx context.Context,
+	name string,
+	serveURL *url.URL,
+	generatorFunc token.GeneratorFunc,
+	supplyNSMgr SupplyNSMgrFunc,
+) *NSMgrEntry {
+	if serveURL == nil {
+		serveURL = n.domain.supplyURL("nsmgr")
+	}
+
+	dialOptions := DefaultDialOptions(generatorFunc)
+
+	options := []nsmgr.Option{
+		nsmgr.WithName(name),
+		nsmgr.WithAuthorizeServer(authorize.NewServer(authorize.Any())),
+		nsmgr.WithConnectOptions(
+			connect.WithDialTimeout(DialTimeout),
+			connect.WithDialOptions(dialOptions...)),
+	}
+
+	if n.domain.Registry != nil {
+		options = append(options, nsmgr.WithRegistry(n.domain.Registry.URL, dialOptions...))
+	}
+
+	if serveURL.Scheme != "unix" {
+		options = append(options, nsmgr.WithURL(serveURL.String()))
+	}
+
+	entry := &NSMgrEntry{
+		Nsmgr: supplyNSMgr(ctx, generatorFunc, options...),
+		Name:  name,
+		URL:   serveURL,
+	}
+
+	serve(ctx, n.t, serveURL, entry.Register)
+
+	log.FromContext(ctx).Debugf("%s: NSMgr %s on %v", n.domain.Name, name, serveURL)
+
+	if n.NSMgr == nil || n.NSMgr.URL.String() != serveURL.String() {
+		n.ForwarderRegistryClient = registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, serveURL,
+			registryclient.WithDialOptions(dialOptions...))
+		n.EndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(ctx, serveURL,
+			registryclient.WithDialOptions(dialOptions...))
+		n.NSRegistryClient = registryclient.NewNetworkServiceRegistryClient(ctx, serveURL,
+			registryclient.WithDialOptions(dialOptions...))
+	}
+
+	n.NSMgr = entry
+
+	return entry
 }
 
 // NewForwarder starts a new forwarder and registers it on the node NSMgr
@@ -52,12 +111,16 @@ func (n *Node) NewForwarder(
 	nse *registryapi.NetworkServiceEndpoint,
 	generatorFunc token.GeneratorFunc,
 	additionalFunctionality ...networkservice.NetworkServiceServer,
-) (*EndpointEntry, error) {
-	ep := new(EndpointEntry)
+) *EndpointEntry {
+	if nse.Url == "" {
+		nse.Url = n.domain.supplyURL("forwarder").String()
+	}
+
+	entry := new(EndpointEntry)
 	additionalFunctionality = append(additionalFunctionality,
 		clienturl.NewServer(n.NSMgr.URL),
 		heal.NewServer(ctx,
-			heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(ep))),
+			heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(entry))),
 			heal.WithOnRestore(heal.OnRestoreIgnore)),
 		connect.NewServer(ctx,
 			client.NewClientFactory(
@@ -71,13 +134,9 @@ func (n *Node) NewForwarder(
 		),
 	)
 
-	entry, err := n.newEndpoint(ctx, nse, generatorFunc, n.ForwarderRegistryClient, additionalFunctionality...)
-	if err != nil {
-		return nil, err
-	}
-	*ep = *entry
-	n.Forwarder = append(n.Forwarder, ep)
-	return ep, nil
+	*entry = *n.newEndpoint(ctx, nse, generatorFunc, n.ForwarderRegistryClient, additionalFunctionality...)
+
+	return entry
 }
 
 // NewEndpoint starts a new endpoint and registers it on the node NSMgr
@@ -86,7 +145,11 @@ func (n *Node) NewEndpoint(
 	nse *registryapi.NetworkServiceEndpoint,
 	generatorFunc token.GeneratorFunc,
 	additionalFunctionality ...networkservice.NetworkServiceServer,
-) (*EndpointEntry, error) {
+) *EndpointEntry {
+	if nse.Url == "" {
+		nse.Url = n.domain.supplyURL("nse").String()
+	}
+
 	return n.newEndpoint(ctx, nse, generatorFunc, n.EndpointRegistryClient, additionalFunctionality...)
 }
 
@@ -96,40 +159,32 @@ func (n *Node) newEndpoint(
 	generatorFunc token.GeneratorFunc,
 	registryClient registryapi.NetworkServiceEndpointRegistryClient,
 	additionalFunctionality ...networkservice.NetworkServiceServer,
-) (_ *EndpointEntry, err error) {
-	// 1. Create endpoint server
-	ep := endpoint.NewServer(ctx, generatorFunc,
-		endpoint.WithName(nse.Name),
+) *EndpointEntry {
+	name := nse.Name
+	entry := endpoint.NewServer(ctx, generatorFunc,
+		endpoint.WithName(name),
 		endpoint.WithAdditionalFunctionality(additionalFunctionality...),
 	)
 
-	// 2. Start listening on URL
-	u := &url.URL{Scheme: "tcp", Host: "127.0.0.1:0"}
-	if nse.Url != "" {
-		u, err = url.Parse(nse.Url)
-		if err != nil {
-			return nil, err
-		}
-	}
+	serveURL, err := url.Parse(nse.Url)
+	require.NoError(n.t, err)
 
-	ctx = log.Join(ctx, log.Empty())
-	serve(ctx, u, ep.Register)
+	serve(ctx, n.t, serveURL, entry.Register)
 
-	nse.Url = u.String()
-
-	// 3. Register with the node registry client
-	var reg *registryapi.NetworkServiceEndpoint
-	if reg, err = registryClient.Register(ctx, nse); err != nil {
-		return nil, err
-	}
+	reg, err := registryClient.Register(ctx, nse)
+	require.NoError(n.t, err)
 
 	nse.Name = reg.Name
 	nse.ExpirationTime = reg.ExpirationTime
 	nse.NetworkServiceLabels = reg.NetworkServiceLabels
 
-	log.FromContext(ctx).Debugf("Started listen endpoint %s on %s.", nse.Name, u.String())
+	log.FromContext(ctx).Debugf("%s: endpoint %s on %v", n.domain.Name, nse.Name, serveURL)
 
-	return &EndpointEntry{Endpoint: ep, URL: u}, nil
+	return &EndpointEntry{
+		Endpoint: entry,
+		Name:     name,
+		URL:      serveURL,
+	}
 }
 
 // NewClient starts a new client and connects it to the node NSMgr
@@ -138,7 +193,6 @@ func (n *Node) NewClient(
 	generatorFunc token.GeneratorFunc,
 	additionalFunctionality ...networkservice.NetworkServiceClient,
 ) networkservice.NetworkServiceClient {
-	ctx = log.Join(ctx, log.Empty())
 	return client.NewClient(
 		ctx,
 		n.NSMgr.URL,

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -75,7 +75,7 @@ type EndpointEntry struct {
 // Domain contains attached to domain nodes, registry
 type Domain struct {
 	Nodes         []*Node
-	NSMgrProxy    *EndpointEntry
+	NSMgrProxy    *NSMgrEntry
 	Registry      *RegistryEntry
 	RegistryProxy *RegistryEntry
 

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -92,7 +92,7 @@ func (d *Domain) NewNSRegistryClient(ctx context.Context, generatorFunc token.Ge
 	case d.Registry != nil:
 		registryURL = d.Registry.URL
 	case len(d.Nodes) != 0:
-		registryURL = d.Nodes[0].NSMgr.URL
+		registryURL = d.Nodes[0].URL()
 	default:
 		return nil
 	}

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -19,7 +19,6 @@ package sandbox
 import (
 	"context"
 	"net/url"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -36,7 +35,7 @@ import (
 type SupplyNSMgrProxyFunc func(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator token.GeneratorFunc, options ...nsmgrproxy.Option) nsmgr.Nsmgr
 
 // SupplyNSMgrFunc supplies NSMGR
-type SupplyNSMgrFunc func(context.Context, token.GeneratorFunc, ...nsmgr.Option) nsmgr.Nsmgr
+type SupplyNSMgrFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgr.Option) nsmgr.Nsmgr
 
 // SupplyRegistryFunc supplies Registry
 type SupplyRegistryFunc func(ctx context.Context, expiryDuration time.Duration, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry
@@ -45,7 +44,7 @@ type SupplyRegistryFunc func(ctx context.Context, expiryDuration time.Duration, 
 type SupplyRegistryProxyFunc func(ctx context.Context, dnsResolver dnsresolve.Resolver, options ...grpc.DialOption) registry.Registry
 
 // SetupNodeFunc setups each node on Builder.Build() stage
-type SetupNodeFunc func(ctx context.Context, node *Node, config *NodeConfig)
+type SetupNodeFunc func(ctx context.Context, node *Node, nodeNum int)
 
 // RegistryEntry is pair of registry.Registry and url.URL
 type RegistryEntry struct {
@@ -56,13 +55,15 @@ type RegistryEntry struct {
 // NSMgrEntry is pair of nsmgr.Nsmgr and url.URL
 type NSMgrEntry struct {
 	nsmgr.Nsmgr
-	URL *url.URL
+	Name string
+	URL  *url.URL
 }
 
 // EndpointEntry is pair of endpoint.Endpoint and url.URL
 type EndpointEntry struct {
 	endpoint.Endpoint
-	URL *url.URL
+	Name string
+	URL  *url.URL
 }
 
 // Domain contains attached to domain nodes, registry
@@ -71,33 +72,9 @@ type Domain struct {
 	NSMgrProxy    *EndpointEntry
 	Registry      *RegistryEntry
 	RegistryProxy *RegistryEntry
-	DNSResolver   dnsresolve.Resolver
-	Name          string
-	resources     []context.CancelFunc
-	domainTemp    string
-}
 
-// NodeConfig keeps custom node configuration parameters
-type NodeConfig struct {
-	NsmgrCtx                   context.Context
-	NsmgrGenerateTokenFunc     token.GeneratorFunc
-	ForwarderCtx               context.Context
-	ForwarderGenerateTokenFunc token.GeneratorFunc
-}
+	DNSResolver dnsresolve.Resolver
+	Name        string
 
-// AddResources appends resources to the Domain to close it later
-func (d *Domain) AddResources(resources []context.CancelFunc) {
-	d.resources = append(d.resources, resources...)
-}
-
-// Cleanup frees all resources related to the domain
-func (d *Domain) cleanup() {
-	for _, r := range d.resources {
-		r()
-	}
-
-	// Remove Nsmgr local unix socket file if exists.
-	if d.domainTemp != "" {
-		_ = os.RemoveAll(d.domainTemp)
-	}
+	supplyURL func(prefix string) *url.URL
 }


### PR DESCRIPTION
Sandbox rework for #740. Corresponding heal tests rework.

Changes:
1. adds `Node.NewNSMgr`
2. all `sandbox` methods now handle errors inside with `require.NoError`
3. removes `Builder.SetCustomConfig` - replaces it with extended `Builder.SetNodeSetup`
4. removes `Domain.resources` - every resource now has a goroutine waiting on the corresponding context
5. adds `.Name` to `NSMgrEntry`, `EndpointEntry` to enable emulation of `NSMgr`/`Forwarder`/`Endpoint` restart with same name + URL
6. removes `Node.Forwarder` - forwarder can be accessed after custom creation in `Builder.SetNodeSetup`