### PR TITLE
[sdk#713] registry connect (fix)

### DIFF
--- a/pkg/registry/chains/client/nse_client.go
+++ b/pkg/registry/chains/client/nse_client.go
@@ -72,13 +72,15 @@ func newNetworkServiceEndpointRegistryClient(ctx context.Context, connectTo *url
 		interposeClient,
 		serialize.NewNetworkServiceEndpointRegistryClient(),
 		refresh.NewNetworkServiceEndpointRegistryClient(ctx),
-		sendfd.NewNetworkServiceEndpointRegistryClient(),
 		additionalFunctionalityClient,
 		adapters.NetworkServiceEndpointServerToClient(
 			chain.NewNetworkServiceEndpointRegistryServer(
 				clienturl.NewNetworkServiceEndpointRegistryServer(connectTo),
 				connect.NewNetworkServiceEndpointRegistryServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) registry.NetworkServiceEndpointRegistryClient {
-					return registry.NewNetworkServiceEndpointRegistryClient(cc)
+					return chain.NewNetworkServiceEndpointRegistryClient(
+						sendfd.NewNetworkServiceEndpointRegistryClient(),
+						registry.NewNetworkServiceEndpointRegistryClient(cc),
+					)
 				}, clientOpts.dialOptions...),
 			),
 		),


### PR DESCRIPTION
## Description
Moves `sendfd` chain element to the client chain after `connect`.

## Issue link
sdk#713


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by ~integration testing~ docker tests in `cmd-nse-`
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
