### PR TITLE
[sdk#898] Add clockmock Start

### DIFF
--- a/pkg/networkservice/common/discover/server_test.go
+++ b/pkg/networkservice/common/discover/server_test.go
@@ -512,8 +512,11 @@ func TestMatchExactEndpoint(t *testing.T) {
 func TestMatchSelectedNSESecondAttempt(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	const requestTimeout = time.Second
 	const tick = requestTimeout / 10

--- a/pkg/networkservice/common/journal/server_test.go
+++ b/pkg/networkservice/common/journal/server_test.go
@@ -67,8 +67,11 @@ func TestConnect(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	ts := time.Now()
 	clockMock.Set(ts)

--- a/pkg/networkservice/common/onidle/server_test.go
+++ b/pkg/networkservice/common/onidle/server_test.go
@@ -44,7 +44,7 @@ func TestIdleNotifier_NoRequests(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	timeout := time.Hour
@@ -67,7 +67,7 @@ func TestIdleNotifier_Refresh(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	timeout := time.Hour
@@ -97,7 +97,7 @@ func TestIdleNotifier_HoldingActiveRequest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	timeout := time.Hour
@@ -137,7 +137,7 @@ func TestIdleNotifier_FailedRequest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	timeout := time.Hour
@@ -168,7 +168,7 @@ func TestIdleNotifier_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	timeout := time.Hour
@@ -192,7 +192,7 @@ func TestIdleNotifier_RequestAfterExpire(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	timeout := time.Hour

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -65,7 +65,7 @@ func TestRefreshClient_ValidRefresh(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{
@@ -109,7 +109,7 @@ func TestRefreshClient_StopRefreshAtClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{
@@ -149,7 +149,7 @@ func TestRefreshClient_RestartsRefreshAtAnotherRequest(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	cloneClient := &countClient{

--- a/pkg/networkservice/common/timeout/server_test.go
+++ b/pkg/networkservice/common/timeout/server_test.go
@@ -83,7 +83,7 @@ func TestTimeoutServer_Request(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -112,7 +112,7 @@ func TestTimeoutServer_CloseBeforeTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -144,7 +144,7 @@ func TestTimeoutServer_CloseAfterTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)
@@ -218,7 +218,7 @@ func TestTimeoutServer_RefreshFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	connServer := newConnectionsServer(t)

--- a/pkg/registry/common/expire/nse_server_test.go
+++ b/pkg/registry/common/expire/nse_server_test.go
@@ -54,8 +54,11 @@ const (
 func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		serialize.NewNetworkServiceEndpointRegistryServer(),
@@ -74,8 +77,11 @@ func TestExpireNSEServer_ShouldCorrectlySetExpirationTime_InRemoteCase(t *testin
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 
@@ -110,8 +116,11 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromInput_AndWork(t *testing
 func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	s := next.NewNetworkServiceEndpointRegistryServer(
 		serialize.NewNetworkServiceEndpointRegistryServer(),
@@ -130,8 +139,11 @@ func TestExpireNSEServer_ShouldUseLessExpirationTimeFromResponse(t *testing.T) {
 func TestExpireNSEServer_ShouldRemoveNSEAfterExpirationTime(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()
 
@@ -209,7 +221,7 @@ func TestExpireNSEServer_RefreshFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	c := next.NewNetworkServiceEndpointRegistryClient(
@@ -244,7 +256,7 @@ func TestExpireNSEServer_RefreshKeepsNoUnregister(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	unregisterServer := new(unregisterNSEServer)

--- a/pkg/registry/common/querycache/nse_client_test.go
+++ b/pkg/registry/common/querycache/nse_client_test.go
@@ -135,7 +135,7 @@ func Test_QueryCacheClient_ShouldCleanUpOnTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	clockMock := clockmock.New()
+	clockMock := clockmock.New(ctx)
 	ctx = clock.WithClock(ctx, clockMock)
 
 	mem := memory.NewNetworkServiceEndpointRegistryServer()

--- a/pkg/registry/common/refresh/nse_registry_client_test.go
+++ b/pkg/registry/common/refresh/nse_registry_client_test.go
@@ -54,8 +54,11 @@ func testNSE() *registry.NetworkServiceEndpoint {
 func TestNewNetworkServiceEndpointRegistryClient(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -100,8 +103,11 @@ func TestRefreshNSEClient_ShouldSetExpirationTime_BeforeCallNext(t *testing.T) {
 func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(
@@ -132,8 +138,11 @@ func Test_RefreshNSEClient_CalledRegisterTwice(t *testing.T) {
 func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	endpoint := &registry.NetworkServiceEndpoint{
 		Name: "nse-1",
@@ -183,8 +192,11 @@ func Test_RefreshNSEClient_ShouldOverrideNameAndDuration(t *testing.T) {
 func Test_RefreshNSEClient_SetsCorrectExpireTime(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	clockMock := clockmock.New()
-	ctx := clock.WithClock(context.Background(), clockMock)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
 
 	countClient := new(requestCountClient)
 	client := next.NewNetworkServiceEndpointRegistryClient(

--- a/pkg/tools/clockmock/mock.go
+++ b/pkg/tools/clockmock/mock.go
@@ -75,10 +75,7 @@ func (m *Mock) Start(ctx context.Context, speed float64) {
 
 // Set sets the current time of the mock clock to a specific one.
 func (m *Mock) Set(t time.Time) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	m.mock.Set(t)
+	m.Add(safeDuration(m.Until(t)))
 }
 
 // Add moves the current time of the mock clock forward by the specified duration.
@@ -86,7 +83,7 @@ func (m *Mock) Add(d time.Duration) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	m.mock.Add(d)
+	m.mock.Add(safeDuration(d))
 }
 
 // Now returns mock current time
@@ -123,7 +120,7 @@ func (m *Mock) Timer(d time.Duration) clock.Timer {
 
 	return &mockTimer{
 		mock:  m,
-		Timer: m.mock.Timer(d),
+		timer: m.mock.Timer(d),
 	}
 }
 
@@ -150,7 +147,7 @@ func (m *Mock) AfterFunc(d time.Duration, f func()) clock.Timer {
 func (m *Mock) afterFunc(d time.Duration, f func()) clock.Timer {
 	return &mockTimer{
 		mock: m,
-		Timer: m.mock.AfterFunc(d, func() {
+		timer: m.mock.AfterFunc(d, func() {
 			go f()
 		}),
 	}
@@ -162,7 +159,8 @@ func (m *Mock) Ticker(d time.Duration) clock.Ticker {
 	defer m.lock.RUnlock()
 
 	return &mockTicker{
-		Ticker: m.mock.Ticker(d),
+		mock:   m,
+		ticker: m.mock.Ticker(d),
 	}
 }
 

--- a/pkg/tools/clockmock/mock_test.go
+++ b/pkg/tools/clockmock/mock_test.go
@@ -34,6 +34,32 @@ const (
 	testTick = testWait / 100
 )
 
+func TestMock_Start(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	m := clockmock.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const speed = 1000.0
+	const hours = 7
+
+	m.Start(ctx, speed)
+
+	realStart, mockStart := time.Now(), m.Now()
+	for i := 0; i < hours; i++ {
+		time.Sleep(testWait)
+		m.Add(time.Hour)
+	}
+	realDuration, mockDuration := time.Since(realStart), m.Since(mockStart)
+
+	mockSpeed := float64((mockDuration - hours*time.Hour) / realDuration)
+
+	require.Greater(t, mockSpeed/speed, 0.9)
+	require.Less(t, mockSpeed/speed, 1.1)
+}
+
 func TestMock_Timer(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 

--- a/pkg/tools/clockmock/ticker.go
+++ b/pkg/tools/clockmock/ticker.go
@@ -23,13 +23,24 @@ import (
 )
 
 type mockTicker struct {
-	*libclock.Ticker
+	mock   *Mock
+	ticker *libclock.Ticker
 }
 
 func (t *mockTicker) C() <-chan time.Time {
-	return t.Ticker.C
+	return t.ticker.C
+}
+
+func (t *mockTicker) Stop() {
+	t.mock.lock.RLock()
+	defer t.mock.lock.RUnlock()
+
+	t.ticker.Stop()
 }
 
 func (t *mockTicker) Reset(d time.Duration) {
-	t.Ticker.Reset(d)
+	t.mock.lock.RLock()
+	defer t.mock.lock.RUnlock()
+
+	t.ticker.Reset(d)
 }

--- a/pkg/tools/clockmock/timer.go
+++ b/pkg/tools/clockmock/timer.go
@@ -23,22 +23,31 @@ import (
 )
 
 type mockTimer struct {
-	mock *Mock
-
-	*libclock.Timer
+	mock  *Mock
+	timer *libclock.Timer
 }
 
 func (t *mockTimer) C() <-chan time.Time {
-	return t.Timer.C
+	return t.timer.C
+}
+
+func (t *mockTimer) Stop() bool {
+	t.mock.lock.RLock()
+	defer t.mock.lock.RUnlock()
+
+	return t.timer.Stop()
 }
 
 func (t *mockTimer) Reset(d time.Duration) bool {
-	if d = safeDuration(d); d == 0 {
+	if d = safeDuration(d); d > 0 {
+		t.mock.lock.RLock()
+		defer t.mock.lock.RUnlock()
+	} else {
 		t.mock.lock.Lock()
 		defer t.mock.lock.Unlock()
 
 		defer t.mock.mock.Add(0)
 	}
 
-	return t.Timer.Reset(d)
+	return t.timer.Reset(d)
 }


### PR DESCRIPTION
## Description
1. Add clockmock Start (needed for the discover stage in sandbox tests).
2. Fix clocmock race issues.

## Issue link
Relates to #898.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
