### PR TITLE
[qfix] Add timeout for discoverNetworkServiceEndpoint

### DIFF
--- a/pkg/networkservice/common/discover/server_test.go
+++ b/pkg/networkservice/common/discover/server_test.go
@@ -474,6 +474,9 @@ func TestMatchExactService(t *testing.T) {
 func TestMatchExactEndpoint(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	nseServer := memory.NewNetworkServiceEndpointRegistryServer()
 
 	nseName := "final-endpoint"
@@ -497,9 +500,6 @@ func TestMatchExactEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. Try to discover NSE by the right name
-	ctx, cancel := context.WithTimeout(context.Background(), testWait)
-	defer cancel()
-
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
 			NetworkServiceEndpointName: nseName,
@@ -517,9 +517,6 @@ func TestMatchExactEndpoint(t *testing.T) {
 	require.NoError(t, err)
 
 	// 4. Try to discover NSE by the right name
-	ctx, cancel = context.WithTimeout(context.Background(), testWait)
-	defer cancel()
-
 	_, err = server.Request(ctx, request.Clone())
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description
Adds timeout for `discoverNetworkServiceEndpoint`.

## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/runs/2855694310

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
