### PR TITLE
Docker sandbox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -176,20 +176,15 @@ issues:
     - path: .*registry.*.go
       linters:
         - dupl
+    # Sometimes test functions just get long :(
+    - path: .*_test.go
+      linters:
+        - funlen
     # TODO - remove after deciding how to properly handle the cancel
     - path: pkg/networkservice/common/connect/server.go
       linters:
         - govet
       text: "lostcancel"
-    # Sometimes test functions just get long :(
-    - path: pkg/networkservice/common/monitor/server_test.go
-      linters:
-        - funlen
-      text: "Function 'TestMonitor' is too long"
-    - path: pkg/networkservice/common/connect/server_test.go
-      linters:
-        - funlen
-      text: "Function 'TestConnectServerShouldNotPanicOnRequest' is too long"
     - path: pkg/networkservice/utils/checks/checkerror/server_test.go
       linters:
         - dupl

--- a/pkg/networkservice/chains/nsmgr/server_notwindows_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_notwindows_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package nsmgr_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
+	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
+)
+
+func TestNSMGR_LocalUsecaseUnix(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	domain := sandbox.NewBuilder(ctx, t).
+		UseUnixSockets().
+		SetNodesCount(1).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		SetRegistrySupplier(nil).
+		Build()
+
+	nseReg := &registry.NetworkServiceEndpoint{
+		Name:                "final-endpoint",
+		NetworkServiceNames: []string{"my-service-remote"},
+	}
+
+	counter := &counterServer{}
+	domain.Nodes[0].NewEndpoint(ctx, nseReg,
+		sandbox.WithEndpointAdditionalFunctionality(counter),
+	)
+
+	nsc := domain.Nodes[0].NewClient(ctx)
+
+	request := &networkservice.NetworkServiceRequest{
+		MechanismPreferences: []*networkservice.Mechanism{
+			{Cls: cls.LOCAL, Type: kernelmech.MECHANISM},
+		},
+		Connection: &networkservice.Connection{
+			Id:             "1",
+			NetworkService: "my-service-remote",
+			Context:        &networkservice.ConnectionContext{},
+		},
+	}
+
+	conn, err := nsc.Request(ctx, request.Clone())
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 5, len(conn.Path.PathSegments))
+
+	// Simulate refresh from client.
+
+	refreshRequest := request.Clone()
+	refreshRequest.Connection = conn.Clone()
+
+	conn2, err := nsc.Request(ctx, refreshRequest)
+	require.NoError(t, err)
+	require.NotNil(t, conn2)
+	require.Equal(t, 5, len(conn2.Path.PathSegments))
+	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+	// Close.
+
+	e, err := nsc.Close(ctx, conn)
+	require.NoError(t, err)
+	require.NotNil(t, e)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+}
+
+func TestNSMGR_RemoteUsecaseUnix(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	domain := sandbox.NewBuilder(ctx, t).
+		UseUnixSockets().
+		SetNodesCount(2).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		Build()
+
+	nseReg := &registry.NetworkServiceEndpoint{
+		Name:                "final-endpoint",
+		NetworkServiceNames: []string{"my-service-remote"},
+	}
+
+	counter := &counterServer{}
+	domain.Nodes[1].NewEndpoint(ctx, nseReg,
+		sandbox.WithEndpointAdditionalFunctionality(counter),
+	)
+
+	nsc := domain.Nodes[0].NewClient(ctx)
+
+	request := &networkservice.NetworkServiceRequest{
+		MechanismPreferences: []*networkservice.Mechanism{
+			{Cls: cls.LOCAL, Type: kernelmech.MECHANISM},
+		},
+		Connection: &networkservice.Connection{
+			Id:             "1",
+			NetworkService: "my-service-remote",
+			Context:        &networkservice.ConnectionContext{},
+		},
+	}
+
+	conn, err := nsc.Request(ctx, request.Clone())
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 8, len(conn.Path.PathSegments))
+
+	// Simulate refresh from client.
+
+	refreshRequest := request.Clone()
+	refreshRequest.Connection = conn.Clone()
+
+	conn2, err := nsc.Request(ctx, refreshRequest)
+	require.NoError(t, err)
+	require.NotNil(t, conn2)
+	require.Equal(t, 8, len(conn2.Path.PathSegments))
+	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+
+	// Close.
+	e, err := nsc.Close(ctx, conn)
+	require.NoError(t, err)
+	require.NotNil(t, e)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+}

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
@@ -56,10 +57,9 @@ func TestNSMGR_RemoteUsecase_Parallel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	counter := &counterServer{}
@@ -80,8 +80,7 @@ func TestNSMGR_RemoteUsecase_Parallel(t *testing.T) {
 			Name:                "final-endpoint",
 			NetworkServiceNames: []string{"my-service-remote"},
 		}
-		_, err := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
-		require.NoError(t, err)
+		domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 	}()
 	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -116,10 +115,9 @@ func TestNSMGR_SelectsRestartingEndpoint(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	request := &networkservice.NetworkServiceRequest{
@@ -175,10 +173,9 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	counter := new(counterServer)
@@ -201,8 +198,7 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 				Name:                "final-endpoint-" + strconv.Itoa(id),
 				NetworkServiceNames: []string{"my-service-remote"},
 			}
-			_, err := domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, newBusyEndpoint())
-			require.NoError(t, err)
+			domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, newBusyEndpoint())
 			wg.Done()
 		}(i)
 	}
@@ -213,8 +209,7 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 			Name:                "final-endpoint-3",
 			NetworkServiceNames: []string{"my-service-remote"},
 		}
