### PR TITLE
Edit clockmock.Mock to slowly run time all the time

### DIFF
--- a/pkg/networkservice/common/discover/server_test.go
+++ b/pkg/networkservice/common/discover/server_test.go
@@ -512,11 +512,8 @@ func TestMatchExactEndpoint(t *testing.T) {
 func TestMatchSelectedNSESecondAttempt(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	const requestTimeout = time.Second
 	const tick = requestTimeout / 10

--- a/pkg/networkservice/common/discover/server_test.go
+++ b/pkg/networkservice/common/discover/server_test.go
@@ -512,8 +512,11 @@ func TestMatchExactEndpoint(t *testing.T) {
 func TestMatchSelectedNSESecondAttempt(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	const requestTimeout = time.Second
 	const tick = requestTimeout / 10

--- a/pkg/networkservice/common/journal/server_test.go
+++ b/pkg/networkservice/common/journal/server_test.go
@@ -67,11 +67,8 @@ func TestConnect(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	ts := time.Now()
 	clockMock.Set(ts)

--- a/pkg/networkservice/common/journal/server_test.go
+++ b/pkg/networkservice/common/journal/server_test.go
@@ -67,8 +67,11 @@ func TestConnect(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	ts := time.Now()
 	clockMock.Set(ts)

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -65,7 +65,7 @@ func TestRefreshClient_ValidRefresh(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{
@@ -109,7 +109,7 @@ func TestRefreshClient_StopRefreshAtClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{
@@ -149,7 +149,7 @@ func TestRefreshClient_RestartsRefreshAtAnotherRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -65,7 +65,7 @@ func TestRefreshClient_ValidRefresh(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{
@@ -109,7 +109,7 @@ func TestRefreshClient_StopRefreshAtClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{
@@ -149,7 +149,7 @@ func TestRefreshClient_RestartsRefreshAtAnotherRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{

--- a/pkg/networkservice/common/timeout/server_test.go
+++ b/pkg/networkservice/common/timeout/server_test.go
@@ -83,7 +83,7 @@ func TestTimeoutServer_Request(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -112,7 +112,7 @@ func TestTimeoutServer_CloseBeforeTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -144,7 +144,7 @@ func TestTimeoutServer_CloseAfterTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -218,7 +218,7 @@ func TestTimeoutServer_RefreshFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)

--- a/pkg/networkservice/common/timeout/server_test.go
+++ b/pkg/networkservice/common/timeout/server_test.go
@@ -83,7 +83,7 @@ func TestTimeoutServer_Request(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -112,7 +112,7 @@ func TestTimeoutServer_CloseBeforeTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -144,7 +144,7 @@ func TestTimeoutServer_CloseAfterTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -218,7 +218,7 @@ func TestTimeoutServer_RefreshFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -53,11 +53,8 @@ const (
 func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, expireTimeout),
@@ -75,11 +72,8 @@ func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testin
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 
@@ -113,11 +107,8 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, expireTimeout),
@@ -134,11 +125,8 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {
 func TestExpireNSEServer_ShouldRemoveNSEAfterExpirationTime(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 
@@ -214,7 +202,7 @@ func TestExpireNSEServer_RefreshFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	c := next.NewNetworkServiceEndpointRegistryClient(
@@ -248,7 +236,7 @@ func TestExpireNSEServer_RefreshKeepsNoUnregister(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	unregisterServer := new(unregisterNSEServer)

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -53,8 +53,11 @@ const (
 func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, expireTimeout),
@@ -72,8 +75,11 @@ func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testin
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 
@@ -107,8 +113,11 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, expireTimeout),
@@ -125,8 +134,11 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {
 func TestExpireNSEServer_ShouldRemoveNSEAfterExpirationTime(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 
@@ -202,7 +214,7 @@ func TestExpireNSEServer_RefreshFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	c := next.NewNetworkServiceEndpointRegistryClient(
@@ -236,7 +248,7 @@ func TestExpireNSEServer_RefreshKeepsNoUnregister(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	unregisterServer := new(unregisterNSEServer)

--- a/pkg/registry/common/querycache/nse_client_test.go
+++ b/pkg/registry/common/querycache/nse_client_test.go
@@ -135,7 +135,7 @@ func Test_QueryCacheClient_ShouldCleanUpOnTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock()
+	clockMock := clockmock.NewMock(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()

--- a/pkg/registry/common/querycache/nse_client_test.go
+++ b/pkg/registry/common/querycache/nse_client_test.go
@@ -135,7 +135,7 @@ func Test_QueryCacheClient_ShouldCleanUpOnTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.NewMock(ctx)
+	clockMock := clockmock.New()
 	ctx = clock.WithClock(ctx, clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()

--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -54,11 +54,8 @@ func testNSE() *registry.NetworkServiceEndpoint {
 func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -103,11 +100,8 @@ func TestRefreshNSEClient_ShouldSetExpirationTime_BeforeCallNext(t *testing.T) {
 func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -138,11 +132,8 @@ func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
 func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	endpoint := &registry.NetworkServiceEndpoint{
 		Name: "nse-1",
@@ -192,11 +183,8 @@ func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 func Test_RefreshNSEClient_SetsCorrectExpireTime(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	clockMock := clockmock.NewMock(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
+	clockMock := clockmock.New()
+	ctx := clock.WithClock(context.Background(), clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(

--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -54,8 +54,11 @@ func testNSE() *registry.NetworkServiceEndpoint {
 func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -100,8 +103,11 @@ func TestRefreshNSEClient_ShouldSetExpirationTime_BeforeCallNext(t *testing.T) {
 func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -132,8 +138,11 @@ func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
 func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	endpoint := &registry.NetworkServiceEndpoint{
 		Name: "nse-1",
@@ -183,8 +192,11 @@ func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 func Test_RefreshNSEClient_SetsCorrectExpireTime(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.NewMock()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.NewMock(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(

--- a/pkg/tools/clockmock/mock.go
+++ b/pkg/tools/clockmock/mock.go
@@ -35,30 +35,14 @@ type Mock struct {
 	mock *libclock.Mock
 }
 
-// NewMock returns a new mocked clock
-func NewMock(ctx context.Context) *Mock {
-	m := &Mock{
+// New returns a new mocked clock
+func New() *Mock {
+	return &Mock{
 		mock: libclock.NewMock(),
 	}
-
-	// Timers added with zero or negative duration will never run if time stands still. So mocked time
-	// should be slowed down (~100000 times) but never frozen.
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(100 * time.Microsecond):
-				m.Add(time.Nanosecond)
-			}
-		}
-	}()
-
-	return m
 }
 
 // Set sets the current time of the mock clock to a specific one.
-// This should only be called from a single goroutine at a time.
 func (m *Mock) Set(t time.Time) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -67,7 +51,6 @@ func (m *Mock) Set(t time.Time) {
 }
 
 // Add moves the current time of the mock clock forward by the specified duration.
-// This should only be called from a single goroutine at a time.
 func (m *Mock) Add(d time.Duration) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -97,11 +80,19 @@ func (m *Mock) Sleep(d time.Duration) {
 
 // Timer returns a timer that will fire when the mock current time becomes > m.Now().Add(d)
 func (m *Mock) Timer(d time.Duration) clock.Timer {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
+	if d = safeDuration(d); d > 0 {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+	} else {
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
+		defer m.mock.Add(0)
+	}
 
 	return &mockTimer{
-		Timer: m.mock.Timer(safeDuration(d)),
+		mock:  m,
+		Timer: m.mock.Timer(d),
 	}
 }
 
@@ -112,15 +103,23 @@ func (m *Mock) After(d time.Duration) <-chan time.Time {
 
 // AfterFunc returns a timer that will call f when the mock current time becomes > m.Now().Add(d)
 func (m *Mock) AfterFunc(d time.Duration, f func()) clock.Timer {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
+	if d = safeDuration(d); d > 0 {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+	} else {
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
+		defer m.mock.Add(0)
+	}
 
 	return m.afterFunc(d, f)
 }
 
 func (m *Mock) afterFunc(d time.Duration, f func()) clock.Timer {
 	return &mockTimer{
-		Timer: m.mock.AfterFunc(safeDuration(d), func() {
+		mock: m,
+		Timer: m.mock.AfterFunc(d, func() {
 			go f()
 		}),
 	}

--- a/pkg/tools/clockmock/timer.go
+++ b/pkg/tools/clockmock/timer.go
@@ -23,6 +23,8 @@ import (
 )
 
 type mockTimer struct {
+	mock *Mock
+
 	*libclock.Timer
 }
 
@@ -31,5 +33,12 @@ func (t *mockTimer) C() <-chan time.Time {
 }
 
 func (t *mockTimer) Reset(d time.Duration) bool {
-	return t.Timer.Reset(safeDuration(d))
+	if d = safeDuration(d); d == 0 {
+		t.mock.lock.Lock()
+		defer t.mock.lock.Unlock()
+
+		defer t.mock.mock.Add(0)
+	}
+
+	return t.Timer.Reset(d)
 }


### PR DESCRIPTION
#764

## Issue
If code uses timer added with 0 duration, it will never fire in test with `clockmock.Mock` until time will be modified.

## Solution
Make time in `clockmock.Mock` always running but slowed down at 100000 times.

Closes https://github.com/networkservicemesh/sdk/issues/865.