### PR TITLE
[qfix] Use grpcutils.UnwrapCode in setid

### DIFF
--- a/pkg/registry/common/setid/client.go
+++ b/pkg/registry/common/setid/client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 )
 
 type setIDClient struct {
@@ -52,7 +53,7 @@ func (c *setIDClient) Register(ctx context.Context, nse *registry.NetworkService
 	}
 	nameSuffix = "-" + nameSuffix
 
-	for err = status.Error(codes.AlreadyExists, ""); err != nil && isAlreadyExistsError(err); {
+	for err = status.Error(codes.AlreadyExists, ""); grpcutils.UnwrapCode(err) == codes.AlreadyExists; {
 		name := uuid.New().String() + nameSuffix
 
 		nse.Name = name
@@ -62,11 +63,6 @@ func (c *setIDClient) Register(ctx context.Context, nse *registry.NetworkService
 	}
 
 	return reg, err
-}
-
-func isAlreadyExistsError(e error) bool {
-	grpcStatus, ok := status.FromError(e)
-	return ok && grpcStatus.Code() == codes.AlreadyExists
 }
 
 func (c *setIDClient) Find(ctx context.Context, query *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {

--- a/pkg/registry/common/setid/client_test.go
+++ b/pkg/registry/common/setid/client_test.go
@@ -92,7 +92,7 @@ func TestSetIDClient_Duplicate(t *testing.T) {
 		setid.NewNetworkServiceEndpointRegistryClient(),
 		&errorClient{
 			expected: 3,
-			err:      status.Error(codes.AlreadyExists, ""),
+			err:      errors.Wrap(status.Error(codes.AlreadyExists, ""), "Error"),
 		},
 	)
 


### PR DESCRIPTION
## Description
Use `grpcutils.UnwrapCode` instead of `status.Code` in `setid`.

## Issue link
https://github.com/networkservicemesh/integration-k8s-aks/pull/53

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
