### PR TITLE
Stop double healing connections

### DIFF
--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -124,10 +124,12 @@ func (u *healClient) listenToConnectionChanges(healConnection, restoreConnection
 	for {
 		event, err := monitorClient.Recv()
 		if err != nil {
-			u.conns.Range(func(id string, info *connectionInfo) bool {
-				info.mut.Lock()
-				defer info.mut.Unlock()
-				restoreConnection(info.conn)
+			u.conns.Range(func(id string, connInfo *connectionInfo) bool {
+				connInfo.mut.Lock()
+				defer connInfo.mut.Unlock()
+				if connInfo.active {
+					restoreConnection(connInfo.conn)
+				}
 				return true
 			})
 			return


### PR DESCRIPTION
## Description
Check if connection is active before healing.

## Issue link
Closes https://github.com/networkservicemesh/sdk/issues/902.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unstable unit testing
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
