### PR TITLE
[sdk#978] Use less restore timeout in heal by default

### DIFF
--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -112,7 +112,9 @@ func NewClient(ctx context.Context, connectTo *url.URL, clientOpts ...Option) ne
 		adapters.NewServerToClient(
 			chain.NewNetworkServiceServer(
 				heal.NewServer(ctx,
-					heal.WithOnHeal(rv)),
+					heal.WithOnHeal(rv),
+					heal.WithRestoreEnabled(true),
+					heal.WithRestoreTimeout(time.Minute)),
 				clienturl.NewServer(connectTo),
 				connect.NewServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {
 					return chain.NewNetworkServiceClient(

--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -113,7 +113,7 @@ func NewClient(ctx context.Context, connectTo *url.URL, clientOpts ...Option) ne
 			chain.NewNetworkServiceServer(
 				heal.NewServer(ctx,
 					heal.WithOnHeal(rv),
-					heal.WithRestoreEnabled(true),
+					heal.WithOnRestore(heal.OnRestoreRestore),
 					heal.WithRestoreTimeout(time.Minute)),
 				clienturl.NewServer(connectTo),
 				connect.NewServer(ctx, func(ctx context.Context, cc grpc.ClientConnInterface) networkservice.NetworkServiceClient {

--- a/pkg/networkservice/common/heal/option.go
+++ b/pkg/networkservice/common/heal/option.go
@@ -16,7 +16,11 @@
 
 package heal
 
-import "github.com/networkservicemesh/api/pkg/api/networkservice"
+import (
+	"time"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+)
 
 // Option is an option pattern for heal server
 type Option func(healOpts *healOptions)
@@ -44,7 +48,15 @@ func WithRestoreEnabled(restoreEnabled bool) Option {
 	}
 }
 
+// WithRestoreTimeout sets restore timeout. Default `1m`.
+func WithRestoreTimeout(restoreTimeout time.Duration) Option {
+	return func(healOpts *healOptions) {
+		healOpts.restoreTimeout = restoreTimeout
+	}
+}
+
 type healOptions struct {
 	onHeal         *networkservice.NetworkServiceClient
 	restoreEnabled bool
+	restoreTimeout time.Duration
 }

--- a/pkg/networkservice/common/heal/option.go
+++ b/pkg/networkservice/common/heal/option.go
@@ -22,6 +22,18 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 )
 
+// OnRestore is an action that should be performed on restore request
+type OnRestore int
+
+const (
+	// OnRestoreRestore - restore should be performed
+	OnRestoreRestore OnRestore = iota
+	// OnRestoreHeal - heal should be performed
+	OnRestoreHeal
+	// OnRestoreIgnore - restore request should be ignored
+	OnRestoreIgnore
+)
+
 // Option is an option pattern for heal server
 type Option func(healOpts *healOptions)
 
@@ -39,12 +51,12 @@ func WithOnHeal(onHeal *networkservice.NetworkServiceClient) Option {
 	}
 }
 
-// WithRestoreEnabled sets is restore enabled. Default `true`.
-// IMPORTANT: restore should be disabled for the Forwarder, because it results in NSMgr doesn't understanding that
+// WithOnRestore sets on restore action. Default `OnRestoreRestore`.
+// IMPORTANT: should be set `OnRestoreIgnore` for the Forwarder, because it results in NSMgr doesn't understanding that
 // Request is coming from Forwarder (https://github.com/networkservicemesh/sdk/issues/970).
-func WithRestoreEnabled(restoreEnabled bool) Option {
+func WithOnRestore(onRestore OnRestore) Option {
 	return func(healOpts *healOptions) {
-		healOpts.restoreEnabled = restoreEnabled
+		healOpts.onRestore = onRestore
 	}
 }
 
@@ -57,6 +69,6 @@ func WithRestoreTimeout(restoreTimeout time.Duration) Option {
 
 type healOptions struct {
 	onHeal         *networkservice.NetworkServiceClient
-	restoreEnabled bool
+	onRestore      OnRestore
 	restoreTimeout time.Duration
 }

--- a/pkg/networkservice/common/heal/server.go
+++ b/pkg/networkservice/common/heal/server.go
@@ -26,8 +26,9 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/discover"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
@@ -48,6 +49,7 @@ type healServer struct {
 	ctx            context.Context
 	onHeal         *networkservice.NetworkServiceClient
 	restoreEnabled bool
+	restoreTimeout time.Duration
 	healContextMap ctxWrapperMap
 }
 
@@ -55,6 +57,7 @@ type healServer struct {
 func NewServer(ctx context.Context, opts ...Option) networkservice.NetworkServiceServer {
 	healOpts := &healOptions{
 		restoreEnabled: true,
+		restoreTimeout: 15 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(healOpts)
@@ -64,6 +67,7 @@ func NewServer(ctx context.Context, opts ...Option) networkservice.NetworkServic
 		ctx:            ctx,
 		onHeal:         healOpts.onHeal,
 		restoreEnabled: healOpts.restoreEnabled,
+		restoreTimeout: healOpts.restoreTimeout,
 	}
 
 	if rv.onHeal == nil {
@@ -74,10 +78,7 @@ func NewServer(ctx context.Context, opts ...Option) networkservice.NetworkServic
 }
 
 func (f *healServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	ctx = withRequestHealConnectionFunc(ctx, f.handleHealConnectionRequest)
-	if f.restoreEnabled {
-		ctx = withRequestRestoreConnectionFunc(ctx, f.handleRestoreConnectionRequest)
-	}
+	ctx = f.withHandlers(ctx)
 
 	conn, err := next.Server(ctx).Request(ctx, request)
 	if err != nil {
@@ -101,6 +102,17 @@ func (f *healServer) Request(ctx context.Context, request *networkservice.Networ
 	}
 
 	return conn, nil
+}
+
+func (f *healServer) withHandlers(ctx context.Context) context.Context {
+	ctx = withRequestHealConnectionFunc(ctx, f.handleHealConnectionRequest)
+
+	restoreConnectionHandler := f.handleHealConnectionRequest
+	if f.restoreEnabled {
+		restoreConnectionHandler = f.handleRestoreConnectionRequest
+	}
+
+	return withRequestRestoreConnectionFunc(ctx, restoreConnectionHandler)
 }
 
 func (f *healServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
@@ -180,7 +192,7 @@ func (f *healServer) restoreConnection(ctx context.Context, request *networkserv
 		return
 	}
 
-	deadline := clockTime.Now().Add(time.Minute)
+	deadline := clockTime.Now().Add(f.restoreTimeout)
 	if deadline.After(expireTime) {
 		deadline = expireTime
 	}

--- a/pkg/networkservice/common/heal/server.go
+++ b/pkg/networkservice/common/heal/server.go
@@ -48,7 +48,7 @@ type ctxWrapper struct {
 type healServer struct {
 	ctx            context.Context
 	onHeal         *networkservice.NetworkServiceClient
-	restoreEnabled bool
+	onRestore      OnRestore
 	restoreTimeout time.Duration
 	healContextMap ctxWrapperMap
 }
@@ -56,7 +56,7 @@ type healServer struct {
 // NewServer - creates a new networkservice.NetworkServiceServer chain element that implements the healing algorithm
 func NewServer(ctx context.Context, opts ...Option) networkservice.NetworkServiceServer {
 	healOpts := &healOptions{
-		restoreEnabled: true,
+		onRestore:      OnRestoreRestore,
 		restoreTimeout: 15 * time.Second,
 	}
 	for _, opt := range opts {
@@ -66,7 +66,7 @@ func NewServer(ctx context.Context, opts ...Option) networkservice.NetworkServic
 	rv := &healServer{
 		ctx:            ctx,
 		onHeal:         healOpts.onHeal,
-		restoreEnabled: healOpts.restoreEnabled,
+		onRestore:      healOpts.onRestore,
 		restoreTimeout: healOpts.restoreTimeout,
 	}
 
@@ -107,12 +107,18 @@ func (f *healServer) Request(ctx context.Context, request *networkservice.Networ
 func (f *healServer) withHandlers(ctx context.Context) context.Context {
 	ctx = withRequestHealConnectionFunc(ctx, f.handleHealConnectionRequest)
 
-	restoreConnectionHandler := f.handleHealConnectionRequest
-	if f.restoreEnabled {
+	var restoreConnectionHandler requestHealFuncType
+	switch f.onRestore {
+	case OnRestoreRestore:
 		restoreConnectionHandler = f.handleRestoreConnectionRequest
+	case OnRestoreHeal:
+		restoreConnectionHandler = f.handleHealConnectionRequest
+	case OnRestoreIgnore:
+		restoreConnectionHandler = func(*networkservice.Connection) {}
 	}
+	ctx = withRequestRestoreConnectionFunc(ctx, restoreConnectionHandler)
 
-	return withRequestRestoreConnectionFunc(ctx, restoreConnectionHandler)
+	return ctx
 }
 
 func (f *healServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -58,7 +58,7 @@ func (n *Node) NewForwarder(
 		clienturl.NewServer(n.NSMgr.URL),
 		heal.NewServer(ctx,
 			heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(ep))),
-			heal.WithRestoreEnabled(false)),
+			heal.WithOnRestore(heal.OnRestoreIgnore)),
 		connect.NewServer(ctx,
 			client.NewClientFactory(
 				client.WithName(nse.Name),


### PR DESCRIPTION
## Description
Uses `15s` default restore timeout instead of `1m` in heal server.

## Issue link
#978 

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
