### PR TITLE
[sdk#970] Add restoreEnabled option to heal

### DIFF
--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -111,7 +111,8 @@ func NewClient(ctx context.Context, connectTo *url.URL, clientOpts ...Option) ne
 		metadata.NewClient(),
 		adapters.NewServerToClient(
 			chain.NewNetworkServiceServer(
-				heal.NewServer(ctx, rv),
+				heal.NewServer(ctx,
+					heal.WithOnHeal(rv)),
 				clienturl.NewServer(connectTo),
 				connect.NewServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 					return chain.NewNetworkServiceClient(

--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -193,7 +193,8 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 			recvfd.NewServer(), // Receive any files passed
 			interpose.NewServer(&interposeRegistryServer),
 			filtermechanisms.NewServer(&urlsRegistryServer),
-			heal.NewServer(ctx, addressof.NetworkServiceClient(adapters.NewServerToClient(rv))),
+			heal.NewServer(ctx,
+				heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(rv)))),
 			connect.NewServer(ctx,
 				client.NewClientFactory(
 					client.WithName(opts.name),

--- a/pkg/networkservice/chains/nsmgrproxy/server.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server.go
@@ -157,7 +157,8 @@ func NewServer(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator to
 			interdomainurl.NewServer(&nseStockServer),
 			discover.NewServer(nsClient, nseClient),
 			swapip.NewServer(ctx, opts.mapipFilePath),
-			heal.NewServer(ctx, addressof.NetworkServiceClient(adapters.NewServerToClient(rv))),
+			heal.NewServer(ctx,
+				heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(rv)))),
 			connect.NewServer(ctx,
 				client.NewClientFactory(
 					client.WithName(opts.name),

--- a/pkg/networkservice/common/heal/option.go
+++ b/pkg/networkservice/common/heal/option.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heal
+
+import "github.com/networkservicemesh/api/pkg/api/networkservice"
+
+// Option is an option pattern for heal server
+type Option func(healOpts *healOptions)
+
+// WithOnHeal - sets client used 'onHeal'.
+// * If we detect we need to heal, onHeal.Request is used to heal.
+// * If we can't heal connection, onHeal.Close will be called.
+// * If onHeal is nil, then we simply set onHeal to this client chain element.
+// Since networkservice.NetworkServiceClient is an interface (and thus a pointer) *networkservice.NetworkServiceClient
+// is a double pointer. Meaning it points to a place that points to a place that implements
+// networkservice.NetworkServiceClient. This is done because when we use heal.NewClient as part of a chain, we may not
+// *have* a pointer to this chain.
+func WithOnHeal(onHeal *networkservice.NetworkServiceClient) Option {
+	return func(healOpts *healOptions) {
+		healOpts.onHeal = onHeal
+	}
+}
+
+// WithRestoreEnabled sets is restore enabled. Default `true`.
+// IMPORTANT: restore should be disabled for the Forwarder, because it results in NSMgr doesn't understanding that
+// Request is coming from Forwarder (https://github.com/networkservicemesh/sdk/issues/970).
+func WithRestoreEnabled(restoreEnabled bool) Option {
+	return func(healOpts *healOptions) {
+		healOpts.restoreEnabled = restoreEnabled
+	}
+}
+
+type healOptions struct {
+	onHeal         *networkservice.NetworkServiceClient
+	restoreEnabled bool
+}

--- a/pkg/networkservice/common/heal/server_test.go
+++ b/pkg/networkservice/common/heal/server_test.go
@@ -77,7 +77,8 @@ func TestHealClient_Request(t *testing.T) {
 		monitor.NewServer(ctx, &monitorServer),
 		updatetoken.NewServer(sandbox.GenerateTestToken),
 	)
-	healServer := heal.NewServer(ctx, addressof.NetworkServiceClient(onHeal))
+	healServer := heal.NewServer(ctx,
+		heal.WithOnHeal(addressof.NetworkServiceClient(onHeal)))
 	client := chain.NewNetworkServiceClient(
 		updatepath.NewClient("testClient"),
 		adapters.NewServerToClient(healServer),

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -56,7 +56,9 @@ func (n *Node) NewForwarder(
 	ep := new(EndpointEntry)
 	additionalFunctionality = append(additionalFunctionality,
 		clienturl.NewServer(n.NSMgr.URL),
-		heal.NewServer(ctx, addressof.NetworkServiceClient(adapters.NewServerToClient(ep))),
+		heal.NewServer(ctx,
+			heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(ep))),
+			heal.WithRestoreEnabled(false)),
 		connect.NewServer(ctx,
 			client.NewClientFactory(
 				client.WithName(nse.Name),


### PR DESCRIPTION
## Description
Reworks heal server to options, adds `restoreEnabled` option.

## Issue link
#970

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Edited existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
