### PR TITLE
[sdk#925] Replace time.After() with waiting on client context done

### DIFF
--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -20,7 +20,6 @@ package heal
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
@@ -28,7 +27,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/clock"
 )
 
 type connectionInfo struct {
@@ -121,7 +119,7 @@ func (u *healClient) Request(ctx context.Context, request *networkservice.Networ
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-condCh:
-	case <-clock.FromContext(ctx).After(100 * time.Millisecond):
+	case <-u.ctx.Done():
 		_, _ = next.Client(ctx).Close(ctx, conn)
 		return nil, errors.Errorf("timeout waiting for connection monitor: %s", conn.GetId())
 	}


### PR DESCRIPTION
## Description
Missed this in the initial PR https://github.com/networkservicemesh/sdk/pull/926#discussion_r635858267.

## Issue link
#925 


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Tested by the existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [x] Refactoring
- [ ] CI
