### PR TITLE
[sdk#740] Rework sandbox to use tokenTimeout instead of tokenGenerator

### DIFF
--- a/pkg/networkservice/chains/nsmgr/scale_test.go
+++ b/pkg/networkservice/chains/nsmgr/scale_test.go
@@ -45,7 +45,7 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
-	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg := &registry.NetworkService{
 		Name: "ns-1",
@@ -95,9 +95,9 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 		},
 	}
 
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, makerServer)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, makerServer)
 
-	nsc := domain.Nodes[1].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[1].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	// check first request
 	conn, err := nsc.Request(ctx, &networkservice.NetworkServiceRequest{
@@ -139,7 +139,7 @@ func (m *nseMaker) Request(_ context.Context, _ *networkservice.NetworkServiceRe
 		return nil, errors.New("can't create new endpoint")
 	}
 
-	m.domain.Nodes[1].NewEndpoint(m.ctx, m.nseReg, sandbox.GenerateTestToken, endpoint)
+	m.domain.Nodes[1].NewEndpoint(m.ctx, m.nseReg, sandbox.DefaultTokenTimeout, endpoint)
 
 	return nil, errors.New("can't provide requested network service")
 }

--- a/pkg/networkservice/chains/nsmgr/single_test.go
+++ b/pkg/networkservice/chains/nsmgr/single_test.go
@@ -49,14 +49,14 @@ func Test_DNSUsecase(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
-	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 
-	nse := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, dnscontext.NewServer(
+	nse := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, dnscontext.NewServer(
 		&networkservice.DNSConfig{
 			DnsServerIps:  []string{"8.8.8.8"},
 			SearchDomains: []string{"my.domain1"},
@@ -75,7 +75,7 @@ func Test_DNSUsecase(t *testing.T) {
 
 	const expectedCorefile = ". {\n\tforward . 8.8.4.4\n\tlog\n\treload\n}\nmy.domain1 {\n\tfanout . 8.8.4.4 8.8.8.8\n\tlog\n}"
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken, dnscontext.NewClient(
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout, dnscontext.NewClient(
 		dnscontext.WithChainContext(ctx),
 		dnscontext.WithCorefilePath(corefilePath),
 		dnscontext.WithResolveConfigPath(resolveConfigPath),
@@ -110,12 +110,12 @@ func Test_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 		SetNodesCount(1).
 		SetRegistryProxySupplier(nil).
 		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, _ int) {
-			node.NewNSMgr(ctx, "nsmgr", nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+			node.NewNSMgr(ctx, "nsmgr", nil, sandbox.DefaultTokenTimeout, nsmgr.NewServer)
 		}).
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
 		Build()
 
-	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func Test_ShouldCorrectlyAddForwardersWithSameNames(t *testing.T) {
 	var forwarders [3]*sandbox.EndpointEntry
 	for i := range forwarderRegs {
 		forwarderRegs[i] = forwarderReg.Clone()
-		forwarders[i] = domain.Nodes[0].NewForwarder(ctx, forwarderRegs[i], sandbox.GenerateTestToken)
+		forwarders[i] = domain.Nodes[0].NewForwarder(ctx, forwarderRegs[i], sandbox.DefaultTokenTimeout)
 	}
 
 	// 2. Wait for refresh
@@ -158,7 +158,7 @@ func Test_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 		SetRegistryExpiryDuration(sandbox.RegistryExpiryDuration).
 		Build()
 
-	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	// 1. Add endpoints
 	var nseRegs [2]*registry.NetworkServiceEndpoint
@@ -170,14 +170,14 @@ func Test_ShouldCorrectlyAddEndpointsWithSameNames(t *testing.T) {
 		nseRegs[i] = defaultRegistryEndpoint(nsReg.Name)
 		nseRegs[i].NetworkServiceNames[0] = nsReg.Name
 
-		nses[i] = domain.Nodes[0].NewEndpoint(ctx, nseRegs[i], sandbox.GenerateTestToken)
+		nses[i] = domain.Nodes[0].NewEndpoint(ctx, nseRegs[i], sandbox.DefaultTokenTimeout)
 	}
 
 	// 2. Wait for refresh
 	<-time.After(sandbox.RegistryExpiryDuration)
 
 	// 3. Request
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	for _, nseReg := range nseRegs {
 		_, err := nsc.Request(ctx, defaultRequest(nseReg.NetworkServiceNames[0]))
@@ -209,7 +209,7 @@ func Test_Local_NoURLUsecase(t *testing.T) {
 		SetRegistrySupplier(nil).
 		Build()
 
-	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
@@ -218,9 +218,9 @@ func Test_Local_NoURLUsecase(t *testing.T) {
 	request := defaultRequest(nsReg.Name)
 	counter := &counterServer{}
 
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, counter)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
@@ -269,7 +269,7 @@ func Test_ShouldParseNetworkServiceLabelsTemplate(t *testing.T) {
 		SetNSMgrProxySupplier(nil).
 		Build()
 
-	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg := defaultRegistryService()
 	nsReg.Matches = []*registry.Match{
@@ -290,9 +290,9 @@ func Test_ShouldParseNetworkServiceLabelsTemplate(t *testing.T) {
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 	nseReg.NetworkServiceLabels = map[string]*registry.NetworkServiceLabels{nsReg.Name: {}}
 
-	nse := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
+	nse := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 	require.NoError(t, err)
 
 	req := defaultRequest(nsReg.Name)

--- a/pkg/networkservice/chains/nsmgr/utils_test.go
+++ b/pkg/networkservice/chains/nsmgr/utils_test.go
@@ -69,9 +69,9 @@ func testNSEAndClient(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	nse := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
+	nse := domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout)
 
-	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := defaultRequest(nseReg.NetworkServiceNames[0])
 

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -64,7 +64,7 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		SetDNSResolver(dnsServer).
 		Build()
 
-	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg := &registry.NetworkService{
 		Name: "my-service-interdomain",
@@ -78,9 +78,9 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		NetworkServiceNames: []string{nsReg.Name},
 	}
 
-	cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout)
 
-	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -138,7 +138,7 @@ func TestNSMGR_Interdomain_TwoNodesNSEs(t *testing.T) {
 		SetDNSResolver(dnsServer).
 		Build()
 
-	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	_, err := nsRegistryClient.Register(ctx, &registry.NetworkService{
 		Name: "my-service-interdomain-1",
@@ -154,15 +154,15 @@ func TestNSMGR_Interdomain_TwoNodesNSEs(t *testing.T) {
 		Name:                "final-endpoint-1",
 		NetworkServiceNames: []string{"my-service-interdomain-1"},
 	}
-	cluster2.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.GenerateTestToken)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.DefaultTokenTimeout)
 
 	nseReg2 := &registry.NetworkServiceEndpoint{
 		Name:                "final-endpoint-2",
 		NetworkServiceNames: []string{"my-service-interdomain-2"},
 	}
-	cluster2.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.DefaultTokenTimeout)
 
-	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -250,7 +250,7 @@ func TestNSMGR_FloatingInterdomainUseCase(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
-	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg := &registry.NetworkService{
 		Name: "my-service-interdomain@" + floating.Name,
@@ -264,9 +264,9 @@ func TestNSMGR_FloatingInterdomainUseCase(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain"},
 	}
 
-	cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout)
 
-	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -343,7 +343,7 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 
 	// register first ednpoint
 
-	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := cluster2.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg1 := &registry.NetworkService{
 		Name: "my-service-interdomain-1@" + floating.Name,
@@ -357,7 +357,7 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain-1"},
 	}
 
-	cluster2.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.GenerateTestToken)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.DefaultTokenTimeout)
 
 	nsReg2 := &registry.NetworkService{
 		Name: "my-service-interdomain-1@" + floating.Name,
@@ -365,7 +365,7 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 
 	// register second ednpoint
 
-	nsRegistryClient = cluster3.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient = cluster3.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	_, err = nsRegistryClient.Register(ctx, nsReg2)
 	require.NoError(t, err)
@@ -375,11 +375,11 @@ func TestNSMGR_FloatingInterdomain_FourClusters(t *testing.T) {
 		NetworkServiceNames: []string{"my-service-interdomain-2"},
 	}
 
-	cluster3.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken)
+	cluster3.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.DefaultTokenTimeout)
 
 	// connect to first endpoint from cluster2
 
-	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{
@@ -495,13 +495,13 @@ func Test_Interdomain_PassThroughUsecase(t *testing.T) {
 							kernelmech.NewClient(),
 						)),
 						connect.WithDialTimeout(sandbox.DialTimeout),
-						connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
+						connect.WithDialOptions(clusters[i].DefaultDialOptions(sandbox.DefaultTokenTimeout)...),
 					),
 				),
 			}
 		}
 
-		nsRegistryClient := clusters[i].NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+		nsRegistryClient := clusters[i].NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 		nsReg, err := nsRegistryClient.Register(ctx, &registry.NetworkService{
 			Name: fmt.Sprintf("my-service-remote-%v", i),
@@ -512,10 +512,10 @@ func Test_Interdomain_PassThroughUsecase(t *testing.T) {
 			Name:                fmt.Sprintf("endpoint-%v", i),
 			NetworkServiceNames: []string{nsReg.Name},
 		}
-		clusters[i].Nodes[0].NewEndpoint(ctx, nsesReg, sandbox.GenerateTestToken, additionalFunctionality...)
+		clusters[i].Nodes[0].NewEndpoint(ctx, nsesReg, sandbox.DefaultTokenTimeout, additionalFunctionality...)
 	}
 
-	nsc := clusters[clusterCount-1].Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
+	nsc := clusters[clusterCount-1].Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
 
 	request := &networkservice.NetworkServiceRequest{
 		MechanismPreferences: []*networkservice.Mechanism{

--- a/pkg/networkservice/common/connect/server_cancel_test.go
+++ b/pkg/networkservice/common/connect/server_cancel_test.go
@@ -56,7 +56,7 @@ func TestConnect_CancelDuringRequest(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		Build()
 
-	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	service1Name := "my-service-endpoint"
 	_, err = nsRegistryClient.Register(ctx, &registry.NetworkService{
@@ -76,7 +76,7 @@ func TestConnect_CancelDuringRequest(t *testing.T) {
 	}
 	nscCtx, nscCancel := context.WithCancel(ctx)
 	var flag atomic.Bool
-	domain.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.GenerateTestToken, checkrequest.NewServer(t, func(*testing.T, *networkservice.NetworkServiceRequest) {
+	domain.Nodes[0].NewEndpoint(ctx, nseReg1, sandbox.DefaultTokenTimeout, checkrequest.NewServer(t, func(*testing.T, *networkservice.NetworkServiceRequest) {
 		if flag.Load() {
 			nscCancel()
 		}
@@ -100,13 +100,13 @@ func TestConnect_CancelDuringRequest(t *testing.T) {
 		Name:                "endpoint-2",
 		NetworkServiceNames: []string{service2Name},
 	}
-	domain.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken,
+	domain.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.DefaultTokenTimeout,
 		chain.NewNetworkServiceServer(
 			clienturl.NewServer(domain.Nodes[0].URL()),
 			connect.NewServer(ctx,
 				clientFactory,
 				connect.WithDialTimeout(sandbox.DialTimeout),
-				connect.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...),
+				connect.WithDialOptions(domain.DefaultDialOptions(sandbox.DefaultTokenTimeout)...),
 			),
 		),
 	)
@@ -121,8 +121,8 @@ func TestConnect_CancelDuringRequest(t *testing.T) {
 			Context:        &networkservice.ConnectionContext{},
 		},
 	}
-	nsc1 := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
-	nsc2 := domain.Nodes[0].NewClient(nscCtx, sandbox.GenerateTestToken)
+	nsc1 := domain.Nodes[0].NewClient(ctx, sandbox.DefaultTokenTimeout)
+	nsc2 := domain.Nodes[0].NewClient(nscCtx, sandbox.DefaultTokenTimeout)
 
 	_, err = nsc1.Request(ctx, request.Clone())
 	require.NoError(t, err)

--- a/pkg/networkservice/common/refresh/client_test.go
+++ b/pkg/networkservice/common/refresh/client_test.go
@@ -234,10 +234,9 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	domain := sandbox.NewBuilder(ctx, t).
 		SetNodesCount(2).
 		SetRegistryProxySupplier(nil).
-		SetTokenGenerateFunc(sandbox.GenerateTestToken).
 		Build()
 
-	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
 	nsReg := &registry.NetworkService{
 		Name: "my-service-remote",
@@ -252,10 +251,9 @@ func TestRefreshClient_Sandbox(t *testing.T) {
 	}
 
 	refreshSrv := newRefreshTesterServer(t, sandboxMinDuration, sandboxExpireTimeout)
-	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, refreshSrv)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.DefaultTokenTimeout, refreshSrv)
 
-	nscTokenGenerator := sandbox.GenerateExpiringToken(sandboxExpireTimeout)
-	nsc := domain.Nodes[1].NewClient(ctx, nscTokenGenerator)
+	nsc := domain.Nodes[1].NewClient(ctx, sandboxExpireTimeout)
 
 	refreshSrv.beforeRequest("test-conn")
 	_, err = nsc.Request(ctx, mkRequest("test-conn", nil))

--- a/pkg/registry/chains/memory/server_test.go
+++ b/pkg/registry/chains/memory/server_test.go
@@ -19,20 +19,17 @@ package memory_test
 
 import (
 	"context"
+	"testing"
+	"time"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice/payload"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/goleak"
-	"google.golang.org/grpc"
-
-	"testing"
-	"time"
 )
 
 func Test_RegistryMemory_ShouldSetDefaultPayload(t *testing.T) {
@@ -47,23 +44,17 @@ func Test_RegistryMemory_ShouldSetDefaultPayload(t *testing.T) {
 		SetNSMgrProxySupplier(nil).
 		Build()
 
-	// start grpc client connection and register it
-	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(domain.Registry.URL), sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...)
-	require.NoError(t, err)
-	defer func() {
-		_ = cc.Close()
-	}()
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.DefaultTokenTimeout)
 
-	nsrc := registry.NewNetworkServiceRegistryClient(cc)
-	ns, err := nsrc.Register(ctx, &registry.NetworkService{
+	ns, err := nsRegistryClient.Register(ctx, &registry.NetworkService{
 		Name: "ns-1",
 	})
 	require.NoError(t, err)
 
-	nsrfc, err := nsrc.Find(ctx, &registry.NetworkServiceQuery{NetworkService: ns})
+	stream, err := nsRegistryClient.Find(ctx, &registry.NetworkServiceQuery{NetworkService: ns})
 	require.NoError(t, err)
 
-	ns, err = nsrfc.Recv()
+	ns, err = stream.Recv()
 	require.NoError(t, err)
 
 	require.Equal(t, payload.IP, ns.Payload)

--- a/pkg/registry/common/heal/find_test.go
+++ b/pkg/registry/common/heal/find_test.go
@@ -45,10 +45,10 @@ func TestHealClient_FindTest(t *testing.T) {
 		SetRegistryProxySupplier(nil).
 		SetNSMgrProxySupplier(nil).
 		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, nodeNum int) {
-			node.NewNSMgr(nsmgrCtx, sandbox.UniqueName("nsmgr"), nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+			node.NewNSMgr(nsmgrCtx, sandbox.UniqueName("nsmgr"), nil, sandbox.DefaultTokenTimeout, nsmgr.NewServer)
 			node.NewForwarder(ctx, &registry.NetworkServiceEndpoint{
 				Name: sandbox.UniqueName("forwarder"),
-			}, sandbox.GenerateTestToken)
+			}, sandbox.DefaultTokenTimeout)
 		}).
 		Build()
 
@@ -56,7 +56,7 @@ func TestHealClient_FindTest(t *testing.T) {
 	findCtx, findCancel := context.WithCancel(ctx)
 
 	nsRegistryClient := registryclient.NewNetworkServiceRegistryClient(ctx, domain.Nodes[0].URL(),
-		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
+		registryclient.WithDialOptions(domain.DefaultDialOptions(sandbox.DefaultTokenTimeout)...))
 
 	nsStream, err := nsRegistryClient.Find(findCtx, &registry.NetworkServiceQuery{
 		NetworkService: new(registry.NetworkService),
@@ -65,7 +65,7 @@ func TestHealClient_FindTest(t *testing.T) {
 	require.NoError(t, err)
 
 	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, domain.Nodes[0].URL(),
-		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
+		registryclient.WithDialOptions(domain.DefaultDialOptions(sandbox.DefaultTokenTimeout)...))
 
 	nseStream, err := nseRegistryClient.Find(findCtx, &registry.NetworkServiceEndpointQuery{
 		NetworkServiceEndpoint: new(registry.NetworkServiceEndpoint),
@@ -81,7 +81,7 @@ func TestHealClient_FindTest(t *testing.T) {
 		return grpcutils.CheckURLFree(mgr.URL)
 	}, time.Second, 100*time.Millisecond)
 
-	mgr = domain.Nodes[0].NewNSMgr(ctx, mgr.Name, mgr.URL, sandbox.GenerateTestToken, nsmgr.NewServer)
+	mgr = domain.Nodes[0].NewNSMgr(ctx, mgr.Name, mgr.URL, sandbox.DefaultTokenTimeout, nsmgr.NewServer)
 
 	// 3. Register new NS, NSE
 	_, err = mgr.NetworkServiceRegistryServer().Register(ctx, &registry.NetworkService{

--- a/pkg/tools/sandbox/domain.go
+++ b/pkg/tools/sandbox/domain.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
+	"google.golang.org/grpc"
+
+	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/dnsresolve"
+)
+
+// Domain contains attached to domain nodes, registry
+type Domain struct {
+	t *testing.T
+
+	Nodes         []*Node
+	NSMgrProxy    *NSMgrEntry
+	Registry      *RegistryEntry
+	RegistryProxy *RegistryEntry
+
+	DNSResolver dnsresolve.Resolver
+	Name        string
+
+	supplyURL            func(prefix string) *url.URL
+	supplyTokenGenerator SupplyTokenGeneratorFunc
+}
+
+// NewNSRegistryClient creates new NS registry client for the domain
+func (d *Domain) NewNSRegistryClient(ctx context.Context, tokenTimeout time.Duration) registryapi.NetworkServiceRegistryClient {
+	var registryURL *url.URL
+	switch {
+	case d.Registry != nil:
+		registryURL = d.Registry.URL
+	case len(d.Nodes) != 0:
+		registryURL = d.Nodes[0].URL()
+	default:
+		return nil
+	}
+
+	return registryclient.NewNetworkServiceRegistryClient(ctx, registryURL,
+		registryclient.WithDialOptions(d.DefaultDialOptions(tokenTimeout)...))
+}
+
+// DefaultDialOptions returns default dial options for the domain
+func (d *Domain) DefaultDialOptions(tokenTimeout time.Duration) []grpc.DialOption {
+	return DefaultDialOptions(d.supplyTokenGenerator(tokenTimeout))
+}

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -28,25 +28,27 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgrproxy"
 	"github.com/networkservicemesh/sdk/pkg/registry"
-	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/dnsresolve"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
-// SupplyNSMgrProxyFunc nsmgr proxy
+// SupplyNSMgrProxyFunc supplies NSMgr proxy
 type SupplyNSMgrProxyFunc func(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator token.GeneratorFunc, options ...nsmgrproxy.Option) nsmgr.Nsmgr
 
-// SupplyNSMgrFunc supplies NSMGR
+// SupplyNSMgrFunc supplies NSMgr
 type SupplyNSMgrFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgr.Option) nsmgr.Nsmgr
 
 // SupplyRegistryFunc supplies Registry
 type SupplyRegistryFunc func(ctx context.Context, expiryDuration time.Duration, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry
 
-// SupplyRegistryProxyFunc supplies registry proxy
+// SupplyRegistryProxyFunc supplies Registry proxy
 type SupplyRegistryProxyFunc func(ctx context.Context, dnsResolver dnsresolve.Resolver, options ...grpc.DialOption) registry.Registry
 
 // SetupNodeFunc setups each node on Builder.Build() stage
 type SetupNodeFunc func(ctx context.Context, node *Node, nodeNum int)
+
+// SupplyTokenGeneratorFunc supplies token generator
+type SupplyTokenGeneratorFunc func(tokenTimeout time.Duration) token.GeneratorFunc
 
 // RegistryEntry is pair of registry.Registry and url.URL
 type RegistryEntry struct {
@@ -70,33 +72,4 @@ type EndpointEntry struct {
 
 	endpoint.Endpoint
 	registryapi.NetworkServiceEndpointRegistryClient
-}
-
-// Domain contains attached to domain nodes, registry
-type Domain struct {
-	Nodes         []*Node
-	NSMgrProxy    *NSMgrEntry
-	Registry      *RegistryEntry
-	RegistryProxy *RegistryEntry
-
-	DNSResolver dnsresolve.Resolver
-	Name        string
-
-	supplyURL func(prefix string) *url.URL
-}
-
-// NewNSRegistryClient creates new NS registry client for the domain
-func (d *Domain) NewNSRegistryClient(ctx context.Context, generatorFunc token.GeneratorFunc) registryapi.NetworkServiceRegistryClient {
-	var registryURL *url.URL
-	switch {
-	case d.Registry != nil:
-		registryURL = d.Registry.URL
-	case len(d.Nodes) != 0:
-		registryURL = d.Nodes[0].URL()
-	default:
-		return nil
-	}
-
-	return registryclient.NewNetworkServiceRegistryClient(ctx, registryURL,
-		registryclient.WithDialOptions(DefaultDialOptions(generatorFunc)...))
 }

--- a/pkg/tools/sandbox/utils.go
+++ b/pkg/tools/sandbox/utils.go
@@ -23,11 +23,10 @@ import (
 
 	"github.com/edwarnicke/grpcfd"
 	"github.com/google/uuid"
+	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-
-	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/opentracing"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
@@ -38,6 +37,8 @@ const (
 	RegistryExpiryDuration = time.Second
 	// DialTimeout is a default dial timeout for the sandbox tests
 	DialTimeout = 500 * time.Millisecond
+	// DefaultTokenTimeout is a default token timeout for sandbox testing
+	DefaultTokenTimeout = time.Hour
 )
 
 type insecurePerRPCCredentials struct {
@@ -109,10 +110,10 @@ func UniqueName(prefix string) string {
 }
 
 // SetupDefaultNode setups NSMgr and default Forwarder on the given node
-func SetupDefaultNode(ctx context.Context, node *Node, supplyNSMgr SupplyNSMgrFunc) {
-	node.NewNSMgr(ctx, UniqueName("nsmgr"), nil, GenerateTestToken, supplyNSMgr)
+func SetupDefaultNode(ctx context.Context, node *Node, tokenTimeout time.Duration, supplyNSMgr SupplyNSMgrFunc) {
+	node.NewNSMgr(ctx, UniqueName("nsmgr"), nil, tokenTimeout, supplyNSMgr)
 
 	node.NewForwarder(ctx, &registryapi.NetworkServiceEndpoint{
 		Name: UniqueName("forwarder"),
-	}, GenerateTestToken)
+	}, tokenTimeout)
 }


### PR DESCRIPTION
## Description
1. Reworks sandbox to set `tokenGeneratorSupplier` for domain:
```go
// SupplyTokenGeneratorFunc supplies token generator
type SupplyTokenGeneratorFunc func(tokenTimeout time.Duration) token.GeneratorFunc
```
2.  Starts using `tokenTimeout` instead of `tokenGenerator` in all `New*` methods:
```patch
// NewNSMgr creates a new NSMgr
func (n *Node) NewNSMgr(
	ctx context.Context,
	name string,
	serveURL *url.URL,
-	tokenGenerator token.GeneratorFunc,
+	tokenTimeout time.Duration,
	supplyNSMgr SupplyNSMgrFunc,
) *NSMgrEntry {
```
3. Adds `DefaultDialOptions` for domain:
```go
// DefaultDialOptions returns default dial options for the domain
func (d *Domain) DefaultDialOptions(tokenTimeout time.Duration) []grpc.DialOption {
	return DefaultDialOptions(d.supplyTokenGenerator(tokenTimeout))
}
```

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [x] Refactoring
- [ ] CI
