### PR TITLE
Update request labels based on NS Matches

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/recvfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/roundrobin"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updaterequestlabels"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
 	"github.com/networkservicemesh/sdk/pkg/registry"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/checkid"
@@ -182,6 +183,7 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		endpoint.WithAdditionalFunctionality(
 			discover.NewServer(nsClient, nseClient),
 			roundrobin.NewServer(),
+			updaterequestlabels.NewServer(),
 			excludedprefixes.NewServer(ctx),
 			recvfd.NewServer(), // Receive any files passed
 			interpose.NewServer(&interposeRegistryServer),
@@ -210,10 +212,10 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		checkid.NewNetworkServiceEndpointRegistryServer(),
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
 		registryrecvfd.NewNetworkServiceEndpointRegistryServer(), // Allow to receive a passed files
-		urlsRegistryServer,        // Store endpoints URLs
-		interposeRegistryServer,   // Store cross connect NSEs
-		localBypassRegistryServer, // Perform URL transformations
-		nseRegistry,               // Register NSE inside Remote registry
+		urlsRegistryServer,                                       // Store endpoints URLs
+		interposeRegistryServer,                                  // Store cross connect NSEs
+		localBypassRegistryServer,                                // Perform URL transformations
+		nseRegistry,                                              // Register NSE inside Remote registry
 	)
 
 	rv.Registry = registry.NewServer(nsChain, nseChain)

--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -212,10 +212,10 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		checkid.NewNetworkServiceEndpointRegistryServer(),
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
 		registryrecvfd.NewNetworkServiceEndpointRegistryServer(), // Allow to receive a passed files
-		urlsRegistryServer,                                       // Store endpoints URLs
-		interposeRegistryServer,                                  // Store cross connect NSEs
-		localBypassRegistryServer,                                // Perform URL transformations
-		nseRegistry,                                              // Register NSE inside Remote registry
+		urlsRegistryServer,        // Store endpoints URLs
+		interposeRegistryServer,   // Store cross connect NSEs
+		localBypassRegistryServer, // Perform URL transformations
+		nseRegistry,               // Register NSE inside Remote registry
 	)
 
 	rv.Registry = registry.NewServer(nsChain, nseChain)

