### PR TITLE
[sdk#993] Fix TestMock_AfterFunc

### DIFF
--- a/pkg/tools/clockmock/mock_test.go
+++ b/pkg/tools/clockmock/mock_test.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	timeout  = 2 * time.Hour
-	testWait = 100 * time.Millisecond
+	testWait = 200 * time.Millisecond
 	testTick = testWait / 100
 )
 


### PR DESCRIPTION
## Description
Increase timeout for clockmock tests.

## Issue link
#993

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] ~Bug fix~ Test fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI