### PR TITLE
Use default sandbox dial timeout for sandbox NSC

### DIFF
--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -143,6 +143,7 @@ func (n *Node) NewClient(
 		ctx,
 		n.NSMgr.URL,
 		client.WithDialOptions(DefaultDialOptions(generatorFunc)...),
+		client.WithDialTimeout(DialTimeout),
 		client.WithAuthorizeClient(authorize.NewClient(authorize.Any())),
 		client.WithAdditionalFunctionality(additionalFunctionality...),
 	)


### PR DESCRIPTION
## Description
Use default sandbox dial timeout `500ms` instead of default `100ms` for sandbox NSC.


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing.
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
