### PR TITLE
fix: Improve condition for 'Update dependent repositories' job

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -28,7 +28,7 @@ jobs:
           - cmd-nsc-init
     name: Update ${{ matrix.repository }}
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.ref == 'refs/heads/main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push' }}
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Description

Condition `github.event_name == 'push'` is more strict then `github.ref == 'refs/heads/main`