### PR TITLE
qfix: dnsClient should configure coredns file on starting to prevent coredns failure

### DIFF
--- a/pkg/networkservice/connectioncontext/dnscontext/client_test.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client_test.go
@@ -55,6 +55,9 @@ func Test_DNSContextClient_Usecases(t *testing.T) {
 	log
 	reload
 }`
+
+	requireFileChanged(ctx, t, corefilePath, expectedEmptyCorefile)
+
 	var samples = []struct {
 		request          *networkservice.NetworkServiceRequest
 		expectedCorefile string


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

Fixes coredns restarting for webhook example
```
loading Caddyfile via flag: open /etc/coredns/Corefile: no such file or directory
```

Currently, coredns config creating too long, and coredns container could be restarted few times...