--- a/pkg/networkservice/common/discover/context.go
+++ b/pkg/networkservice/common/discover/context.go
@@ -39,14 +39,11 @@ type NetworkServiceCandidates struct {
 
 // WithCandidates -
 //    Wraps 'parent' in a new Context that has the Candidates
-func WithCandidates(parent context.Context, candidates []*registry.NetworkServiceEndpoint, service *registry.NetworkService) context.Context {
+func WithCandidates(parent context.Context, candidates *NetworkServiceCandidates) context.Context {
 	if parent == nil {
 		panic("cannot create context from nil parent")
 	}
-	return context.WithValue(parent, candidatesKey, &NetworkServiceCandidates{
-		NetworkService: service,
-		Endpoints:      candidates,
-	})
+	return context.WithValue(parent, candidatesKey, candidates)
 }
 
 // Candidates -

--- a/pkg/networkservice/common/discover/context.go
+++ b/pkg/networkservice/common/discover/context.go
@@ -35,6 +35,7 @@ type contextKeyType string
 type NetworkServiceCandidates struct {
 	NetworkService *registry.NetworkService
 	Endpoints      []*registry.NetworkServiceEndpoint
+	DestLabels     []map[string]string
 }
 
 // WithCandidates -

--- a/pkg/networkservice/common/discover/context.go
+++ b/pkg/networkservice/common/discover/context.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Cisco Systems, Inc.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/networkservice/common/discover/match_selector.go
+++ b/pkg/networkservice/common/discover/match_selector.go
@@ -53,20 +53,22 @@ func filterValidNSEs(clockTime clock.Clock, nses ...*registry.NetworkServiceEndp
 	return validNetworkServiceEndpoints
 }
 
-func matchEndpoint(nsLabels map[string]string, nsName string, match *registry.Match, nses []*registry.NetworkServiceEndpoint) []*registry.NetworkServiceEndpoint {
+func matchEndpoint(nsLabels map[string]string, nsName string, match *registry.Match, nses []*registry.NetworkServiceEndpoint) ([]*registry.NetworkServiceEndpoint, []map[string]string) {
 	if match == nil {
-		return nses
+		return nses, nil
 	}
 
 	var nseCandidates []*registry.NetworkServiceEndpoint
+	var destLabels []map[string]string
 	for _, destination := range match.GetRoutes() {
 		for _, nse := range nses {
 			if isSubset(nse.GetNetworkServiceLabels()[nsName].Labels, destination.GetDestinationSelector(), nsLabels) {
 				nseCandidates = append(nseCandidates, nse)
+				destLabels = append(destLabels, destination.GetDestinationSelector())
 			}
 		}
 	}
-	return nseCandidates
+	return nseCandidates, destLabels
 }
 
 // ProcessLabels generates matches based on destination label selectors that specify templating.

--- a/pkg/networkservice/common/discover/match_selector.go
+++ b/pkg/networkservice/common/discover/match_selector.go
@@ -53,28 +53,15 @@ func filterValidNSEs(clockTime clock.Clock, nses ...*registry.NetworkServiceEndp
 	return validNetworkServiceEndpoints
 }
 
-func matchEndpoint(nsLabels map[string]string, ns *registry.NetworkService, nses []*registry.NetworkServiceEndpoint) []*registry.NetworkServiceEndpoint {
-	var match *registry.Match
-	// Iterate through the matches
-	for _, m := range ns.GetMatches() {
-		// All match source selector labels should be present in the requested labels map
-		if !isSubset(nsLabels, m.GetSourceSelector(), nsLabels) {
-			continue
-		}
-		match = m
-		break
-	}
-
+func matchEndpoint(nsLabels map[string]string, nsName string, match *registry.Match, nses []*registry.NetworkServiceEndpoint) []*registry.NetworkServiceEndpoint {
 	if match == nil {
 		return nses
 	}
 
 	var nseCandidates []*registry.NetworkServiceEndpoint
-	// Check all Destinations in that match
 	for _, destination := range match.GetRoutes() {
-		// Each NSE should be matched against that destination
 		for _, nse := range nses {
-			if isSubset(nse.GetNetworkServiceLabels()[ns.Name].Labels, destination.GetDestinationSelector(), nsLabels) {
+			if isSubset(nse.GetNetworkServiceLabels()[nsName].Labels, destination.GetDestinationSelector(), nsLabels) {
 				nseCandidates = append(nseCandidates, nse)
 			}
 		}

--- a/pkg/networkservice/common/discover/match_selector.go
+++ b/pkg/networkservice/common/discover/match_selector.go
@@ -53,13 +53,11 @@ func filterValidNSEs(clockTime clock.Clock, nses ...*registry.NetworkServiceEndp
 	return validNetworkServiceEndpoints
 }
 
-func matchEndpoint(nsLabels map[string]string, nsName string, match *registry.Match, nses []*registry.NetworkServiceEndpoint) ([]*registry.NetworkServiceEndpoint, []map[string]string) {
+func matchEndpoint(nsLabels map[string]string, nsName string, match *registry.Match, nses []*registry.NetworkServiceEndpoint) (nseCandidates []*registry.NetworkServiceEndpoint, destLabels []map[string]string) {
 	if match == nil {
 		return nses, nil
 	}
 
-	var nseCandidates []*registry.NetworkServiceEndpoint
-	var destLabels []map[string]string
 	for _, destination := range match.GetRoutes() {
 		for _, nse := range nses {
 			if isSubset(nse.GetNetworkServiceLabels()[nsName].Labels, destination.GetDestinationSelector(), nsLabels) {

--- a/pkg/networkservice/common/discover/server.go
+++ b/pkg/networkservice/common/discover/server.go
@@ -76,7 +76,10 @@ func (d *discoverCandidatesServer) Request(ctx context.Context, request *network
 
 	delay := defaultDiscoverDelay
 	for ctx.Err() == nil {
-		resp, err := next.Server(ctx).Request(WithCandidates(ctx, nses, ns), request)
+		resp, err := next.Server(ctx).Request(WithCandidates(ctx, &NetworkServiceCandidates{
+			NetworkService: ns,
+			Endpoints:      nses,
+		}), request)
 		if err == nil {
 			return resp, err
 		}

--- a/pkg/networkservice/common/discover/server.go
+++ b/pkg/networkservice/common/discover/server.go
@@ -176,11 +176,6 @@ func (d *discoverCandidatesServer) discoverNetworkServiceEndpoints(ctx context.C
 			NetworkServiceNames: []string{ns.Name},
 		},
 	}
-	// if match != nil {
-	// 	query.NetworkServiceEndpoint.NetworkServiceLabels = map[string]*registry.NetworkServiceLabels{
-	// 		ns.Name: {Labels: match.GetRoutes()[0].GetDestinationSelector()},
-	// 	}
-	// }
 
 	nseStream, err := d.nseClient.Find(ctx, query)
 	if err != nil {

--- a/pkg/networkservice/common/discover/server.go
+++ b/pkg/networkservice/common/discover/server.go
@@ -170,7 +170,7 @@ func (d *discoverCandidatesServer) discoverNetworkServiceEndpoints(ctx context.C
 	}
 	nseList := registry.ReadNetworkServiceEndpointList(nseStream)
 
-	result := matchEndpoint(clockTime, labels, ns, nseList...)
+	result := matchEndpoint(labels, ns, filterValidNSEs(clockTime, nseList...))
 	if len(result) != 0 {
 		return result, nil
 	}
@@ -190,7 +190,7 @@ func (d *discoverCandidatesServer) discoverNetworkServiceEndpoints(ctx context.C
 			return nil, errors.WithStack(err)
 		}
 
-		result = matchEndpoint(clockTime, labels, ns, nse)
+		result = matchEndpoint(labels, ns, filterValidNSEs(clockTime, nse))
 		if len(result) != 0 {
 			return result, nil
 		}

--- a/pkg/networkservice/common/heal/server.go
+++ b/pkg/networkservice/common/heal/server.go
@@ -244,7 +244,7 @@ func (f *healServer) createHealContext(requestCtx, cachedCtx context.Context) co
 	}
 	healCtx := f.ctx
 	if candidates := discover.Candidates(ctx); candidates != nil {
-		healCtx = discover.WithCandidates(healCtx, candidates.Endpoints, candidates.NetworkService)
+		healCtx = discover.WithCandidates(healCtx, candidates)
 	}
 
 	return healCtx

--- a/pkg/networkservice/common/updaterequestlabels/server.go
+++ b/pkg/networkservice/common/updaterequestlabels/server.go
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package updaterequestlabels provides a networkservice chain element that updates Connection.Labels using discovery.Candidates
 package updaterequestlabels
 
 import (
@@ -49,6 +50,8 @@ func (s *updateRequestLabelsServer) Close(ctx context.Context, conn *networkserv
 	return next.Server(ctx).Close(ctx, conn)
 }
 
+// updateLabels - updates labels in conn, return original value of conn.Labels.
+// If context doesn't contain info for network service specified in conn, does nothing.
 func (s *updateRequestLabelsServer) updateLabels(ctx context.Context, conn *networkservice.Connection) map[string]string {
 	originalLabels := conn.Labels
 	labels, err := s.getLabelsForEndpoint(ctx, conn.NetworkServiceEndpointName)
@@ -58,6 +61,7 @@ func (s *updateRequestLabelsServer) updateLabels(ctx context.Context, conn *netw
 	return originalLabels
 }
 
+// getLabelsForEndpoint - searches for labels linked to specified endpointName in context
 func (s *updateRequestLabelsServer) getLabelsForEndpoint(ctx context.Context, endpointName string) (map[string]string, error) {
 	candidates := discover.Candidates(ctx)
 	if candidates == nil {

--- a/pkg/networkservice/common/updaterequestlabels/server.go
+++ b/pkg/networkservice/common/updaterequestlabels/server.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updaterequestlabels
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/discover"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+type updateRequestLabelsServer struct{}
+
+// NewServer - create chain element that will update Connection.Labels according to information from discover.Candidates
+func NewServer() networkservice.NetworkServiceServer {
+	return &updateRequestLabelsServer{}
+}
+
+func (s *updateRequestLabelsServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	originalLabels := s.updateLabels(ctx, request.Connection)
+	conn, err := next.Server(ctx).Request(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	conn.Labels = originalLabels
+	return conn, nil
+}
+
+func (s *updateRequestLabelsServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	_ = s.updateLabels(ctx, conn)
+	return next.Server(ctx).Close(ctx, conn)
+}
+
+func (s *updateRequestLabelsServer) updateLabels(ctx context.Context, conn *networkservice.Connection) map[string]string {
+	originalLabels := conn.Labels
+	labels, err := s.getLabelsForEndpoint(ctx, conn.NetworkServiceEndpointName)
+	if err == nil {
+		conn.Labels = labels
+	}
+	return originalLabels
+}
+
+func (s *updateRequestLabelsServer) getLabelsForEndpoint(ctx context.Context, endpointName string) (map[string]string, error) {
+	candidates := discover.Candidates(ctx)
+	if candidates == nil {
+		return nil, errors.New("candidates are not found")
+	}
+	if candidates.DestLabels == nil {
+		return nil, errors.New("candidates.DestLabels are empty")
+	}
+
+	idx := -1
+	for i, nse := range candidates.Endpoints {
+		if endpointName == nse.Name {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return nil, errors.New("endpoint with specified name is not found in candidates")
+	}
+	return candidates.DestLabels[idx], nil
+}

--- a/pkg/networkservice/common/updaterequestlabels/server_test.go
+++ b/pkg/networkservice/common/updaterequestlabels/server_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updaterequestlabels_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/discover"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updaterequestlabels"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/checks/checkrequest"
+)
+
+func TestUpdateLabels(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	candidates := &discover.NetworkServiceCandidates{
+		Endpoints: []*registry.NetworkServiceEndpoint{
+			{Name: "nse-name1"},
+			{Name: "nse-name2"},
+		},
+		DestLabels: []map[string]string{
+			{"app": "firewall"},
+			{"app": "vpn"},
+		},
+	}
+
+	server := next.NewNetworkServiceServer(
+		updaterequestlabels.NewServer(),
+		checkrequest.NewServer(t, func(t *testing.T, request *networkservice.NetworkServiceRequest) {
+			require.Equal(t, candidates.DestLabels[0], request.Connection.Labels)
+		}),
+	)
+
+	ctx = discover.WithCandidates(ctx, candidates)
+
+	initialLabels := map[string]string{"not": "empty"}
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &networkservice.Connection{
+			NetworkServiceEndpointName: candidates.Endpoints[0].Name,
+			Labels:                     initialLabels,
+		},
+	}
+	conn, err := server.Request(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, initialLabels, conn.Labels)
+}
+
+func TestUpdateLabels_WithoutLabels(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	candidates := &discover.NetworkServiceCandidates{
+		Endpoints: []*registry.NetworkServiceEndpoint{
+			{Name: "nse-name1"},
+			{Name: "nse-name2"},
+		},
+	}
+
+	initialLabels := map[string]string{"not": "empty"}
+
+	server := next.NewNetworkServiceServer(
+		updaterequestlabels.NewServer(),
+		checkrequest.NewServer(t, func(t *testing.T, request *networkservice.NetworkServiceRequest) {
+			require.Equal(t, initialLabels, request.Connection.Labels)
+		}),
+	)
+
+	ctx = discover.WithCandidates(ctx, candidates)
+
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &networkservice.Connection{
+			NetworkServiceEndpointName: candidates.Endpoints[0].Name,
+			Labels:                     initialLabels,
+		},
+	}
+	conn, err := server.Request(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, initialLabels, conn.Labels)
+}


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Make discovery server save destination labels for each endpoint, make roundrobin server replace them on request.

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/sdk/issues/878

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
