### PR TITLE
[qfix] Fix data race caused by querycache

### DIFF
--- a/pkg/registry/common/querycache/nse_client.go
+++ b/pkg/registry/common/querycache/nse_client.go
@@ -64,7 +64,7 @@ func (q *queryCacheNSEClient) Find(ctx context.Context, query *registry.NetworkS
 
 	resultCh := make(chan *registry.NetworkServiceEndpoint, len(nses))
 	for _, nse := range nses {
-		resultCh <- nse
+		resultCh <- nse.Clone()
 		q.storeInCache(ctx, nse, opts...)
 	}
 	close(resultCh)

--- a/pkg/registry/common/querycache/nse_client.go
+++ b/pkg/registry/common/querycache/nse_client.go
@@ -64,8 +64,8 @@ func (q *queryCacheNSEClient) Find(ctx context.Context, query *registry.NetworkS
 
 	resultCh := make(chan *registry.NetworkServiceEndpoint, len(nses))
 	for _, nse := range nses {
-		resultCh <- nse.Clone()
-		q.storeInCache(ctx, nse, opts...)
+		resultCh <- nse
+		q.storeInCache(ctx, nse.Clone(), opts...)
 	}
 	close(resultCh)
 


### PR DESCRIPTION
## Description
Adds missed NSE clone on return in `querycache`.

## Logs
```
2021-05-13T06:34:36.2512451Z ==================
2021-05-13T06:34:36.2512901Z WARNING: DATA RACE
2021-05-13T06:34:36.2513439Z Read at 0x00c000970c98 by goroutine 21:
...
2021-05-13T06:34:36.2526316Z   github.com/networkservicemesh/api/pkg/api/registry.(*NetworkServiceEndpoint).Clone()
2021-05-13T06:34:36.2527457Z       C:/Users/runneradmin/go/pkg/mod/github.com/networkservicemesh/api@v0.0.0-20210509180413-5753c9f30588/pkg/api/registry/helpers.go:101 +0xd7
2021-05-13T06:34:36.2528765Z   github.com/networkservicemesh/sdk/pkg/registry/common/querycache.(*queryCacheNSEClient).findInCache()
...
2021-05-13T06:34:36.2622739Z Previous write at 0x00c000970c98 by goroutine 102:
2021-05-13T06:34:36.2623804Z   github.com/networkservicemesh/sdk/pkg/registry/common/localbypass.(*localBypassNSEFindServer).Send()
...
```


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
