### PR TITLE
[qfix] Don't start healing if ctx is canceled

### DIFF
--- a/pkg/networkservice/common/heal/server.go
+++ b/pkg/networkservice/common/heal/server.go
@@ -193,7 +193,9 @@ func (f *healServer) restoreConnection(ctx context.Context, request *networkserv
 		}
 	}
 
-	f.processHeal(ctx, request.Clone(), opts...)
+	if ctx.Err() == nil {
+		f.processHeal(ctx, request.Clone(), opts...)
+	}
 }
 
 func (f *healServer) processHeal(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) {

--- a/pkg/networkservice/common/heal/server.go
+++ b/pkg/networkservice/common/heal/server.go
@@ -193,14 +193,16 @@ func (f *healServer) restoreConnection(ctx context.Context, request *networkserv
 		}
 	}
 
-	if ctx.Err() == nil {
-		f.processHeal(ctx, request.Clone(), opts...)
-	}
+	f.processHeal(ctx, request.Clone(), opts...)
 }
 
 func (f *healServer) processHeal(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) {
 	logEntry := log.FromContext(ctx).WithField("healServer", "processHeal")
 	conn := request.GetConnection()
+
+	if ctx.Err() != nil {
+		return
+	}
 
 	candidates := discover.Candidates(ctx)
 	if candidates != nil || conn.GetPath().GetIndex() == 0 {


### PR DESCRIPTION
## Description
Restore shouldn't start heal if heal context is canceled.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