-		_, err := domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
-		require.NoError(t, err)
+		domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 	}()
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -242,10 +237,9 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	nseReg := &registry.NetworkServiceEndpoint{
@@ -254,8 +248,7 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	_, err := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -300,9 +293,8 @@ func TestNSMGR_ConnectToDeadNSE(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
-		SetContext(ctx).
 		SetRegistryProxySupplier(nil).
 		Build()
 
@@ -314,8 +306,7 @@ func TestNSMGR_ConnectToDeadNSE(t *testing.T) {
 	counter := &counterServer{}
 
 	nseCtx, killNse := context.WithCancel(ctx)
-	_, err := domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, counter)
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -352,9 +343,8 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
-		SetContext(ctx).
 		SetNSMgrProxySupplier(nil).
 		SetRegistryProxySupplier(nil).
 		Build()
@@ -365,8 +355,7 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	_, err := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -412,9 +401,8 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 	defer cancel()
 
 	const nodesCount = 7
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(nodesCount).
-		SetContext(ctx).
 		SetRegistryProxySupplier(nil).
 		Build()
 
@@ -426,7 +414,7 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 				chain.NewNetworkServiceServer(
 					clienturl.NewServer(domain.Nodes[i].NSMgr.URL),
 					connect.NewServer(ctx,
-						sandbox.NewCrossConnectClientFactory(sandbox.GenerateTestToken,
+						sandbox.NewCrossConnectClientFactory(
 							newPassTroughClient(fmt.Sprintf("my-service-remote-%v", i-1)),
 							kernel.NewClient()),
 						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
@@ -438,8 +426,7 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 			Name:                fmt.Sprintf("endpoint-%v", i),
 			NetworkServiceNames: []string{fmt.Sprintf("my-service-remote-%v", i)},
 		}
-		_, err := domain.Nodes[i].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
-		require.NoError(t, err)
+		domain.Nodes[i].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
 	}
 
 	nsc := domain.Nodes[nodesCount-1].NewClient(ctx, sandbox.GenerateTestToken)
@@ -471,9 +458,8 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 	defer cancel()
 
 	const nsesCount = 7
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
-		SetContext(ctx).
 		SetRegistryProxySupplier(nil).
 		Build()
 
@@ -484,7 +470,7 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 				chain.NewNetworkServiceServer(
 					clienturl.NewServer(domain.Nodes[0].NSMgr.URL),
 					connect.NewServer(ctx,
-						sandbox.NewCrossConnectClientFactory(sandbox.GenerateTestToken,
+						sandbox.NewCrossConnectClientFactory(
 							newPassTroughClient(fmt.Sprintf("my-service-remote-%v", i-1)),
 							kernel.NewClient()),
 						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
@@ -496,8 +482,7 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 			Name:                fmt.Sprintf("endpoint-%v", i),
 			NetworkServiceNames: []string{fmt.Sprintf("my-service-remote-%v", i)},
 		}
-		_, err := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
-		require.NoError(t, err)
+		domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
 	}
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
@@ -528,12 +513,13 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
-		SetNodeSetup(nil).
+		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, _ int) {
+			node.NewNSMgr(ctx, sandbox.Name("nsmgr"), nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+		}).
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
-		SetContext(ctx).
 		Build()
 
 	forwarderReg := &registry.NetworkServiceEndpoint{
@@ -547,16 +533,13 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 
 	// 1. Add forwarders
 	forwarder1Reg := forwarderReg.Clone()
-	_, err := domain.Nodes[0].NewForwarder(ctx, forwarder1Reg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewForwarder(ctx, forwarder1Reg, sandbox.GenerateTestToken)
 
 	forwarder2Reg := forwarderReg.Clone()
-	_, err = domain.Nodes[0].NewForwarder(ctx, forwarder2Reg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewForwarder(ctx, forwarder2Reg, sandbox.GenerateTestToken)
 
 	forwarder3Reg := forwarderReg.Clone()
-	_, err = domain.Nodes[0].NewForwarder(ctx, forwarder3Reg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewForwarder(ctx, forwarder3Reg, sandbox.GenerateTestToken)
 
 	// 2. Wait for refresh
 	<-time.After(sandbox.RegistryExpiryDuration)
@@ -564,7 +547,7 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 	testNSEAndClient(ctx, t, domain, nseReg.Clone())
 
 	// 3. Delete first forwarder
-	_, err = domain.Nodes[0].ForwarderRegistryClient.Unregister(ctx, forwarder1Reg)
+	_, err := domain.Nodes[0].ForwarderRegistryClient.Unregister(ctx, forwarder1Reg)
 	require.NoError(t, err)
 
 	testNSEAndClient(ctx, t, domain, nseReg.Clone())
@@ -585,11 +568,10 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
-		SetContext(ctx).
 		Build()
 
 	nseReg := &registry.NetworkServiceEndpoint{
@@ -601,19 +583,17 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 	// 1. Add endpoints
 	nse1Reg := nseReg.Clone()
 	nse1Reg.NetworkServiceNames = []string{"service-1"}
-	_, err := domain.Nodes[0].NewEndpoint(ctx, nse1Reg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nse1Reg, sandbox.GenerateTestToken)
 
 	nse2Reg := nseReg.Clone()
 	nse2Reg.NetworkServiceNames = []string{"service-2"}
-	_, err = domain.Nodes[0].NewEndpoint(ctx, nse2Reg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nse2Reg, sandbox.GenerateTestToken)
 
 	// 2. Wait for refresh
 	<-time.After(sandbox.RegistryExpiryDuration)
 
 	// 3. Request
-	_, err = nsc.Request(ctx, &networkservice.NetworkServiceRequest{
+	_, err := nsc.Request(ctx, &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
 			NetworkService: "service-1",
 		},
@@ -641,10 +621,9 @@ func TestNSMGR_ShouldCleanAllClientAndEndpointGoroutines(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
-		SetContext(ctx).
 		Build()
 
 	// We have lazy initialization in some chain elements in both networkservice, registry chains. So registering an
@@ -674,8 +653,7 @@ func testNSEAndClient(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	_, err := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -811,12 +789,8 @@ func TestNSMGR_LocalUsecaseNoURL(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
-		SetNodesCount(1).
+	domain := sandbox.NewBuilder(ctx, t).
 		UseUnixSockets().
-		SetContext(ctx).
-		SetNSMgrProxySupplier(nil).
-		SetRegistryProxySupplier(nil).
 		Build()
 
 	nseReg := &registry.NetworkServiceEndpoint{
@@ -825,8 +799,7 @@ func TestNSMGR_LocalUsecaseNoURL(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	_, err := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
@@ -80,9 +79,11 @@ func TestNSMGR_RemoteUsecase_Parallel(t *testing.T) {
 			Name:                "final-endpoint",
 			NetworkServiceNames: []string{"my-service-remote"},
 		}
-		domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
+		domain.Nodes[0].NewEndpoint(ctx, nseReg,
+			sandbox.WithEndpointAdditionalFunctionality(counter),
+		)
 	}()
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[1].NewClient(ctx)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -157,7 +158,7 @@ func TestNSMGR_SelectsRestartingEndpoint(t *testing.T) {
 	})
 
 	// 3. Create client and request endpoint
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[0].NewClient(ctx)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -198,7 +199,9 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 				Name:                "final-endpoint-" + strconv.Itoa(id),
 				NetworkServiceNames: []string{"my-service-remote"},
 			}
-			domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, newBusyEndpoint())
+			domain.Nodes[1].NewEndpoint(ctx, nseReg,
+				sandbox.WithEndpointAdditionalFunctionality(newBusyEndpoint()),
+			)
 			wg.Done()
 		}(i)
 	}
@@ -209,9 +212,11 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 			Name:                "final-endpoint-3",
 			NetworkServiceNames: []string{"my-service-remote"},
 		}
-		domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
+		domain.Nodes[1].NewEndpoint(ctx, nseReg,
+			sandbox.WithEndpointAdditionalFunctionality(counter),
+		)
 	}()
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[0].NewClient(ctx)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -248,7 +253,9 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg,
+		sandbox.WithEndpointAdditionalFunctionality(counter),
+	)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -261,7 +268,7 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 		},
 	}
 
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[1].NewClient(ctx)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -306,9 +313,11 @@ func TestNSMGR_ConnectToDeadNSE(t *testing.T) {
 	counter := &counterServer{}
 
 	nseCtx, killNse := context.WithCancel(ctx)
-	domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.DefaultTokenTimeout, counter)
+	domain.Nodes[0].NewEndpoint(nseCtx, nseReg,
+		sandbox.WithEndpointAdditionalFunctionality(counter),
+	)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[0].NewClient(ctx)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -355,9 +364,11 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg,
+		sandbox.WithEndpointAdditionalFunctionality(counter),
+	)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[0].NewClient(ctx)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -426,10 +437,12 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 			Name:                fmt.Sprintf("endpoint-%v", i),
 			NetworkServiceNames: []string{fmt.Sprintf("my-service-remote-%v", i)},
 		}
-		domain.Nodes[i].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, additionalFunctionality...)
+		domain.Nodes[i].NewEndpoint(ctx, nseReg,
+			sandbox.WithEndpointAdditionalFunctionality(additionalFunctionality...),
+		)
 	}
 
