### PR TITLE
move sriov tokens from sdk-sriov into sdk repo

### DIFF
--- a/pkg/tools/tokens/tokens.go
+++ b/pkg/tools/tokens/tokens.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2021 Nordix Foundation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tokens provides utility methods to store and load tokens to/from environment variables
+package tokens
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	envPrefix = "NSM_SRIOV_TOKENS_"
+)
+
+// ToEnv returns a (name, value) pair to store given tokens into the environment variable
+func ToEnv(tokenName string, tokenIDs []string) (name, value string) {
+	return fmt.Sprintf("%s%s", envPrefix, tokenName), strings.Join(tokenIDs, ",")
+}
+
+// FromEnv returns all stored tokens from the list of environment variables
+func FromEnv(envs []string) map[string][]string {
+	tokens := map[string][]string{}
+	for _, env := range envs {
+		if !strings.HasPrefix(env, envPrefix) {
+			continue
+		}
+		nameIDs := strings.Split(strings.TrimPrefix(env, envPrefix), "=")
+		tokens[nameIDs[0]] = strings.Split(nameIDs[1], ",")
+	}
+	return tokens
+}

--- a/pkg/tools/tokens/tokens_test.go
+++ b/pkg/tools/tokens/tokens_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2021 Nordix Foundation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokens_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/tokens"
+)
+
+func TestToEnv(t *testing.T) {
+	name, value := tokens.ToEnv("name", []string{"1", "2", "3"})
+	require.Equal(t, "NSM_SRIOV_TOKENS_name", name)
+	require.Equal(t, "1,2,3", value)
+}
+
+func TestFromEnv(t *testing.T) {
+	envs := []string{
+		"A=aaa",
+		"NSM_SRIOV_TOKENS_name-1=1,2,3",
+		"B=bbb",
+		"NSM_SRIOV_TOKENS_name-2=4",
+	}
+
+	toks := tokens.FromEnv(envs)
+	require.Equal(t, map[string][]string{
+		"name-1": {"1", "2", "3"},
+		"name-2": {"4"},
+	}, toks)
+}


### PR DESCRIPTION
Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Move tokens package from sdk-sriov repo into sdk repo as per feedback [here](https://github.com/networkservicemesh/cmd-forwarder-sriov/issues/163#issuecomment-839757019)

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/cmd-forwarder-sriov/issues/163

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [x] Refactoring
- [ ] CI
