### PR TITLE
[qfix] Make clientinfo skip already preset labels

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -186,6 +186,10 @@ issues:
       linters:
         - funlen
       text: "Function 'TestMonitor' is too long"
+    - path: pkg/networkservice/common/clientinfo/client_test.go
+      linters:
+        - funlen
+      text: "Function 'TestClientInfo' is too long"
     - path: pkg/networkservice/common/connect/server_test.go
       linters:
         - funlen

--- a/pkg/registry/common/clientinfo/server_test.go
+++ b/pkg/registry/common/clientinfo/server_test.go
@@ -78,9 +78,9 @@ func TestLabelsServer(t *testing.T) {
 				"CLUSTER_NAME": "CCC",
 			},
 			expected: map[string]string{
-				"NodeNameKey":    "AAA",
-				"PodNameKey":     "BBB",
-				"ClusterNameKey": "CCC",
+				"NodeNameKey":    "OLD_VAL1",
+				"PodNameKey":     "OLD_VAL2",
+				"ClusterNameKey": "OLD_VAL3",
 				"SomeOtherLabel": "DDD",
 			},
 			input: map[string]string{
@@ -97,7 +97,7 @@ func TestLabelsServer(t *testing.T) {
 			},
 			expected: map[string]string{
 				"NodeNameKey":    "OLD_VAL1",
-				"ClusterNameKey": "CCC",
+				"ClusterNameKey": "OLD_VAL2",
 				"SomeOtherLabel": "DDD",
 			},
 			input: map[string]string{

--- a/pkg/tools/clientinfo/clientinfo.go
+++ b/pkg/tools/clientinfo/clientinfo.go
@@ -49,7 +49,8 @@ func AddClientInfo(ctx context.Context, labels map[string]string) {
 		}
 		oldValue, isPresent := labels[labelName]
 		if isPresent {
-			log.FromContext(ctx).Warnf("The label %s was already assigned to %s. Overwriting.", labelName, oldValue)
+			log.FromContext(ctx).Warnf("The label %s was already assigned to %s. Skipping.", labelName, oldValue)
+			continue
 		}
 		labels[labelName] = value
 	}


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Currently `clientinfo` overwrites labels that are already present. This is incorrect behaviour because this way local NS manager which contains `clientinfo` element will overwrite labels with its local values, rendering `clientinfo` useless, because we already know our local values and we want to know where the request came from.

This PR makes `clientinfo` skip already present values and changes the unit tests to accommodate for this change (for both `networkservice`'s and `registry`'s `clientinfo` element).

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
