### PR TITLE
Stop healing after close

### DIFF
--- a/pkg/networkservice/common/heal/server.go
+++ b/pkg/networkservice/common/heal/server.go
@@ -104,13 +104,11 @@ func (f *healServer) Request(ctx context.Context, request *networkservice.Networ
 }
 
 func (f *healServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	rv, err := next.Server(ctx).Close(ctx, conn)
+
 	f.stopHeal(conn)
 
-	rv, err := next.Server(ctx).Close(ctx, conn)
-	if err != nil {
-		return nil, err
-	}
-	return rv, nil
+	return rv, err
 }
 
 func (f *healServer) getHealContext(conn *networkservice.Connection) (*networkservice.NetworkServiceRequest, context.Context) {


### PR DESCRIPTION
## Description
Stop healing after `next.Close()` to prevent stopping ourselves.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
