### PR TITLE
[sdk#978] Disable restore in heal

### DIFF
--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -112,7 +112,9 @@ func NewClient(ctx context.Context, connectTo *url.URL, clientOpts ...Option) ne
 		adapters.NewServerToClient(
 			chain.NewNetworkServiceServer(
 				heal.NewServer(ctx,
-					heal.WithOnHeal(rv)),
+					heal.WithOnHeal(rv),
+					heal.WithRestoreEnabled(true),
+					heal.WithRestoreTimeout(time.Minute)),
 				clienturl.NewServer(connectTo),
 				connect.NewServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 					return chain.NewNetworkServiceClient(

--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -113,7 +113,7 @@ func NewClient(ctx context.Context, connectTo *url.URL, clientOpts ...Option) ne
 			chain.NewNetworkServiceServer(
 				heal.NewServer(ctx,
 					heal.WithOnHeal(rv),
-					heal.WithRestoreEnabled(true),
+					heal.WithOnRestore(heal.OnRestoreRestore),
 					heal.WithRestoreTimeout(time.Minute)),
 				clienturl.NewServer(connectTo),
 				connect.NewServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {

--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -23,35 +23,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
 const (
-	tick         = 10 * time.Millisecond
-	timeout      = 10 * time.Second
-	tokenTimeout = 5 * time.Second
+	tick    = 10 * time.Millisecond
+	timeout = 10 * time.Second
 )
 
-func TestNSMGR_HealEndpoint(t *testing.T) {
-	testNSMGRHealEndpoint(t, false)
-}
-
-func TestNSMGR_HealEndpointRestored(t *testing.T) {
-	testNSMGRHealEndpoint(t, true)
-}
-
-func testNSMGRHealEndpoint(t *testing.T, restored bool) {
+func TestNSMGRHealEndpoint(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+
 	domain := sandbox.NewBuilder(t).
 		SetNodesCount(2).
 		SetRegistryProxySupplier(nil).
@@ -62,19 +52,11 @@ func testNSMGRHealEndpoint(t *testing.T, restored bool) {
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
-	if !restored {
-		nseReg.ExpirationTime = timestamppb.New(time.Now().Add(tokenTimeout))
-	}
 
 	nseCtx, nseCtxCancel := context.WithCancel(context.Background())
 
 	counter := &counterServer{}
-	var nse *sandbox.EndpointEntry
-	if restored {
-		nse, err = domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, counter)
-	} else {
-		nse, err = domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.GenerateExpiringToken(tokenTimeout), counter)
-	}
+	_, err = domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, counter)
 	require.NoError(t, err)
 
 	request := defaultRequest(nsReg.Name)
@@ -83,26 +65,16 @@ func testNSMGRHealEndpoint(t *testing.T, restored bool) {
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
-	require.NotNil(t, conn)
 	require.Equal(t, 1, counter.UniqueRequests())
-	require.Equal(t, 8, len(conn.Path.PathSegments))
 
 	nseCtxCancel()
 
-	// Wait grpc unblock the port
-	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(nse.URL)
-	}, timeout, tick)
-
 	nseReg2 := defaultRegistryEndpoint(nsReg.Name)
 	nseReg2.Name += "-2"
-	if restored {
-		nseReg2.Url = nse.URL.String()
-	}
 	_, err = domain.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, counter)
 	require.NoError(t, err)
 
-	// Wait NSE expired and reconnecting to the new NSE
+	// Wait reconnecting to the new NSE
 	require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
 	require.Equal(t, 2, counter.UniqueRequests())
 
@@ -111,10 +83,10 @@ func testNSMGRHealEndpoint(t *testing.T, restored bool) {
 	_, err = nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 
-	// Close.
-	e, err := nsc.Close(ctx, conn)
+	// Close with old connection
+	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.NotNil(t, e)
+
 	require.Equal(t, 2, counter.UniqueRequests())
 	require.Equal(t, 1, counter.UniqueCloses())
 }
@@ -127,26 +99,11 @@ func TestNSMGR_HealLocalForwarder(t *testing.T) {
 		nil,
 		{
 			ForwarderCtx:               forwarderCtx,
-			ForwarderGenerateTokenFunc: sandbox.GenerateExpiringToken(tokenTimeout),
-		},
-	}
-
-	testNSMGRHealForwarder(t, 1, false, customConfig, forwarderCtxCancel)
-}
-
-func TestNSMGR_HealLocalForwarderRestored(t *testing.T) {
-	forwarderCtx, forwarderCtxCancel := context.WithCancel(context.Background())
-	defer forwarderCtxCancel()
-
-	customConfig := []*sandbox.NodeConfig{
-		nil,
-		{
-			ForwarderCtx:               forwarderCtx,
 			ForwarderGenerateTokenFunc: sandbox.GenerateTestToken,
 		},
 	}
 
-	testNSMGRHealForwarder(t, 1, true, customConfig, forwarderCtxCancel)
+	testNSMGRHealForwarder(t, 1, customConfig, forwarderCtxCancel)
 }
 
 func TestNSMGR_HealRemoteForwarder(t *testing.T) {
@@ -156,29 +113,16 @@ func TestNSMGR_HealRemoteForwarder(t *testing.T) {
 	customConfig := []*sandbox.NodeConfig{
 		{
 			ForwarderCtx:               forwarderCtx,
-			ForwarderGenerateTokenFunc: sandbox.GenerateExpiringToken(tokenTimeout),
-		},
-	}
-
-	testNSMGRHealForwarder(t, 0, false, customConfig, forwarderCtxCancel)
-}
-
-func TestNSMGR_HealRemoteForwarderRestored(t *testing.T) {
-	forwarderCtx, forwarderCtxCancel := context.WithCancel(context.Background())
-	defer forwarderCtxCancel()
-
-	customConfig := []*sandbox.NodeConfig{
-		{
-			ForwarderCtx:               forwarderCtx,
 			ForwarderGenerateTokenFunc: sandbox.GenerateTestToken,
 		},
 	}
 
-	testNSMGRHealForwarder(t, 0, true, customConfig, forwarderCtxCancel)
+	testNSMGRHealForwarder(t, 0, customConfig, forwarderCtxCancel)
 }
 
-func testNSMGRHealForwarder(t *testing.T, nodeNum int, restored bool, customConfig []*sandbox.NodeConfig, forwarderCtxCancel context.CancelFunc) {
+func testNSMGRHealForwarder(t *testing.T, nodeNum int, customConfig []*sandbox.NodeConfig, forwarderCtxCancel context.CancelFunc) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -203,64 +147,39 @@ func testNSMGRHealForwarder(t *testing.T, nodeNum int, restored bool, customConf
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
-	require.NotNil(t, conn)
 	require.Equal(t, 1, counter.UniqueRequests())
-	require.Equal(t, 8, len(conn.Path.PathSegments))
 
 	forwarderCtxCancel()
 
-	// Wait grpc unblock the port
-	require.GreaterOrEqual(t, 1, len(domain.Nodes[nodeNum].Forwarder))
-	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(domain.Nodes[nodeNum].Forwarder[0].URL)
-	}, timeout, tick)
-
-	forwarderReg := &registry.NetworkServiceEndpoint{
+	_, err = domain.Nodes[nodeNum].NewForwarder(ctx, &registry.NetworkServiceEndpoint{
 		Name: "forwarder-restored",
-	}
-	if restored {
-		forwarderReg.Url = domain.Nodes[nodeNum].Forwarder[0].URL.String()
-	}
-	_, err = domain.Nodes[nodeNum].NewForwarder(ctx, forwarderReg, sandbox.GenerateTestToken)
+	}, sandbox.GenerateTestToken)
 	require.NoError(t, err)
 
-	// Wait Cross NSE expired and reconnecting through the new Cross NSE
-	if restored {
-		require.Eventually(t, checkSecondRequestsReceived(func() int {
-			return int(atomic.LoadInt32(&counter.Requests))
-		}), timeout, tick)
-	} else {
-		require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
-	}
-	if restored {
-		require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
-	} else {
-		require.Equal(t, 2, counter.UniqueRequests())
-	}
+	// Wait reconnecting through the new Forwarder
+	require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
+	require.Equal(t, 2, counter.UniqueRequests())
 
 	// Check refresh
 	request.Connection = conn
 	_, err = nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 
-	// Close.
-	closes := atomic.LoadInt32(&counter.Closes)
-	e, err := nsc.Close(ctx, conn)
+	// Close with old connection
+	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.NotNil(t, e)
 
-	if restored {
-		require.Equal(t, int32(3), atomic.LoadInt32(&counter.Requests))
-		require.Equal(t, closes+1, atomic.LoadInt32(&counter.Closes))
-	} else {
-		require.Equal(t, 2, counter.UniqueRequests())
-		require.Equal(t, 2, counter.UniqueCloses())
-	}
+	require.Equal(t, 2, counter.UniqueRequests())
+	require.Equal(t, 1, counter.UniqueCloses())
 }
 
 func TestNSMGR_HealLocalNSMgrRestored(t *testing.T) {
-	nsmgrCtx, nsmgrCtxCancel := context.WithCancel(context.Background())
-	defer nsmgrCtxCancel()
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	nsmgrCtx, nsmgrCtxCancel := context.WithCancel(ctx)
 
 	customConfig := []*sandbox.NodeConfig{
 		nil,
@@ -270,29 +189,6 @@ func TestNSMGR_HealLocalNSMgrRestored(t *testing.T) {
 		},
 	}
 
-	testNSMGRHealNSMgr(t, 1, customConfig, nsmgrCtxCancel)
-}
-
-func TestNSMGR_HealRemoteNSMgrRestored(t *testing.T) {
-	nsmgrCtx, nsmgrCtxCancel := context.WithCancel(context.Background())
-	defer nsmgrCtxCancel()
-
-	customConfig := []*sandbox.NodeConfig{
-		{
-			NsmgrCtx:               nsmgrCtx,
-			NsmgrGenerateTokenFunc: sandbox.GenerateTestToken,
-		},
-	}
-
-	testNSMGRHealNSMgr(t, 0, customConfig, nsmgrCtxCancel)
-}
-
-func testNSMGRHealNSMgr(t *testing.T, nodeNum int, customConfig []*sandbox.NodeConfig, nsmgrCtxCancel context.CancelFunc) {
-	t.Cleanup(func() { goleak.VerifyNone(t) })
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
 	builder := sandbox.NewBuilder(t)
 	domain := builder.
 		SetNodesCount(2).
@@ -314,54 +210,54 @@ func testNSMGRHealNSMgr(t *testing.T, nodeNum int, customConfig []*sandbox.NodeC
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
-	require.NotNil(t, conn)
-	require.Equal(t, 1, counter.UniqueRequests())
-	require.Equal(t, 8, len(conn.Path.PathSegments))
+	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
 
 	nsmgrCtxCancel()
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
-	require.Equal(t, int32(0), atomic.LoadInt32(&counter.Closes))
 
+	// Wait grpc unblock the port
 	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(domain.Nodes[nodeNum].NSMgr.URL)
+		return grpcutils.CheckURLFree(domain.Nodes[1].NSMgr.URL)
 	}, timeout, tick)
 
-	restoredNSMgrEntry, restoredNSMgrResources := builder.NewNSMgr(ctx, domain.Nodes[nodeNum], domain.Nodes[nodeNum].NSMgr.URL.Host, domain.Registry.URL, sandbox.GenerateTestToken)
-	domain.Nodes[nodeNum].NSMgr = restoredNSMgrEntry
+	restoredNSMgrEntry, restoredNSMgrResources := builder.NewNSMgr(ctx, domain.Nodes[1], domain.Nodes[1].NSMgr.URL.Host, domain.Registry.URL, sandbox.GenerateTestToken)
+	domain.Nodes[1].NSMgr = restoredNSMgrEntry
 	domain.AddResources(restoredNSMgrResources)
 
+	// Wait NSC restore the connection
 	require.Eventually(t, checkSecondRequestsReceived(func() int {
 		return int(atomic.LoadInt32(&counter.Requests))
 	}), timeout, tick)
+	require.Equal(t, int32(2), counter.Requests)
+	require.Equal(t, 1, counter.UniqueRequests())
 
 	// Check refresh
 	request.Connection = conn
 	_, err = nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 
-	// Close.
-	closes := atomic.LoadInt32(&counter.Closes)
+	// Close with old connection
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
 
 	require.Equal(t, int32(3), atomic.LoadInt32(&counter.Requests))
-	require.Equal(t, closes+1, atomic.LoadInt32(&counter.Closes))
+	require.Equal(t, 1, counter.UniqueRequests())
+	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
 }
 
 func TestNSMGR_HealRemoteNSMgr(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	nsmgrCtx, nsmgrCtxCancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	nsmgrCtx, nsmgrCtxCancel := context.WithCancel(ctx)
 
 	customConfig := []*sandbox.NodeConfig{
 		{
 			NsmgrCtx:               nsmgrCtx,
-			NsmgrGenerateTokenFunc: sandbox.GenerateExpiringToken(tokenTimeout),
+			NsmgrGenerateTokenFunc: sandbox.GenerateTestToken,
 		},
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 
 	builder := sandbox.NewBuilder(t)
 	domain := builder.
@@ -395,7 +291,7 @@ func TestNSMGR_HealRemoteNSMgr(t *testing.T) {
 	_, err = domain.Nodes[2].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, counter)
 	require.NoError(t, err)
 
-	// Wait NSMgr expired and reconnecting through the new NSMgr
+	// Wait through the new NSMgr
 	require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
 	require.Equal(t, 2, counter.UniqueRequests())
 
@@ -404,12 +300,12 @@ func TestNSMGR_HealRemoteNSMgr(t *testing.T) {
 	_, err = nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 
-	// Close.
-	e, err := nsc.Close(ctx, conn)
+	// Close
+	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.NotNil(t, e)
+
 	require.Equal(t, 2, counter.UniqueRequests())
-	require.Equal(t, 2, counter.UniqueCloses())
+	require.Equal(t, 1, counter.UniqueCloses())
 }
 
 func TestNSMGR_CloseHeal(t *testing.T) {

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -338,10 +338,6 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	require.Error(t, err)
 	require.NoError(t, ctx.Err())
 
-	// Close
-	_, err = nsc.Close(ctx, conn)
-	require.Error(t, err)
-
 	// Endpoint unregister
 	_, err = s.domain.Nodes[0].EndpointRegistryClient.Unregister(ctx, nseReg)
 	require.NoError(t, err)

--- a/pkg/networkservice/common/heal/option.go
+++ b/pkg/networkservice/common/heal/option.go
@@ -22,6 +22,18 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 )
 
+// OnRestore is an action that should be performed on restore request
+type OnRestore int
+
+const (
+	// OnRestoreRestore - restore should be performed
+	OnRestoreRestore OnRestore = iota
+	// OnRestoreHeal - heal should be performed
+	OnRestoreHeal
+	// OnRestoreIgnore - restore request should be ignored
+	OnRestoreIgnore
+)
+
 // Option is an option pattern for heal server
 type Option func(healOpts *healOptions)
 
@@ -39,10 +51,12 @@ func WithOnHeal(onHeal *networkservice.NetworkServiceClient) Option {
 	}
 }
 
-// WithRestoreEnabled sets is restore enabled. Default `false`.
-func WithRestoreEnabled(restoreEnabled bool) Option {
+// WithOnRestore sets on restore action. Default `OnRestoreHeal`.
+// IMPORTANT: should be set `OnRestoreIgnore` for the Forwarder, because it results in NSMgr doesn't understanding that
+// Request is coming from Forwarder (https://github.com/networkservicemesh/sdk/issues/970).
+func WithOnRestore(onRestore OnRestore) Option {
 	return func(healOpts *healOptions) {
-		healOpts.restoreEnabled = restoreEnabled
+		healOpts.onRestore = onRestore
 	}
 }
 
@@ -55,6 +69,6 @@ func WithRestoreTimeout(restoreTimeout time.Duration) Option {
 
 type healOptions struct {
 	onHeal         *networkservice.NetworkServiceClient
-	restoreEnabled bool
+	onRestore      OnRestore
 	restoreTimeout time.Duration
 }

--- a/pkg/networkservice/common/heal/option.go
+++ b/pkg/networkservice/common/heal/option.go
@@ -16,7 +16,11 @@
 
 package heal
 
-import "github.com/networkservicemesh/api/pkg/api/networkservice"
+import (
+	"time"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+)
 
 // Option is an option pattern for heal server
 type Option func(healOpts *healOptions)
@@ -35,16 +39,22 @@ func WithOnHeal(onHeal *networkservice.NetworkServiceClient) Option {
 	}
 }
 
-// WithRestoreEnabled sets is restore enabled. Default `true`.
-// IMPORTANT: restore should be disabled for the Forwarder, because it results in NSMgr doesn't understanding that
-// Request is coming from Forwarder (https://github.com/networkservicemesh/sdk/issues/970).
+// WithRestoreEnabled sets is restore enabled. Default `false`.
 func WithRestoreEnabled(restoreEnabled bool) Option {
 	return func(healOpts *healOptions) {
 		healOpts.restoreEnabled = restoreEnabled
 	}
 }
 
+// WithRestoreTimeout sets restore timeout. Default `1m`.
+func WithRestoreTimeout(restoreTimeout time.Duration) Option {
+	return func(healOpts *healOptions) {
+		healOpts.restoreTimeout = restoreTimeout
+	}
+}
+
 type healOptions struct {
 	onHeal         *networkservice.NetworkServiceClient
 	restoreEnabled bool
+	restoreTimeout time.Duration
 }

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -58,7 +58,7 @@ func (n *Node) NewForwarder(
 		clienturl.NewServer(n.NSMgr.URL),
 		heal.NewServer(ctx,
 			heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(ep))),
-			heal.WithRestoreEnabled(false)),
+			heal.WithOnRestore(heal.OnRestoreIgnore)),
 		connect.NewServer(ctx,
 			client.NewClientFactory(
 				client.WithName(nse.Name),


### PR DESCRIPTION
## Description
Makes restore disabled in heal by default. Enables restore only in client by default.

## Issue link
#978 

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
