### PR TITLE
Rework of sandbox passthrough tests for using matches

### DIFF
--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -42,9 +43,9 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanismtranslation"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/replacelabels"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injecterror"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injectlabels"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -401,48 +402,17 @@ func (s *nsmgrSuite) Test_PassThroughRemoteUsecase() {
 	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
 	require.NoError(t, err)
 
-	var nsesReg [nodesCount]*registry.NetworkServiceEndpoint
+	var nsesReg []*registry.NetworkServiceEndpoint
 	for i := 0; i < nodesCount; i++ {
-		nsesReg[i] = &registry.NetworkServiceEndpoint{
-			Name:                fmt.Sprintf("endpoint-%v", i),
-			NetworkServiceNames: []string{nsReg.GetName()},
-			NetworkServiceLabels: map[string]*registry.NetworkServiceLabels{
-				nsReg.GetName(): {
-					Labels: map[string]string{
-						step: fmt.Sprintf("%v", i),
-					},
-				},
-			},
+		labels := map[string]string{
+			step: fmt.Sprintf("%v", i),
 		}
-
-		var additionalFunctionality []networkservice.NetworkServiceServer
-		if i != nodesCount-1 {
-			additionalFunctionality = []networkservice.NetworkServiceServer{
-				chain.NewNetworkServiceServer(
-					clienturl.NewServer(s.domain.Nodes[i].NSMgr.URL),
-					connect.NewServer(ctx,
-						client.NewClientFactory(
-							client.WithName(fmt.Sprintf("endpoint-client-%v", i)),
-							client.WithAdditionalFunctionality(
-								mechanismtranslation.NewClient(),
-								injectlabels.NewClient(nsesReg[i].NetworkServiceLabels[nsReg.Name].Labels),
-								kernel.NewClient(),
-							),
-						),
-						connect.WithDialTimeout(sandbox.DialTimeout),
-						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
-					),
-				),
-			}
-		}
-
-		_, err = s.domain.Nodes[i].NewEndpoint(ctx, nsesReg[i], sandbox.GenerateTestToken, additionalFunctionality...)
-		require.NoError(t, err)
+		nsesReg = append(nsesReg, newPassThroughEndpoint(ctx, t, s, labels, fmt.Sprintf("%v", i), nsReg.Name, i != nodesCount-1, i))
 	}
 
 	nsc := s.domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
-	request := defaultRequest(nsReg.GetName())
+	request := defaultRequest(nsReg.Name)
 
 	// Request
 	conn, err := nsc.Request(ctx, request)
@@ -452,6 +422,9 @@ func (s *nsmgrSuite) Test_PassThroughRemoteUsecase() {
 	// Path length to first endpoint is 5
 	// Path length from NSE client to other remote endpoint is 8
 	require.Equal(t, 8*(nodesCount-1)+5, len(conn.Path.PathSegments))
+	for i := 0; i < len(nsesReg); i++ {
+		require.Contains(t, nsesReg[i].Name, conn.Path.PathSegments[i*8+4].Name)
+	}
 
 	// Refresh
 	conn, err = nsc.Request(ctx, request)
@@ -470,7 +443,7 @@ func (s *nsmgrSuite) Test_PassThroughRemoteUsecase() {
 
 func (s *nsmgrSuite) Test_PassThroughLocalUsecase() {
 	t := s.T()
-	const nsesCount = 5
+	const nsesCount = 7
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -479,43 +452,13 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecase() {
 	nsReg, err := s.domain.Nodes[0].NSRegistryClient.Register(ctx, nsReg)
 	require.NoError(t, err)
 
-	var nsesReg [nsesCount]*registry.NetworkServiceEndpoint
+	var nsesReg []*registry.NetworkServiceEndpoint
 	for i := 0; i < nsesCount; i++ {
-		nsesReg[i] = &registry.NetworkServiceEndpoint{
-			Name:                fmt.Sprintf("endpoint-%v", i),
-			NetworkServiceNames: []string{nsReg.GetName()},
-			NetworkServiceLabels: map[string]*registry.NetworkServiceLabels{
-				nsReg.GetName(): {
-					Labels: map[string]string{
-						step: fmt.Sprintf("%v", i),
-					},
-				},
-			},
+		labels := map[string]string{
+			step: fmt.Sprintf("%v", i),
 		}
 
-		var additionalFunctionality []networkservice.NetworkServiceServer
-		if i != nsesCount-1 {
-			additionalFunctionality = []networkservice.NetworkServiceServer{
-				chain.NewNetworkServiceServer(
-					clienturl.NewServer(s.domain.Nodes[0].NSMgr.URL),
-					connect.NewServer(ctx,
-						client.NewClientFactory(
-							client.WithName(fmt.Sprintf("%v", i)),
-							client.WithAdditionalFunctionality(
-								mechanismtranslation.NewClient(),
-								injectlabels.NewClient(nsesReg[i].NetworkServiceLabels[nsReg.Name].Labels),
-								kernel.NewClient(),
-							),
-						),
-						connect.WithDialTimeout(sandbox.DialTimeout),
-						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
-					),
-				),
-			}
-		}
-
-		_, err = s.domain.Nodes[0].NewEndpoint(ctx, nsesReg[i], sandbox.GenerateTestToken, additionalFunctionality...)
-		require.NoError(t, err)
+		nsesReg = append(nsesReg, newPassThroughEndpoint(ctx, t, s, labels, fmt.Sprintf("%v", i), nsReg.Name, i != nsesCount-1, 0))
 	}
 
 	nsc := s.domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
@@ -529,6 +472,9 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecase() {
 	// Path length to first endpoint is 5
 	// Path length from NSE client to other local endpoint is 5
 	require.Equal(t, 5*(nsesCount-1)+5, len(conn.Path.PathSegments))
+	for i := 0; i < len(nsesReg); i++ {
+		require.Contains(t, nsesReg[i].Name, conn.Path.PathSegments[(i+1)*5-1].Name)
+	}
 
 	// Refresh
 	conn, err = nsc.Request(ctx, request)
@@ -562,44 +508,12 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecaseMultiLabel() {
 		for j := 0; j < 3; j++ {
 			labelBvalue += "b"
 
-			nseReg := &registry.NetworkServiceEndpoint{
-				Name:                fmt.Sprintf("endpoint-%v%v", i, j),
-				NetworkServiceNames: []string{nsReg.GetName()},
-				NetworkServiceLabels: map[string]*registry.NetworkServiceLabels{
-					nsReg.GetName(): {
-						Labels: map[string]string{
-							labelA: labelAvalue,
-							labelB: labelBvalue,
-						},
-					},
-				},
+			labels := map[string]string{
+				labelA: labelAvalue,
+				labelB: labelBvalue,
 			}
 
-			var additionalFunctionality []networkservice.NetworkServiceServer
-			if i != 2 || j != 2 {
-				additionalFunctionality = []networkservice.NetworkServiceServer{
-					chain.NewNetworkServiceServer(
-						clienturl.NewServer(s.domain.Nodes[0].NSMgr.URL),
-						connect.NewServer(ctx,
-							client.NewClientFactory(
-								client.WithName(fmt.Sprintf("endpoint-client-%v%v", i, j)),
-								client.WithAdditionalFunctionality(
-									mechanismtranslation.NewClient(),
-									injectlabels.NewClient(nseReg.NetworkServiceLabels[nsReg.Name].Labels),
-									kernel.NewClient(),
-								),
-							),
-							connect.WithDialTimeout(sandbox.DialTimeout),
-							connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
-						),
-					),
-				}
-			}
-
-			_, err = s.domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
-			require.NoError(t, err)
-
-			nsesReg = append(nsesReg, nseReg)
+			nsesReg = append(nsesReg, newPassThroughEndpoint(ctx, t, s, labels, labelAvalue+labelBvalue, nsReg.Name, i != 2 || j != 2, 0))
 		}
 		labelBvalue = ""
 	}
@@ -613,9 +527,10 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecaseMultiLabel() {
 	require.NotNil(t, conn)
 
 	// Path length from NSE client to other local endpoint is 5
+	expectedPath := []string{"ab", "aabb", "aaabbb"}
 	require.Equal(t, 5*len(nsReg.Matches), len(conn.Path.PathSegments))
-	for i := 0; i < len(nsReg.Matches); i++ {
-		require.Contains(t, nsesReg[i*4].Name, conn.Path.PathSegments[(i+1)*5-1].GetName())
+	for i := 0; i < len(expectedPath); i++ {
+		require.Contains(t, conn.Path.PathSegments[(i+1)*5-1].Name, expectedPath[i])
 	}
 
 	// Refresh
@@ -742,4 +657,46 @@ func multiLabelNS() *registry.NetworkService {
 			},
 		},
 	}
+}
+
+func additionalFunctionalityChain(ctx context.Context, clientURL *url.URL, clientName string, labels map[string]string) []networkservice.NetworkServiceServer {
+	return []networkservice.NetworkServiceServer{
+		chain.NewNetworkServiceServer(
+			clienturl.NewServer(clientURL),
+			connect.NewServer(ctx,
+				client.NewClientFactory(
+					client.WithName(fmt.Sprintf("endpoint-client-%v", clientName)),
+					client.WithAdditionalFunctionality(
+						mechanismtranslation.NewClient(),
+						replacelabels.NewClient(labels),
+						kernel.NewClient(),
+					),
+				),
+				connect.WithDialTimeout(sandbox.DialTimeout),
+				connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
+			),
+		),
+	}
+}
+
+func newPassThroughEndpoint(ctx context.Context, t *testing.T, s *nsmgrSuite, labels map[string]string, name, nsRegName string, hasClientFunctionality bool, nodeIndex int) *registry.NetworkServiceEndpoint {
+	nseReg := &registry.NetworkServiceEndpoint{
+		Name:                fmt.Sprintf("endpoint-%v", name),
+		NetworkServiceNames: []string{nsRegName},
+		NetworkServiceLabels: map[string]*registry.NetworkServiceLabels{
+			nsRegName: {
+				Labels: labels,
+			},
+		},
+	}
+
+	var additionalFunctionality []networkservice.NetworkServiceServer
+	if hasClientFunctionality {
+		additionalFunctionality = additionalFunctionalityChain(ctx, s.domain.Nodes[nodeIndex].NSMgr.URL, name, labels)
+	}
+
+	_, err := s.domain.Nodes[nodeIndex].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, additionalFunctionality...)
+	require.NoError(t, err)
+
+	return nseReg
 }

--- a/pkg/networkservice/chains/nsmgr/utils_test.go
+++ b/pkg/networkservice/chains/nsmgr/utils_test.go
@@ -24,13 +24,11 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
 	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
@@ -86,27 +84,6 @@ func testNSEAndClient(
 
 	_, err = domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nseReg)
 	require.NoError(t, err)
-}
-
-type passThroughClient struct {
-	networkService string
-}
-
-func newPassTroughClient(networkService string) *passThroughClient {
-	return &passThroughClient{
-		networkService: networkService,
-	}
-}
-
-func (c *passThroughClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
-	request.Connection.NetworkService = c.networkService
-	request.Connection.NetworkServiceEndpointName = ""
-	return next.Client(ctx).Request(ctx, request, opts...)
-}
-
-func (c *passThroughClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	conn.NetworkService = c.networkService
-	return next.Client(ctx).Close(ctx, conn, opts...)
 }
 
 type counterServer struct {

--- a/pkg/networkservice/common/replacelabels/client.go
+++ b/pkg/networkservice/common/replacelabels/client.go
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package injectlabels sets connection labels
-package injectlabels
+// Package replacelabels sets connection labels
+package replacelabels
 
 import (
 	"context"
@@ -28,11 +28,11 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 )
 
-type injectLabelsClient struct {
+type replaceLabelsClient struct {
 	labels map[string]string
 }
 
-func (s *injectLabelsClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (conn *networkservice.Connection, err error) {
+func (s *replaceLabelsClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (conn *networkservice.Connection, err error) {
 	oldConnLabels := request.Connection.Labels
 	oldNetworkServiceEndpointName := request.Connection.NetworkServiceEndpointName
 
@@ -50,13 +50,13 @@ func (s *injectLabelsClient) Request(ctx context.Context, request *networkservic
 	return conn, nil
 }
 
-func (s *injectLabelsClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+func (s *replaceLabelsClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
 	return next.Client(ctx).Close(ctx, conn, opts...)
 }
 
-// NewClient creates new instance of NetworkServiceClient chain element, which inject labels into connection
+// NewClient creates new instance of NetworkServiceClient chain element, which replaces labels in the connection
 func NewClient(labels map[string]string) networkservice.NetworkServiceClient {
-	return &injectLabelsClient{
+	return &replaceLabelsClient{
 		labels: labels,
 	}
 }

--- a/pkg/networkservice/utils/inject/injectlabels/client.go
+++ b/pkg/networkservice/utils/inject/injectlabels/client.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package injectlabels sets connection labels
+package injectlabels
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+type injectLabelsClient struct {
+	labels map[string]string
+}
+
+func (s *injectLabelsClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (conn *networkservice.Connection, err error) {
+	oldConnLabels := request.Connection.Labels
+	oldNetworkServiceEndpointName := request.Connection.NetworkServiceEndpointName
+
+	request.Connection.Labels = s.labels
+	request.Connection.NetworkServiceEndpointName = ""
+
+	conn, err = next.Client(ctx).Request(ctx, request, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	conn.Labels = oldConnLabels
+	conn.NetworkServiceEndpointName = oldNetworkServiceEndpointName
+
+	return conn, nil
+}
+
+func (s *injectLabelsClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.Client(ctx).Close(ctx, conn, opts...)
+}
+
+// NewClient creates new instance of NetworkServiceClient chain element, which inject labels into connection
+func NewClient(labels map[string]string) networkservice.NetworkServiceClient {
+	return &injectLabelsClient{
+		labels: labels,
+	}
+}

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -22,13 +22,9 @@ import (
 	"time"
 
 	"github.com/edwarnicke/grpcfd"
-	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
-
-	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/tools/opentracing"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
@@ -85,14 +81,6 @@ func GenerateExpiringToken(duration time.Duration) token.GeneratorFunc {
 	return func(_ credentials.AuthInfo) (tokenValue string, expireTime time.Time, err error) {
 		return value, time.Now().Add(duration).Local(), nil
 	}
-}
-
-// NewCrossConnectClientFactory is a client.NewCrossConnectClientFactory with some fields preset for testing
-func NewCrossConnectClientFactory(generatorFunc token.GeneratorFunc, additionalFunctionality ...networkservice.NetworkServiceClient) client.Factory {
-	return client.NewCrossConnectClientFactory(
-		client.WithName(fmt.Sprintf("nsc-%v", uuid.New().String())),
-		client.WithAdditionalFunctionality(additionalFunctionality...),
-	)
 }
 
 // DefaultDialOptions returns default dial options for sandbox testing


### PR DESCRIPTION
Signed-off-by: Mikhail Avramenko <avramenkomihail15@gmail.com>

## Description
With this changes passthrough cases now using labels matching to discover endpoint chain, also added case for testing multi label scenario

## Issue link
fixes https://github.com/networkservicemesh/sdk/issues/880

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [x] Refactoring
- [ ] CI
