### PR TITLE
[sdk#925] Use monitor stream for canceling connect client

### DIFF
--- a/pkg/networkservice/common/connect/monitor_client_test.go
+++ b/pkg/networkservice/common/connect/monitor_client_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect_test
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/cancelctx"
+)
+
+type monitorClient struct {
+	ctx  context.Context
+	cc   grpc.ClientConnInterface
+	err  error
+	lock sync.Mutex
+	once sync.Once
+}
+
+func newMonitorClient(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
+	return &monitorClient{
+		ctx: ctx,
+		cc:  cc,
+	}
+}
+
+func (c *monitorClient) init() error {
+	c.once.Do(func() {
+		cancel := cancelctx.FromContext(c.ctx)
+		if cancel == nil {
+			c.err = errors.New("no cancel func")
+			return
+		}
+
+		var stream grpc_health_v1.Health_WatchClient
+		if stream, c.err = grpc_health_v1.NewHealthClient(c.cc).Watch(c.ctx, new(grpc_health_v1.HealthCheckRequest)); c.err != nil {
+			return
+		}
+
+		go func() {
+			defer cancel()
+			for {
+				if _, err := stream.Recv(); err != nil {
+					c.lock.Lock()
+					c.err = err
+					c.lock.Unlock()
+					return
+				}
+			}
+		}()
+	})
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.err
+}
+
+func (c *monitorClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	if err := c.init(); err != nil {
+		return nil, err
+	}
+	return next.Client(ctx).Request(ctx, request, opts...)
+}
+
+func (c *monitorClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	if err := c.init(); err != nil {
+		return nil, err
+	}
+	return next.Client(ctx).Close(ctx, conn, opts...)
+}

--- a/pkg/networkservice/common/connect/utils_test.go
+++ b/pkg/networkservice/common/connect/utils_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connect_test
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+)
+
+func startServer(ctx context.Context, listenOn *url.URL, server networkservice.NetworkServiceServer) error {
+	grpcServer := grpc.NewServer()
+
+	networkservice.RegisterNetworkServiceServer(grpcServer, server)
+	grpcutils.RegisterHealthServices(grpcServer, server)
+
+	errCh := grpcutils.ListenAndServe(ctx, listenOn, grpcServer)
+	select {
+	case err := <-errCh:
+		return err
+	default:
+	}
+
+	return waitServerStarted(listenOn)
+}
+
+func waitServerStarted(target *url.URL) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(target), grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = cc.Close()
+	}()
+
+	healthCheckRequest := &grpc_health_v1.HealthCheckRequest{
+		Service: networkservice.ServiceNames(null.NewServer())[0],
+	}
+
+	client := grpc_health_v1.NewHealthClient(cc)
+	for ctx.Err() == nil {
+		response, err := client.Check(ctx, healthCheckRequest)
+		if err != nil {
+			return err
+		}
+		if response.Status == grpc_health_v1.HealthCheckResponse_SERVING {
+			return nil
+		}
+	}
+	return ctx.Err()
+}
+
+func waitServerStopped(target *url.URL) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var err error
+	for err == nil && ctx.Err() == nil {
+		dialCtx, dialCancel := context.WithTimeout(ctx, 10*time.Millisecond)
+
+		var cc *grpc.ClientConn
+		if cc, err = grpc.DialContext(dialCtx, grpcutils.URLToTarget(target), grpc.WithBlock(), grpc.WithInsecure()); err == nil {
+			_ = cc.Close()
+		}
+
+		dialCancel()
+	}
+	return ctx.Err()
+}

--- a/pkg/tools/cancelctx/context.go
+++ b/pkg/tools/cancelctx/context.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cancelctx provides methods for creating context with injected cancel func for it
+package cancelctx
+
+import "context"
+
+const (
+	cancelKey contextKeyType = "cancel"
+)
+
+type contextKeyType string
+
+// WithCancel creates a context with cancel func and injects it into the context
+func WithCancel(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		panic("cannot create context from nil parent")
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	ctx = context.WithValue(ctx, cancelKey, cancel)
+
+	return ctx, cancel
+}
+
+// FromContext returns a cancel func for the context
+func FromContext(ctx context.Context) context.CancelFunc {
+	if cancel, ok := ctx.Value(cancelKey).(context.CancelFunc); ok {
+		return cancel
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

### Problem
gRPC stream handles gRPC connection state change faster than our existing check and so we can have monitor stream closed, but connect client still running.

### Solution
Use monitor stream to track gRPC connection liveness.

## Issue link
#925 

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