-	nsc := domain.Nodes[nodesCount-1].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[nodesCount-1].NewClient(ctx)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -482,10 +495,12 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 			Name:                fmt.Sprintf("endpoint-%v", i),
 			NetworkServiceNames: []string{fmt.Sprintf("my-service-remote-%v", i)},
 		}
-		domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, additionalFunctionality...)
+		domain.Nodes[0].NewEndpoint(ctx, nseReg,
+			sandbox.WithEndpointAdditionalFunctionality(additionalFunctionality...),
+		)
 	}
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[0].NewClient(ctx)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -517,7 +532,7 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
 		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, _ int) {
-			node.NewNSMgr(ctx, sandbox.Name("nsmgr"), nil, sandbox.DefaultTokenTimeout, nsmgr.NewServer)
+			node.NewNSMgr(ctx, sandbox.Name("nsmgr"))
 		}).
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
 		Build()
@@ -533,13 +548,13 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 
 	// 1. Add forwarders
 	forwarder1Reg := forwarderReg.Clone()
-	domain.Nodes[0].NewForwarder(ctx, forwarder1Reg, sandbox.DefaultTokenTimeout)
+	domain.Nodes[0].NewForwarder(ctx, forwarder1Reg)
 
 	forwarder2Reg := forwarderReg.Clone()
-	domain.Nodes[0].NewForwarder(ctx, forwarder2Reg, sandbox.DefaultTokenTimeout)
+	domain.Nodes[0].NewForwarder(ctx, forwarder2Reg)
 
 	forwarder3Reg := forwarderReg.Clone()
-	domain.Nodes[0].NewForwarder(ctx, forwarder3Reg, sandbox.DefaultTokenTimeout)
+	domain.Nodes[0].NewForwarder(ctx, forwarder3Reg)
 
 	// 2. Wait for refresh
 	<-time.After(sandbox.RegistryExpiryDuration)
@@ -578,16 +593,16 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 		Name: "endpoint",
 	}
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[0].NewClient(ctx)
 
 	// 1. Add endpoints
 	nse1Reg := nseReg.Clone()
 	nse1Reg.NetworkServiceNames = []string{"service-1"}
-	domain.Nodes[0].NewEndpoint(ctx, nse1Reg, sandbox.DefaultTokenTimeout)
+	domain.Nodes[0].NewEndpoint(ctx, nse1Reg)
 
 	nse2Reg := nseReg.Clone()
 	nse2Reg.NetworkServiceNames = []string{"service-2"}
-	domain.Nodes[0].NewEndpoint(ctx, nse2Reg, sandbox.DefaultTokenTimeout)
+	domain.Nodes[0].NewEndpoint(ctx, nse2Reg)
 
 	// 2. Wait for refresh
 	<-time.After(sandbox.RegistryExpiryDuration)
