### PR TITLE
[qfix] Reduce clockmock set speed test precision

### DIFF
--- a/pkg/tools/clockmock/mock_test.go
+++ b/pkg/tools/clockmock/mock_test.go
@@ -139,8 +139,8 @@ func testMockSetSpeed(t *testing.T, firstSpeed, secondSpeed float64) {
 	mockSpeed := float64(mockDuration-2*hours*time.Hour) / float64(realDuration)
 	avgSpeed := (firstSpeed + secondSpeed) / 2
 
-	require.Greater(t, mockSpeed/avgSpeed, 0.7)
-	require.Less(t, mockSpeed/avgSpeed, 1.3)
+	require.Greater(t, mockSpeed/avgSpeed, 0.6)
+	require.Less(t, mockSpeed/avgSpeed, 1.4)
 }
 
 func TestMock_Timer(t *testing.T) {


### PR DESCRIPTION
## Description
Clock mock set speed tests requires too high precision.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] ~Bug fix~ Test fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