@@ -653,9 +668,9 @@ func testNSEAndClient(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[0].NewClient(ctx)
 
 	conn, err := nsc.Request(ctx, &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -799,9 +814,11 @@ func TestNSMGR_LocalUsecaseNoURL(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg,
+		sandbox.WithEndpointAdditionalFunctionality(counter),
+	)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain.Nodes[0].NewClient(ctx)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -792,65 +791,4 @@ func (c *restartingEndpoint) Close(ctx context.Context, connection *networkservi
 
 func newBusyEndpoint() networkservice.NetworkServiceServer {
 	return injecterror.NewServer(errors.New("sorry, endpoint is busy, try again later"))
-}
-
-func TestNSMGR_LocalUsecaseNoURL(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Unix sockets are not supported under windows, skipping")
-		return
-	}
-	t.Cleanup(func() { goleak.VerifyNone(t) })
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-
-	domain := sandbox.NewBuilder(ctx, t).
-		UseUnixSockets().
-		Build()
-
-	nseReg := &registry.NetworkServiceEndpoint{
-		Name:                "final-endpoint",
-		NetworkServiceNames: []string{"my-service-remote"},
-	}
-
-	counter := &counterServer{}
-	domain.Nodes[0].NewEndpoint(ctx, nseReg,
-		sandbox.WithEndpointAdditionalFunctionality(counter),
-	)
-
-	nsc := domain.Nodes[0].NewClient(ctx)
-
-	request := &networkservice.NetworkServiceRequest{
-		MechanismPreferences: []*networkservice.Mechanism{
-			{Cls: cls.LOCAL, Type: kernelmech.MECHANISM},
-		},
-		Connection: &networkservice.Connection{
-			Id:             "1",
-			NetworkService: "my-service-remote",
-			Context:        &networkservice.ConnectionContext{},
-		},
-	}
-
-	conn, err := nsc.Request(ctx, request.Clone())
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
-	require.Equal(t, 5, len(conn.Path.PathSegments))
-
-	// Simulate refresh from client.
-
-	refreshRequest := request.Clone()
-	refreshRequest.Connection = conn.Clone()
-
-	conn2, err := nsc.Request(ctx, refreshRequest)
-	require.NoError(t, err)
-	require.NotNil(t, conn2)
-	require.Equal(t, 5, len(conn2.Path.PathSegments))
-	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
-	// Close.
-
-	e, err := nsc.Close(ctx, conn)
-	require.NoError(t, err)
-	require.NotNil(t, e)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
 }

--- a/pkg/networkservice/chains/nsmgr/server_test.go
+++ b/pkg/networkservice/chains/nsmgr/server_test.go
@@ -80,9 +80,9 @@ func TestNSMGR_RemoteUsecase_Parallel(t *testing.T) {
 			Name:                "final-endpoint",
 			NetworkServiceNames: []string{"my-service-remote"},
 		}
-		domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+		domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
 	}()
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[1].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -157,7 +157,7 @@ func TestNSMGR_SelectsRestartingEndpoint(t *testing.T) {
 	})
 
 	// 3. Create client and request endpoint
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 				Name:                "final-endpoint-" + strconv.Itoa(id),
 				NetworkServiceNames: []string{"my-service-remote"},
 			}
-			domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, newBusyEndpoint())
+			domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, newBusyEndpoint())
 			wg.Done()
 		}(i)
 	}
@@ -209,9 +209,9 @@ func TestNSMGR_RemoteUsecase_BusyEndpoints(t *testing.T) {
 			Name:                "final-endpoint-3",
 			NetworkServiceNames: []string{"my-service-remote"},
 		}
-		domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+		domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
 	}()
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -261,7 +261,7 @@ func TestNSMGR_RemoteUsecase(t *testing.T) {
 		},
 	}
 
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[1].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -306,9 +306,9 @@ func TestNSMGR_ConnectToDeadNSE(t *testing.T) {
 	counter := &counterServer{}
 
 	nseCtx, killNse := context.WithCancel(ctx)
-	domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, counter)
+	domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.DefaultTokenTimeout, counter)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -355,9 +355,9 @@ func TestNSMGR_LocalUsecase(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -417,7 +417,7 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 						sandbox.NewCrossConnectClientFactory(
 							newPassTroughClient(fmt.Sprintf("my-service-remote-%v", i-1)),
 							kernel.NewClient()),
-						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
+						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.DefaultTokenTimeout)...),
 					),
 				),
 			}
@@ -426,10 +426,10 @@ func TestNSMGR_PassThroughRemote(t *testing.T) {
 			Name:                fmt.Sprintf("endpoint-%v", i),
 			NetworkServiceNames: []string{fmt.Sprintf("my-service-remote-%v", i)},
 		}
-		domain.Nodes[i].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
+		domain.Nodes[i].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, additionalFunctionality...)
 	}
 
-	nsc := domain.Nodes[nodesCount-1].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[nodesCount-1].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -473,7 +473,7 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 						sandbox.NewCrossConnectClientFactory(
 							newPassTroughClient(fmt.Sprintf("my-service-remote-%v", i-1)),
 							kernel.NewClient()),
-						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
+						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.DefaultTokenTimeout)...),
 					),
 				),
 			}
@@ -482,10 +482,10 @@ func TestNSMGR_PassThroughLocal(t *testing.T) {
 			Name:                fmt.Sprintf("endpoint-%v", i),
 			NetworkServiceNames: []string{fmt.Sprintf("my-service-remote-%v", i)},
 		}
-		domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
+		domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, additionalFunctionality...)
 	}
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -517,7 +517,7 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
 		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, _ int) {
-			node.NewNSMgr(ctx, sandbox.Name("nsmgr"), nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+			node.NewNSMgr(ctx, sandbox.Name("nsmgr"), nil, sandbox.DefaultTokenTimeout, nsmgr.NewServer)
 		}).
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
 		Build()
@@ -533,13 +533,13 @@ func TestNSMGR_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 
 	// 1. Add forwarders
 	forwarder1Reg := forwarderReg.Clone()
-	domain.Nodes[0].NewForwarder(ctx, forwarder1Reg, sandbox.GenerateTestToken)
+	domain.Nodes[0].NewForwarder(ctx, forwarder1Reg, sandbox.DefaultTokenTimeout)
 
 	forwarder2Reg := forwarderReg.Clone()
-	domain.Nodes[0].NewForwarder(ctx, forwarder2Reg, sandbox.GenerateTestToken)
+	domain.Nodes[0].NewForwarder(ctx, forwarder2Reg, sandbox.DefaultTokenTimeout)
 
 	forwarder3Reg := forwarderReg.Clone()
-	domain.Nodes[0].NewForwarder(ctx, forwarder3Reg, sandbox.GenerateTestToken)
+	domain.Nodes[0].NewForwarder(ctx, forwarder3Reg, sandbox.DefaultTokenTimeout)
 
 	// 2. Wait for refresh
 	<-time.After(sandbox.RegistryExpiryDuration)
@@ -578,16 +578,16 @@ func TestNSMGR_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 		Name: "endpoint",
 	}
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	// 1. Add endpoints
 	nse1Reg := nseReg.Clone()
 	nse1Reg.NetworkServiceNames = []string{"service-1"}
-	domain.Nodes[0].NewEndpoint(ctx, nse1Reg, sandbox.GenerateTestToken)
+	domain.Nodes[0].NewEndpoint(ctx, nse1Reg, sandbox.DefaultTokenTimeout)
 
 	nse2Reg := nseReg.Clone()
 	nse2Reg.NetworkServiceNames = []string{"service-2"}
-	domain.Nodes[0].NewEndpoint(ctx, nse2Reg, sandbox.GenerateTestToken)
+	domain.Nodes[0].NewEndpoint(ctx, nse2Reg, sandbox.DefaultTokenTimeout)
 
 	// 2. Wait for refresh
 	<-time.After(sandbox.RegistryExpiryDuration)
@@ -653,9 +653,9 @@ func testNSEAndClient(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	conn, err := nsc.Request(ctx, &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -799,9 +799,9 @@ func TestNSMGR_LocalUsecaseNoURL(t *testing.T) {
 	}
 
 	counter := &counterServer{}
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -42,16 +42,14 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
-		SetContext(ctx).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(1).
 		SetDNSResolver(dnsServer).
-		SetContext(ctx).
 		Build()
 
 	require.NoError(t, dnsServer.Register(remoteRegistryDomain, domain2.Registry.URL))
@@ -61,8 +59,7 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain"},
 	}
 
-	_, err := domain2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
-	require.NoError(t, err)
+	domain2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
 
 	nsc := domain1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -59,9 +59,9 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain"},
 	}
 
-	domain2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout)
+	domain2.Nodes[0].NewEndpoint(ctx, nseReg)
 
-	nsc := domain1.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc := domain1.Nodes[0].NewClient(ctx)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -59,9 +59,9 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain"},
 	}
 
-	domain2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
+	domain2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout)
 
-	nsc := domain1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain1.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -206,7 +206,6 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
 		SetRegistryProxySupplier(nil).
-		SetTokenGenerateFunc(sandbox.GenerateTestToken).
 		Build()
 
 	nseReg := &registry.NetworkServiceEndpoint{
@@ -215,10 +214,9 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	}
 
 	refreshSrv := newRefreshTesterServer(t, sandboxMinDuration, sandboxExpireTimeout)
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, refreshSrv)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, refreshSrv)
 
-	nscTokenGenerator := sandbox.GenerateExpiringToken(sandboxExpireTimeout)
-	nsc := domain.Nodes[1].NewClient(ctx, nscTokenGenerator)
+	nsc := domain.Nodes[1].NewClient(ctx, sandboxExpireTimeout)
 
 	refreshSrv.beforeRequest("test-conn")
 	_, err := nsc.Request(ctx, mkRequest("test-conn", nil))

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -214,9 +214,13 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	}
 
 	refreshSrv := newRefreshTesterServer(t, sandboxMinDuration, sandboxExpireTimeout)
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, refreshSrv)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg,
+		sandbox.WithEndpointAdditionalFunctionality(refreshSrv),
+	)
 
-	nsc := domain.Nodes[1].NewClient(ctx, sandboxExpireTimeout)
+	nsc := domain.Nodes[1].NewClient(ctx,
+		sandbox.WithClientTokenTimeout(sandboxExpireTimeout),
+	)
 
 	refreshSrv.beforeRequest("test-conn")
 	_, err := nsc.Request(ctx, mkRequest("test-conn", nil))

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -203,9 +203,8 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), sandboxTotalTimeout)
 	defer cancel()
 
-	domain := sandbox.NewBuilder(t).
+	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
-		SetContext(ctx).
 		SetRegistryProxySupplier(nil).
 		SetTokenGenerateFunc(sandbox.GenerateTestToken).
 		Build()
@@ -216,14 +215,13 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	}
 
 	refreshSrv := newRefreshTesterServer(t, sandboxMinDuration, sandboxExpireTimeout)
-	_, err := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, refreshSrv)
-	require.NoError(t, err)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, refreshSrv)
 
 	nscTokenGenerator := sandbox.GenerateExpiringToken(sandboxExpireTimeout)
 	nsc := domain.Nodes[1].NewClient(ctx, nscTokenGenerator)
 
 	refreshSrv.beforeRequest("test-conn")
-	_, err = nsc.Request(ctx, mkRequest("test-conn", nil))
+	_, err := nsc.Request(ctx, mkRequest("test-conn", nil))
 	require.NoError(t, err)
 	refreshSrv.afterRequest()
 

--- a/pkg/registry/core/interdomain/interdomain_ns_test.go
+++ b/pkg/registry/core/interdomain/interdomain_ns_test.go
@@ -61,14 +61,12 @@ func TestInterdomainNetworkServiceRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
@@ -132,8 +130,7 @@ func TestLocalDomain_NetworkServiceRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSDomainName(localRegistryDomain).
 		SetDNSResolver(dnsServer).
@@ -200,19 +197,17 @@ func TestInterdomainFloatingNetworkServiceRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain3 := sandbox.NewBuilder(t).
+	domain3 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetRegistrySupplier(func(context.Context, time.Duration, *url.URL, ...grpc.DialOption) registry.Registry {
 			return registry.NewServer(

--- a/pkg/registry/core/interdomain/interdomain_nse_test.go
+++ b/pkg/registry/core/interdomain/interdomain_nse_test.go
@@ -62,14 +62,12 @@ func TestInterdomainNetworkServiceEndpointRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
@@ -136,8 +134,7 @@ func TestLocalDomain_NetworkServiceEndpointRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSDomainName(localRegistryDomain).
 		SetDNSResolver(dnsServer).
@@ -208,19 +205,17 @@ func TestInterdomainFloatingNetworkServiceEndpointRegistry(t *testing.T) {
 
 	dnsServer := new(sandbox.FakeDNSResolver)
 
-	domain1 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain1 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain2 := sandbox.NewBuilder(t).
-		SetContext(ctx).
+	domain2 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetDNSResolver(dnsServer).
 		Build()
 
-	domain3 := sandbox.NewBuilder(t).
+	domain3 := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(0).
 		SetRegistrySupplier(func(context.Context, time.Duration, *url.URL, ...grpc.DialOption) registry.Registry {
 			return registry.NewServer(

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -52,9 +52,8 @@ type Builder struct {
 	supplyRegistryProxy SupplyRegistryProxyFunc
 	setupNode           SetupNodeFunc
 
-	DNSDomainName string
-	Resolver      dnsresolve.Resolver
-
+	dnsDomainName          string
+	dnsResolver            dnsresolve.Resolver
 	generateTokenFunc      token.GeneratorFunc
 	registryExpiryDuration time.Duration
 
@@ -73,8 +72,8 @@ func NewBuilder(ctx context.Context, t *testing.T) *Builder {
 		supplyNSMgrProxy:       nsmgrproxy.NewServer,
 		supplyRegistry:         memory.NewServer,
 		supplyRegistryProxy:    proxydns.NewServer,
-		DNSDomainName:          "cluster.local",
-		Resolver:               net.DefaultResolver,
+		dnsDomainName:          "cluster.local",
+		dnsResolver:            net.DefaultResolver,
 		generateTokenFunc:      GenerateTestToken,
 		registryExpiryDuration: time.Minute,
 	}
@@ -126,13 +125,13 @@ func (b *Builder) SetNodeSetup(f SetupNodeFunc) *Builder {
 
 // SetDNSDomainName sets DNS domain name for the building NSM domain
 func (b *Builder) SetDNSDomainName(name string) *Builder {
-	b.DNSDomainName = name
+	b.dnsDomainName = name
 	return b
 }
 
 // SetDNSResolver sets DNS resolver for proxy registries
 func (b *Builder) SetDNSResolver(d dnsresolve.Resolver) *Builder {
-	b.Resolver = d
+	b.dnsResolver = d
 	return b
 }
 
@@ -247,7 +246,7 @@ func (b *Builder) newRegistryProxy() {
 		nsmgrProxyURL = b.domain.NSMgrProxy.URL
 	}
 
-	registryProxy := b.supplyRegistryProxy(b.ctx, b.Resolver, b.DNSDomainName, nsmgrProxyURL, DefaultDialOptions(b.generateTokenFunc)...)
+	registryProxy := b.supplyRegistryProxy(b.ctx, b.dnsResolver, b.dnsDomainName, nsmgrProxyURL, DefaultDialOptions(b.generateTokenFunc)...)
 	serveURL := b.domain.supplyURL("reg-proxy")
 
 	serve(b.ctx, b.t, serveURL, registryProxy.Register)

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -292,7 +292,7 @@ func (b *Builder) newRegistry() {
 func (b *Builder) newNode(nodeNum int) {
 	node := &Node{
 		t:      b.t,
-		domain: b.domain,
+		Domain: b.domain,
 	}
 
 	b.setupNode(b.ctx, node, nodeNum)

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -196,14 +196,6 @@ func (b *Builder) Build() *Domain {
 		supplyClientTC:       b.supplyClientTC,
 	}
 
-	if b.useUnixSockets {
-		msg := "Unix sockets are available only for local tests with no external registry"
-		require.Equal(b.t, b.nodesCount, 1, msg)
-		require.Nil(b.t, b.supplyNSMgrProxy, msg)
-		require.Nil(b.t, b.supplyRegistry, msg)
-		require.Nil(b.t, b.supplyRegistryProxy, msg)
-	}
-
 	b.newNSMgrProxy()
 	b.newRegistryProxy()
 	b.newRegistry()
@@ -225,7 +217,7 @@ func (b *Builder) newNSMgrProxy() {
 	mgr := b.supplyNSMgrProxy(b.ctx, tokenGenerator,
 		nsmgrproxy.WithName(name),
 		nsmgrproxy.WithDialOptions(DefaultSecureDialOptions(b.supplyClientTC(), tokenGenerator)...))
-	serveURL := b.supplyURL("nsmgr-proxy")
+	serveURL := supplyTCPURL(b.t)("nsmgr-proxy")
 
 	serve(b.ctx, b.t, serveURL, b.supplyServerTC(), mgr.Register)
 
@@ -252,7 +244,7 @@ func (b *Builder) newRegistryProxy() {
 	tokenGenerator := b.supplyTokenGenerator(DefaultTokenTimeout)
 
 	registryProxy := b.supplyRegistryProxy(b.ctx, b.dnsResolver, b.dnsDomainName, nsmgrProxyURL, DefaultSecureDialOptions(b.supplyClientTC(), tokenGenerator)...)
-	serveURL := b.supplyURL("reg-proxy")
+	serveURL := supplyTCPURL(b.t)("reg-proxy")
 
 	serve(b.ctx, b.t, serveURL, b.supplyServerTC(), registryProxy.Register)
 
@@ -277,7 +269,7 @@ func (b *Builder) newRegistry() {
 	tokenGenerator := b.supplyTokenGenerator(DefaultTokenTimeout)
 
 	registry := b.supplyRegistry(b.ctx, b.registryExpiryDuration, registryProxyURL, DefaultSecureDialOptions(b.supplyClientTC(), tokenGenerator)...)
-	serveURL := b.supplyURL("reg")
+	serveURL := supplyTCPURL(b.t)("reg")
 
 	serve(b.ctx, b.t, serveURL, b.supplyServerTC(), registry.Register)
 

--- a/pkg/tools/sandbox/grpc_utils.go
+++ b/pkg/tools/sandbox/grpc_utils.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -31,7 +32,9 @@ import (
 )
 
 func serve(ctx context.Context, t *testing.T, u *url.URL, register func(server *grpc.Server)) {
-	server := grpc.NewServer(opentracing.WithTracing()...)
+	server := grpc.NewServer(append([]grpc.ServerOption{
+		grpc.Creds(grpcfdTransportCredentials(insecure.NewCredentials())),
+	}, opentracing.WithTracing()...)...)
 	register(server)
 
 	errCh := grpcutils.ListenAndServe(ctx, u, server)

--- a/pkg/tools/sandbox/grpc_utils.go
+++ b/pkg/tools/sandbox/grpc_utils.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -31,9 +31,9 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
-func serve(ctx context.Context, t *testing.T, u *url.URL, register func(server *grpc.Server)) {
+func serve(ctx context.Context, t *testing.T, u *url.URL, serverTC credentials.TransportCredentials, register func(server *grpc.Server)) {
 	server := grpc.NewServer(append([]grpc.ServerOption{
-		grpc.Creds(grpcfdTransportCredentials(insecure.NewCredentials())),
+		grpc.Creds(grpcfdTransportCredentials(serverTC)),
 	}, opentracing.WithTracing()...)...)
 	register(server)
 
@@ -49,8 +49,8 @@ func serve(ctx context.Context, t *testing.T, u *url.URL, register func(server *
 	}()
 }
 
-func dial(ctx context.Context, t *testing.T, u *url.URL, tokenGenerator token.GeneratorFunc) *grpc.ClientConn {
-	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(u), DefaultDialOptions(tokenGenerator)...)
+func dial(ctx context.Context, t *testing.T, u *url.URL, clientTC credentials.TransportCredentials, tokenGenerator token.GeneratorFunc) *grpc.ClientConn {
+	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(u), DefaultSecureDialOptions(clientTC, tokenGenerator)...)
 	require.NoError(t, err)
 
 	go func() {

--- a/pkg/tools/sandbox/grpc_utils.go
+++ b/pkg/tools/sandbox/grpc_utils.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"github.com/networkservicemesh/sdk/pkg/tools/opentracing"
+	"github.com/networkservicemesh/sdk/pkg/tools/token"
+)
+
+func serve(ctx context.Context, t *testing.T, u *url.URL, register func(server *grpc.Server)) {
+	server := grpc.NewServer(opentracing.WithTracing()...)
+	register(server)
+
+	errCh := grpcutils.ListenAndServe(ctx, u, server)
+	go func() {
+		select {
+		case <-ctx.Done():
+			log.FromContext(ctx).Infof("Stop serve: %v", u.String())
+			return
+		case err := <-errCh:
+			require.NoError(t, err)
+		}
+	}()
+}
+
+func dial(ctx context.Context, t *testing.T, u *url.URL, tokenGenerator token.GeneratorFunc) *grpc.ClientConn {
+	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(u), DefaultDialOptions(tokenGenerator)...)
+	require.NoError(t, err)
+
+	go func() {
+		<-ctx.Done()
+		_ = cc.Close()
+	}()
+
+	return cc
+}

--- a/pkg/tools/sandbox/grpc_utils_notwindows.go
+++ b/pkg/tools/sandbox/grpc_utils_notwindows.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sandbox
+
+import (
+	"github.com/edwarnicke/grpcfd"
+	"google.golang.org/grpc/credentials"
+)
+
+func grpcfdTransportCredentials(cred credentials.TransportCredentials) credentials.TransportCredentials {
+	return grpcfd.TransportCredentials(cred)
+}

--- a/pkg/tools/sandbox/grpc_utils_windows.go
+++ b/pkg/tools/sandbox/grpc_utils_windows.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package sandbox
+
+import "google.golang.org/grpc/credentials"
+
+func grpcfdTransportCredentials(cred credentials.TransportCredentials) credentials.TransportCredentials {
+	return cred
+}

--- a/pkg/tools/sandbox/insecure_tc.go
+++ b/pkg/tools/sandbox/insecure_tc.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"context"
+	"net"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type insecureTC struct {
+	credentials.TransportCredentials
+}
+
+func newInsecureTC() credentials.TransportCredentials {
+	return &insecureTC{
+		TransportCredentials: insecure.NewCredentials(),
+	}
+}
+
+func (insecureTC) ClientHandshake(_ context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, info{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}}, nil
+}
+
+func (insecureTC) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, info{credentials.CommonAuthInfo{SecurityLevel: credentials.PrivacyAndIntegrity}}, nil
+}
+
+// info contains the auth information for an insecure connection.
+// It implements the AuthInfo interface.
+type info struct {
+	credentials.CommonAuthInfo
+}
+
+// AuthType returns the type of info as a string.
+func (info) AuthType() string {
+	return "insecure"
+}

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -74,13 +74,13 @@ func (n *Node) NewNSMgr(
 		nsmgr.WithDialOptions(DefaultSecureDialOptions(clientTC, tokenGenerator)...),
 	}
 
-	if n.Registry != nil {
-		registryCC := dial(ctx, n.t, n.Registry.URL, clientTC, tokenGenerator)
-		options = append(options, nsmgr.WithRegistryClientConn(registryCC))
-	}
-
 	if serveURL.Scheme != "unix" {
 		options = append(options, nsmgr.WithURL(serveURL.String()))
+
+		if n.Registry != nil {
+			registryCC := dial(ctx, n.t, n.Registry.URL, clientTC, tokenGenerator)
+			options = append(options, nsmgr.WithRegistryClientConn(registryCC))
+		}
 	}
 
 	entry := &NSMgrEntry{

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -21,12 +21,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/payload"
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
@@ -38,7 +36,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
@@ -207,17 +204,9 @@ func (n *Node) NewClient(
 	generatorFunc token.GeneratorFunc,
 	additionalFunctionality ...networkservice.NetworkServiceClient,
 ) networkservice.NetworkServiceClient {
-	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(n.NSMgr.URL), DefaultDialOptions(generatorFunc)...)
-	require.NoError(n.t, err)
-
-	go func() {
-		defer func() { _ = cc.Close() }()
-		<-ctx.Done()
-	}()
-
 	return client.NewClient(
 		ctx,
-		cc,
+		dial(ctx, n.t, n.NSMgr.URL, generatorFunc),
 		client.WithAuthorizeClient(authorize.NewClient(authorize.Any())),
 		client.WithAdditionalFunctionality(additionalFunctionality...),
 	)

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -72,9 +72,8 @@ type Domain struct {
 	NSMgrProxy    *EndpointEntry
 	Registry      *RegistryEntry
 	RegistryProxy *RegistryEntry
-	DNSResolver   dnsresolve.Resolver
-	Name          string
-	supplyURL     func(prefix string) *url.URL
+
+	supplyURL func(prefix string) *url.URL
 }
 
 // NodeConfig keeps custom node configuration parameters

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -19,7 +19,6 @@ package sandbox
 import (
 	"context"
 	"net/url"
-	"os"
 	"time"
 
 	"google.golang.org/grpc"
@@ -33,10 +32,10 @@ import (
 )
 
 // SupplyNSMgrProxyFunc nsmgr proxy
-type SupplyNSMgrProxyFunc func(context.Context, token.GeneratorFunc, ...nsmgrproxy.Option) endpoint.Endpoint
+type SupplyNSMgrProxyFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgrproxy.Option) endpoint.Endpoint
 
 // SupplyNSMgrFunc supplies NSMGR
-type SupplyNSMgrFunc func(context.Context, token.GeneratorFunc, ...nsmgr.Option) nsmgr.Nsmgr
+type SupplyNSMgrFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgr.Option) nsmgr.Nsmgr
 
 // SupplyRegistryFunc supplies Registry
 type SupplyRegistryFunc func(ctx context.Context, expiryDuration time.Duration, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry
@@ -45,7 +44,7 @@ type SupplyRegistryFunc func(ctx context.Context, expiryDuration time.Duration, 
 type SupplyRegistryProxyFunc func(ctx context.Context, dnsResolver dnsresolve.Resolver, handlingDNSDomain string, proxyNSMgrURL *url.URL, options ...grpc.DialOption) registry.Registry
 
 // SetupNodeFunc setups each node on Builder.Build() stage
-type SetupNodeFunc func(ctx context.Context, node *Node, config *NodeConfig)
+type SetupNodeFunc func(ctx context.Context, node *Node, i int)
 
 // RegistryEntry is pair of registry.Registry and url.URL
 type RegistryEntry struct {
@@ -56,13 +55,15 @@ type RegistryEntry struct {
 // NSMgrEntry is pair of nsmgr.Nsmgr and url.URL
 type NSMgrEntry struct {
 	nsmgr.Nsmgr
-	URL *url.URL
+	Name string
+	URL  *url.URL
 }
 
 // EndpointEntry is pair of endpoint.Endpoint and url.URL
 type EndpointEntry struct {
 	endpoint.Endpoint
-	URL *url.URL
+	Name string
+	URL  *url.URL
 }
 
 // Domain contains attached to domain nodes, registry
@@ -73,8 +74,7 @@ type Domain struct {
 	RegistryProxy *RegistryEntry
 	DNSResolver   dnsresolve.Resolver
 	Name          string
-	resources     []context.CancelFunc
-	domainTemp    string
+	supplyURL     func(prefix string) *url.URL
 }
 
 // NodeConfig keeps custom node configuration parameters
@@ -83,21 +83,4 @@ type NodeConfig struct {
 	NsmgrGenerateTokenFunc     token.GeneratorFunc
 	ForwarderCtx               context.Context
 	ForwarderGenerateTokenFunc token.GeneratorFunc
-}
-
-// AddResources appends resources to the Domain to close it later
-func (d *Domain) AddResources(resources []context.CancelFunc) {
-	d.resources = append(d.resources, resources...)
-}
-
-// Cleanup frees all resources related to the domain
-func (d *Domain) cleanup() {
-	for _, r := range d.resources {
-		r()
-	}
-
-	// Remove Nsmgr local unix socket file if exists.
-	if d.domainTemp != "" {
-		_ = os.RemoveAll(d.domainTemp)
-	}
 }

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
@@ -45,6 +46,14 @@ type SupplyRegistryProxyFunc func(ctx context.Context, dnsResolver dnsresolve.Re
 
 // SetupNodeFunc setups each node on Builder.Build() stage
 type SetupNodeFunc func(ctx context.Context, node *Node, i int)
+
+type supplyURLFunc func(prefix string) *url.URL
+
+// SupplyTokenGeneratorFunc supplies token generator func
+type SupplyTokenGeneratorFunc func(timeout time.Duration) token.GeneratorFunc
+
+// SupplyTransportCredentialsFunc supplies transport credentials
+type SupplyTransportCredentialsFunc func() credentials.TransportCredentials
 
 // RegistryEntry is pair of registry.Registry and url.URL
 type RegistryEntry struct {
@@ -73,7 +82,10 @@ type Domain struct {
 	Registry      *RegistryEntry
 	RegistryProxy *RegistryEntry
 
-	supplyURL func(prefix string) *url.URL
+	supplyURL            supplyURLFunc
+	supplyServerTC       SupplyTransportCredentialsFunc
+	supplyClientTC       SupplyTransportCredentialsFunc
+	supplyTokenGenerator SupplyTokenGeneratorFunc
 }
 
 // NodeConfig keeps custom node configuration parameters

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -19,16 +19,21 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
+	"testing"
 	"time"
 
 	"github.com/edwarnicke/grpcfd"
 	"github.com/google/uuid"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/opentracing"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
@@ -94,4 +99,13 @@ func SetupDefaultNode(ctx context.Context, node *Node, supplyNSMgr SupplyNSMgrFu
 	node.NewForwarder(ctx, &registryapi.NetworkServiceEndpoint{
 		Name: Name("forwarder"),
 	})
+}
+
+// TCPURL returns a new free localhost TCP URL for serving
+func TCPURL(t *testing.T) *url.URL {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = l.Close() }()
+
+	return grpcutils.AddressToURL(l.Addr())
 }

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -26,6 +26,7 @@ import (
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
@@ -95,7 +96,7 @@ func NewCrossConnectClientFactory(additionalFunctionality ...networkservice.Netw
 // DefaultDialOptions returns default dial options for sandbox testing
 func DefaultDialOptions(genTokenFunc token.GeneratorFunc) []grpc.DialOption {
 	return append([]grpc.DialOption{
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(grpcfdTransportCredentials(insecure.NewCredentials())),
 		grpc.WithBlock(),
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -87,9 +87,11 @@ func Name(prefix string) string {
 
 // SetupDefaultNode setups NSMgr and default Forwarder on the given node
 func SetupDefaultNode(ctx context.Context, node *Node, supplyNSMgr SupplyNSMgrFunc) {
-	node.NewNSMgr(ctx, Name("nsmgr"), nil, DefaultTokenTimeout, supplyNSMgr)
+	node.NewNSMgr(ctx, Name("nsmgr"),
+		WithNSMgrSupplier(supplyNSMgr),
+	)
 
 	node.NewForwarder(ctx, &registryapi.NetworkServiceEndpoint{
 		Name: Name("forwarder"),
-	}, DefaultTokenTimeout)
+	})
 }


### PR DESCRIPTION
## Description
Enables sandbox to be used in docker test (#740).

## Details
1. Adds transport credentials supplier, token generator func supplier to the domain.
2. Adds default secure/insecure dial options.
3. Adds additional client details to node.NewForwarder (and Option pattern to support it).

Depends on #811.