### PR TITLE
[sdk#999] Make sandbox entries restartable

### DIFF
--- a/pkg/networkservice/chains/client/client_heal_test.go
+++ b/pkg/networkservice/chains/client/client_heal_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -52,7 +51,7 @@ func TestClientHeal(t *testing.T) {
 
 	serverCancel()
 	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(serverURL)
+		return sandbox.CheckURLFree(serverURL)
 	}, time.Second, time.Millisecond*10)
 	require.NoError(t, ctx.Err())
 

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injecterror"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -162,7 +161,7 @@ func (s *nsmgrSuite) Test_SelectsRestartingEndpointUsecase() {
 	})
 	require.NoError(t, err)
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, grpcutils.CloneURL(s.domain.Nodes[0].NSMgr.URL),
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, sandbox.CloneURL(s.domain.Nodes[0].NSMgr.URL),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nseReg, err = nseRegistryClient.Register(ctx, nseReg)

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -311,7 +311,6 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	t := s.T()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	nseCtx, killNse := context.WithCancel(ctx)
 	defer cancel()
 
 	nsReg, err := s.nsRegistryClient.Register(ctx, defaultRegistryService())
@@ -320,7 +319,7 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 	counter := &counterServer{}
 
-	s.domain.Nodes[0].NewEndpoint(nseCtx, nseReg, sandbox.GenerateTestToken, counter)
+	nse := s.domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	nsc := s.domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 
@@ -335,7 +334,7 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
 	require.Equal(t, 5, len(conn.Path.PathSegments))
 
-	killNse()
+	nse.Cancel()
 
 	// Simulate refresh from client
 	refreshRequest := request.Clone()

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injecterror"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -161,7 +162,7 @@ func (s *nsmgrSuite) Test_SelectsRestartingEndpointUsecase() {
 	})
 	require.NoError(t, err)
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, s.domain.Nodes[0].URL(),
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, grpcutils.CloneURL(s.domain.Nodes[0].NSMgr.URL),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nseReg, err = nseRegistryClient.Register(ctx, nseReg)
@@ -812,7 +813,7 @@ func newPassThroughEndpoint(
 
 	var additionalFunctionality []networkservice.NetworkServiceServer
 	if hasClientFunctionality {
-		additionalFunctionality = additionalFunctionalityChain(ctx, node.URL(), name, labels)
+		additionalFunctionality = additionalFunctionalityChain(ctx, node.NSMgr.URL, name, labels)
 	}
 
 	if counter != nil {

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -488,7 +488,7 @@ func Test_Interdomain_PassThroughUsecase(t *testing.T) {
 			// Passtrough to the node i-1
 			additionalFunctionality = []networkservice.NetworkServiceServer{
 				chain.NewNetworkServiceServer(
-					clienturl.NewServer(clusters[i].Nodes[0].URL()),
+					clienturl.NewServer(clusters[i].Nodes[0].NSMgr.URL),
 					connect.NewServer(ctx,
 						client.NewClientFactory(client.WithAdditionalFunctionality(
 							newPassTroughClient(fmt.Sprintf("my-service-remote-%v@cluster%v", i-1, i-1)),

--- a/pkg/networkservice/common/connect/server_cancel_test.go
+++ b/pkg/networkservice/common/connect/server_cancel_test.go
@@ -102,7 +102,7 @@ func TestConnect_CancelDuringRequest(t *testing.T) {
 	}
 	domain.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken,
 		chain.NewNetworkServiceServer(
-			clienturl.NewServer(domain.Nodes[0].URL()),
+			clienturl.NewServer(domain.Nodes[0].NSMgr.URL),
 			connect.NewServer(ctx,
 				clientFactory,
 				connect.WithDialTimeout(sandbox.DialTimeout),

--- a/pkg/registry/common/connect/ns_client_test.go
+++ b/pkg/registry/common/connect/ns_client_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
 func TestConnectNSClient(t *testing.T) {
@@ -111,7 +111,7 @@ func TestConnectNSClient_Restart(t *testing.T) {
 	// 2. Restart remote
 	serverCancel()
 	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(u)
+		return sandbox.CheckURLFree(u)
 	}, time.Second, 10*time.Millisecond)
 
 	require.NoError(t, startNSServer(ctx, u, mem))

--- a/pkg/registry/common/connect/nse_client_test.go
+++ b/pkg/registry/common/connect/nse_client_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
 func TestConnectNSEClient(t *testing.T) {
@@ -111,7 +111,7 @@ func TestConnectNSEClient_Restart(t *testing.T) {
 	// 2. Restart remote
 	serverCancel()
 	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(u)
+		return sandbox.CheckURLFree(u)
 	}, time.Second, 10*time.Millisecond)
 
 	require.NoError(t, startNSEServer(ctx, u, mem))

--- a/pkg/registry/common/heal/find_test.go
+++ b/pkg/registry/common/heal/find_test.go
@@ -55,7 +55,7 @@ func TestHealClient_FindTest(t *testing.T) {
 	// 1. Create NS, NSE find clients
 	findCtx, findCancel := context.WithCancel(ctx)
 
-	nsRegistryClient := registryclient.NewNetworkServiceRegistryClient(ctx, domain.Nodes[0].URL(),
+	nsRegistryClient := registryclient.NewNetworkServiceRegistryClient(ctx, grpcutils.CloneURL(domain.Nodes[0].NSMgr.URL),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nsStream, err := nsRegistryClient.Find(findCtx, &registry.NetworkServiceQuery{
@@ -64,7 +64,7 @@ func TestHealClient_FindTest(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, domain.Nodes[0].URL(),
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, grpcutils.CloneURL(domain.Nodes[0].NSMgr.URL),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nseStream, err := nseRegistryClient.Find(findCtx, &registry.NetworkServiceEndpointQuery{

--- a/pkg/registry/common/heal/find_test.go
+++ b/pkg/registry/common/heal/find_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -55,7 +54,7 @@ func TestHealClient_FindTest(t *testing.T) {
 	// 1. Create NS, NSE find clients
 	findCtx, findCancel := context.WithCancel(ctx)
 
-	nsRegistryClient := registryclient.NewNetworkServiceRegistryClient(ctx, grpcutils.CloneURL(domain.Nodes[0].NSMgr.URL),
+	nsRegistryClient := registryclient.NewNetworkServiceRegistryClient(ctx, sandbox.CloneURL(domain.Nodes[0].NSMgr.URL),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nsStream, err := nsRegistryClient.Find(findCtx, &registry.NetworkServiceQuery{
@@ -64,7 +63,7 @@ func TestHealClient_FindTest(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, grpcutils.CloneURL(domain.Nodes[0].NSMgr.URL),
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(ctx, sandbox.CloneURL(domain.Nodes[0].NSMgr.URL),
 		registryclient.WithDialOptions(sandbox.DefaultDialOptions(sandbox.GenerateTestToken)...))
 
 	nseStream, err := nseRegistryClient.Find(findCtx, &registry.NetworkServiceEndpointQuery{
@@ -78,7 +77,7 @@ func TestHealClient_FindTest(t *testing.T) {
 
 	nsmgrCancel()
 	require.Eventually(t, func() bool {
-		return grpcutils.CheckURLFree(mgr.URL)
+		return sandbox.CheckURLFree(mgr.URL)
 	}, time.Second, 100*time.Millisecond)
 
 	mgr = domain.Nodes[0].NewNSMgr(ctx, mgr.Name, mgr.URL, sandbox.GenerateTestToken, nsmgr.NewServer)

--- a/pkg/tools/grpcutils/url.go
+++ b/pkg/tools/grpcutils/url.go
@@ -93,24 +93,3 @@ func TargetToNetAddr(target string) (network, addr string) {
 
 	return network, target
 }
-
-// CheckURLFree returns is given url is free for Listen
-func CheckURLFree(u *url.URL) bool {
-	ln, err := net.Listen(TargetToNetAddr(URLToTarget(u)))
-	if err == nil {
-		err = ln.Close()
-	}
-	return err == nil
-}
-
-// CloneURL clones given url
-func CloneURL(u *url.URL) *url.URL {
-	if u == nil {
-		return nil
-	}
-
-	cloned := new(url.URL)
-	*cloned = *u
-
-	return cloned
-}

--- a/pkg/tools/grpcutils/url.go
+++ b/pkg/tools/grpcutils/url.go
@@ -102,3 +102,15 @@ func CheckURLFree(u *url.URL) bool {
 	}
 	return err == nil
 }
+
+// CloneURL clones given url
+func CloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+
+	cloned := new(url.URL)
+	*cloned = *u
+
+	return cloned
+}

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -256,7 +256,7 @@ func (b *Builder) newRegistry() *RegistryEntry {
 
 	var nsmgrProxyURL *url.URL
 	if b.domain.NSMgrProxy != nil {
-		nsmgrProxyURL = b.domain.NSMgrProxy.URL
+		nsmgrProxyURL = grpcutils.CloneURL(b.domain.NSMgrProxy.URL)
 	}
 
 	entry := &RegistryEntry{
@@ -288,8 +288,8 @@ func (b *Builder) newNSMgrProxy() *NSMgrEntry {
 	}
 	entry.restartableServer = newRestartableServer(b.ctx, b.t, entry.URL, func(ctx context.Context) {
 		entry.Nsmgr = b.supplyNSMgrProxy(ctx,
-			b.domain.Registry.URL,
-			b.domain.RegistryProxy.URL,
+			grpcutils.CloneURL(b.domain.Registry.URL),
+			grpcutils.CloneURL(b.domain.RegistryProxy.URL),
 			b.generateTokenFunc,
 			nsmgrproxy.WithListenOn(entry.URL),
 			nsmgrproxy.WithName(entry.Name),
@@ -329,9 +329,9 @@ func (b *Builder) buildDNSServer() {
 	}
 
 	if b.domain.Registry != nil {
-		resolver.AddSRVEntry(b.name, dnsresolve.DefaultRegistryService, b.domain.Registry.URL)
+		resolver.AddSRVEntry(b.name, dnsresolve.DefaultRegistryService, grpcutils.CloneURL(b.domain.Registry.URL))
 	}
 	if b.domain.NSMgrProxy != nil {
-		resolver.AddSRVEntry(b.name, dnsresolve.DefaultNsmgrProxyService, b.domain.NSMgrProxy.URL)
+		resolver.AddSRVEntry(b.name, dnsresolve.DefaultNsmgrProxyService, grpcutils.CloneURL(b.domain.NSMgrProxy.URL))
 	}
 }

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -256,7 +256,7 @@ func (b *Builder) newRegistry() *RegistryEntry {
 
 	var nsmgrProxyURL *url.URL
 	if b.domain.NSMgrProxy != nil {
-		nsmgrProxyURL = grpcutils.CloneURL(b.domain.NSMgrProxy.URL)
+		nsmgrProxyURL = CloneURL(b.domain.NSMgrProxy.URL)
 	}
 
 	entry := &RegistryEntry{
@@ -288,8 +288,8 @@ func (b *Builder) newNSMgrProxy() *NSMgrEntry {
 	}
 	entry.restartableServer = newRestartableServer(b.ctx, b.t, entry.URL, func(ctx context.Context) {
 		entry.Nsmgr = b.supplyNSMgrProxy(ctx,
-			grpcutils.CloneURL(b.domain.Registry.URL),
-			grpcutils.CloneURL(b.domain.RegistryProxy.URL),
+			CloneURL(b.domain.Registry.URL),
+			CloneURL(b.domain.RegistryProxy.URL),
 			b.generateTokenFunc,
 			nsmgrproxy.WithListenOn(entry.URL),
 			nsmgrproxy.WithName(entry.Name),
@@ -329,9 +329,9 @@ func (b *Builder) buildDNSServer() {
 	}
 
 	if b.domain.Registry != nil {
-		resolver.AddSRVEntry(b.name, dnsresolve.DefaultRegistryService, grpcutils.CloneURL(b.domain.Registry.URL))
+		resolver.AddSRVEntry(b.name, dnsresolve.DefaultRegistryService, CloneURL(b.domain.Registry.URL))
 	}
 	if b.domain.NSMgrProxy != nil {
-		resolver.AddSRVEntry(b.name, dnsresolve.DefaultNsmgrProxyService, grpcutils.CloneURL(b.domain.NSMgrProxy.URL))
+		resolver.AddSRVEntry(b.name, dnsresolve.DefaultNsmgrProxyService, CloneURL(b.domain.NSMgrProxy.URL))
 	}
 }

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -310,8 +310,9 @@ func (b *Builder) newNSMgrProxy() *NSMgrEntry {
 
 func (b *Builder) newNode(nodeNum int) *Node {
 	node := &Node{
-		t:      b.t,
-		domain: b.domain,
+		t:          b.t,
+		domain:     b.domain,
+		Forwarders: make(map[string]*EndpointEntry),
 	}
 
 	b.setupNode(b.ctx, node, nodeNum)

--- a/pkg/tools/sandbox/grpc_utils.go
+++ b/pkg/tools/sandbox/grpc_utils.go
@@ -18,6 +18,7 @@ package sandbox
 
 import (
 	"context"
+	"net"
 	"net/url"
 	"testing"
 
@@ -47,4 +48,25 @@ func serve(ctx context.Context, t *testing.T, u *url.URL, register func(server *
 			require.NoError(t, err)
 		}
 	}()
+}
+
+// CheckURLFree returns is given url is free for Listen
+func CheckURLFree(u *url.URL) bool {
+	ln, err := net.Listen(grpcutils.TargetToNetAddr(grpcutils.URLToTarget(u)))
+	if err == nil {
+		err = ln.Close()
+	}
+	return err == nil
+}
+
+// CloneURL clones given url
+func CloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+
+	cloned := new(url.URL)
+	*cloned = *u
+
+	return cloned
 }

--- a/pkg/tools/sandbox/grpc_utils.go
+++ b/pkg/tools/sandbox/grpc_utils.go
@@ -37,10 +37,11 @@ func serve(ctx context.Context, t *testing.T, u *url.URL, register func(server *
 	register(server)
 
 	errCh := grpcutils.ListenAndServe(ctx, u, server)
+	uString := u.String()
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.FromContext(ctx).Infof("Stop serve: %v", u.String())
+			log.FromContext(ctx).Infof("Stop serve: %s", uString)
 			return
 		case err := <-errCh:
 			require.NoError(t, err)

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -36,6 +36,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
@@ -47,13 +48,6 @@ type Node struct {
 
 	NSMgr      *NSMgrEntry
 	Forwarders map[string]*EndpointEntry
-}
-
-// URL returns node NSMgr URL
-func (n *Node) URL() *url.URL {
-	u := new(url.URL)
-	*u = *n.NSMgr.URL
-	return u
 }
 
 // NewNSMgr creates a new NSMgr
@@ -79,7 +73,7 @@ func (n *Node) NewNSMgr(
 	}
 
 	if n.domain.Registry != nil {
-		options = append(options, nsmgr.WithRegistry(n.domain.Registry.URL, dialOptions...))
+		options = append(options, nsmgr.WithRegistry(grpcutils.CloneURL(n.domain.Registry.URL), dialOptions...))
 	}
 
 	if serveURL.Scheme != "unix" {
@@ -132,7 +126,7 @@ func (n *Node) NewForwarder(
 			endpoint.WithAdditionalFunctionality(
 				append(
 					additionalFunctionality,
-					clienturl.NewServer(n.URL()),
+					clienturl.NewServer(grpcutils.CloneURL(n.NSMgr.URL)),
 					heal.NewServer(ctx,
 						heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(entry))),
 						heal.WithOnRestore(heal.OnRestoreIgnore)),
@@ -151,7 +145,7 @@ func (n *Node) NewForwarder(
 		)
 		serve(ctx, n.t, entry.URL, entry.Endpoint.Register)
 
-		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, n.URL(),
+		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, grpcutils.CloneURL(n.NSMgr.URL),
 			registryclient.WithDialOptions(dialOptions...))
 
 		n.registerEndpoint(ctx, nse, nseClone, entry.NetworkServiceEndpointRegistryClient)
@@ -193,7 +187,7 @@ func (n *Node) NewEndpoint(
 		)
 		serve(ctx, n.t, entry.URL, entry.Endpoint.Register)
 
-		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(ctx, n.URL(),
+		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(ctx, grpcutils.CloneURL(n.NSMgr.URL),
 			registryclient.WithDialOptions(dialOptions...))
 
 		n.registerEndpoint(ctx, nse, nseClone, entry.NetworkServiceEndpointRegistryClient)
@@ -223,7 +217,7 @@ func (n *Node) NewClient(
 ) networkservice.NetworkServiceClient {
 	return client.NewClient(
 		ctx,
-		n.URL(),
+		grpcutils.CloneURL(n.NSMgr.URL),
 		client.WithDialOptions(DefaultDialOptions(generatorFunc)...),
 		client.WithDialTimeout(DialTimeout),
 		client.WithAuthorizeClient(authorize.NewClient(authorize.Any())),

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -86,14 +86,15 @@ func (n *Node) NewNSMgr(
 	}
 
 	entry := &NSMgrEntry{
-		Nsmgr: supplyNSMgr(ctx, generatorFunc, options...),
-		Name:  name,
-		URL:   serveURL,
+		Name: name,
+		URL:  serveURL,
 	}
+	entry.restartableServer = newRestartableServer(ctx, n.t, entry.URL, func(ctx context.Context) {
+		entry.Nsmgr = supplyNSMgr(ctx, generatorFunc, options...)
+		serve(ctx, n.t, entry.URL, entry.Register)
 
-	serve(ctx, n.t, serveURL, entry.Register)
-
-	log.FromContext(ctx).Debugf("%s: NSMgr %s on %v", n.domain.Name, name, serveURL)
+		log.FromContext(ctx).Debugf("%s: NSMgr %s on %v", n.domain.Name, name, serveURL)
+	})
 
 	n.NSMgr = entry
 

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -45,7 +45,8 @@ type Node struct {
 	t      *testing.T
 	domain *Domain
 
-	NSMgr *NSMgrEntry
+	NSMgr      *NSMgrEntry
+	Forwarders map[string]*EndpointEntry
 }
 
 // URL returns node NSMgr URL
@@ -108,38 +109,55 @@ func (n *Node) NewForwarder(
 	generatorFunc token.GeneratorFunc,
 	additionalFunctionality ...networkservice.NetworkServiceServer,
 ) *EndpointEntry {
+	var serveURL *url.URL
+	var err error
 	if nse.Url == "" {
-		nse.Url = n.domain.supplyURL("forwarder").String()
+		serveURL = n.domain.supplyURL("forwarder")
+		nse.Url = serveURL.String()
+	} else {
+		serveURL, err = url.Parse(nse.Url)
+		require.NoError(n.t, err)
 	}
 
+	nseClone := nse.Clone()
 	dialOptions := DefaultDialOptions(generatorFunc)
 
-	entry := new(EndpointEntry)
-	additionalFunctionality = append(additionalFunctionality,
-		clienturl.NewServer(n.URL()),
-		heal.NewServer(ctx,
-			heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(entry))),
-			heal.WithOnRestore(heal.OnRestoreIgnore)),
-		connect.NewServer(ctx,
-			client.NewClientFactory(
-				client.WithName(nse.Name),
-				client.WithAdditionalFunctionality(
-					mechanismtranslation.NewClient(),
-				),
+	entry := &EndpointEntry{
+		Name: nse.Name,
+		URL:  serveURL,
+	}
+	entry.restartableServer = newRestartableServer(ctx, n.t, entry.URL, func(ctx context.Context) {
+		entry.Endpoint = endpoint.NewServer(ctx, generatorFunc,
+			endpoint.WithName(entry.Name),
+			endpoint.WithAdditionalFunctionality(
+				append(
+					additionalFunctionality,
+					clienturl.NewServer(n.URL()),
+					heal.NewServer(ctx,
+						heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(entry))),
+						heal.WithOnRestore(heal.OnRestoreIgnore)),
+					connect.NewServer(ctx,
+						client.NewClientFactory(
+							client.WithName(entry.Name),
+							client.WithAdditionalFunctionality(
+								mechanismtranslation.NewClient(),
+							),
+						),
+						connect.WithDialTimeout(DialTimeout),
+						connect.WithDialOptions(dialOptions...),
+					),
+				)...,
 			),
-			connect.WithDialTimeout(DialTimeout),
-			connect.WithDialOptions(dialOptions...),
-		),
-	)
+		)
+		serve(ctx, n.t, entry.URL, entry.Endpoint.Register)
 
-	*entry = *n.newEndpoint(
-		ctx,
-		nse,
-		generatorFunc,
-		registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, n.URL(),
-			registryclient.WithDialOptions(dialOptions...)),
-		additionalFunctionality...,
-	)
+		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, n.URL(),
+			registryclient.WithDialOptions(dialOptions...))
+
+		n.registerEndpoint(ctx, nse, nseClone, entry.NetworkServiceEndpointRegistryClient)
+	})
+
+	n.Forwarders[entry.Name] = entry
 
 	return entry
 }
@@ -151,53 +169,50 @@ func (n *Node) NewEndpoint(
 	generatorFunc token.GeneratorFunc,
 	additionalFunctionality ...networkservice.NetworkServiceServer,
 ) *EndpointEntry {
+	var serveURL *url.URL
+	var err error
 	if nse.Url == "" {
-		nse.Url = n.domain.supplyURL("nse").String()
+		serveURL = n.domain.supplyURL("nse")
+		nse.Url = serveURL.String()
+	} else {
+		serveURL, err = url.Parse(nse.Url)
+		require.NoError(n.t, err)
 	}
 
-	return n.newEndpoint(
-		ctx,
-		nse,
-		generatorFunc,
-		registryclient.NewNetworkServiceEndpointRegistryClient(ctx, n.URL(),
-			registryclient.WithDialOptions(DefaultDialOptions(generatorFunc)...)),
-		additionalFunctionality...,
-	)
+	nseClone := nse.Clone()
+	dialOptions := DefaultDialOptions(generatorFunc)
+
+	entry := &EndpointEntry{
+		Name: nse.Name,
+		URL:  serveURL,
+	}
+	entry.restartableServer = newRestartableServer(ctx, n.t, entry.URL, func(ctx context.Context) {
+		entry.Endpoint = endpoint.NewServer(ctx, generatorFunc,
+			endpoint.WithName(entry.Name),
+			endpoint.WithAdditionalFunctionality(additionalFunctionality...),
+		)
+		serve(ctx, n.t, entry.URL, entry.Endpoint.Register)
+
+		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(ctx, n.URL(),
+			registryclient.WithDialOptions(dialOptions...))
+
+		n.registerEndpoint(ctx, nse, nseClone, entry.NetworkServiceEndpointRegistryClient)
+	})
+
+	return entry
 }
 
-func (n *Node) newEndpoint(
+func (n *Node) registerEndpoint(
 	ctx context.Context,
-	nse *registryapi.NetworkServiceEndpoint,
-	generatorFunc token.GeneratorFunc,
+	nse, nseClone *registryapi.NetworkServiceEndpoint,
 	registryClient registryapi.NetworkServiceEndpointRegistryClient,
-	additionalFunctionality ...networkservice.NetworkServiceServer,
-) *EndpointEntry {
-	name := nse.Name
-	ep := endpoint.NewServer(ctx, generatorFunc,
-		endpoint.WithName(name),
-		endpoint.WithAdditionalFunctionality(additionalFunctionality...),
-	)
-
-	serveURL, err := url.Parse(nse.Url)
-	require.NoError(n.t, err)
-
-	serve(ctx, n.t, serveURL, ep.Register)
-
-	reg, err := registryClient.Register(ctx, nse)
+) {
+	reg, err := registryClient.Register(ctx, nseClone.Clone())
 	require.NoError(n.t, err)
 
 	nse.Name = reg.Name
 	nse.ExpirationTime = reg.ExpirationTime
 	nse.NetworkServiceLabels = reg.NetworkServiceLabels
-
-	log.FromContext(ctx).Debugf("%s: endpoint %s on %v", n.domain.Name, nse.Name, serveURL)
-
-	return &EndpointEntry{
-		Name:                                 name,
-		URL:                                  serveURL,
-		Endpoint:                             ep,
-		NetworkServiceEndpointRegistryClient: registryClient,
-	}
 }
 
 // NewClient starts a new client and connects it to the node NSMgr

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -36,7 +36,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/tools/addressof"
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
@@ -73,7 +72,7 @@ func (n *Node) NewNSMgr(
 	}
 
 	if n.domain.Registry != nil {
-		options = append(options, nsmgr.WithRegistry(grpcutils.CloneURL(n.domain.Registry.URL), dialOptions...))
+		options = append(options, nsmgr.WithRegistry(CloneURL(n.domain.Registry.URL), dialOptions...))
 	}
 
 	if serveURL.Scheme != "unix" {
@@ -126,7 +125,7 @@ func (n *Node) NewForwarder(
 			endpoint.WithAdditionalFunctionality(
 				append(
 					additionalFunctionality,
-					clienturl.NewServer(grpcutils.CloneURL(n.NSMgr.URL)),
+					clienturl.NewServer(CloneURL(n.NSMgr.URL)),
 					heal.NewServer(ctx,
 						heal.WithOnHeal(addressof.NetworkServiceClient(adapters.NewServerToClient(entry))),
 						heal.WithOnRestore(heal.OnRestoreIgnore)),
@@ -145,7 +144,7 @@ func (n *Node) NewForwarder(
 		)
 		serve(ctx, n.t, entry.URL, entry.Endpoint.Register)
 
-		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, grpcutils.CloneURL(n.NSMgr.URL),
+		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryInterposeClient(ctx, CloneURL(n.NSMgr.URL),
 			registryclient.WithDialOptions(dialOptions...))
 
 		n.registerEndpoint(ctx, nse, nseClone, entry.NetworkServiceEndpointRegistryClient)
@@ -187,7 +186,7 @@ func (n *Node) NewEndpoint(
 		)
 		serve(ctx, n.t, entry.URL, entry.Endpoint.Register)
 
-		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(ctx, grpcutils.CloneURL(n.NSMgr.URL),
+		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(ctx, CloneURL(n.NSMgr.URL),
 			registryclient.WithDialOptions(dialOptions...))
 
 		n.registerEndpoint(ctx, nse, nseClone, entry.NetworkServiceEndpointRegistryClient)
@@ -217,7 +216,7 @@ func (n *Node) NewClient(
 ) networkservice.NetworkServiceClient {
 	return client.NewClient(
 		ctx,
-		grpcutils.CloneURL(n.NSMgr.URL),
+		CloneURL(n.NSMgr.URL),
 		client.WithDialOptions(DefaultDialOptions(generatorFunc)...),
 		client.WithDialTimeout(DialTimeout),
 		client.WithAuthorizeClient(authorize.NewClient(authorize.Any())),

--- a/pkg/tools/sandbox/restartable_server.go
+++ b/pkg/tools/sandbox/restartable_server.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+)
+
+type restartableServer struct {
+	ctx, currentCtx context.Context
+	cancelCurrent   context.CancelFunc
+
+	startFunction func(context.Context)
+}
+
+func newRestartableServer(
+	ctx context.Context,
+	t *testing.T,
+	serveURL *url.URL,
+	startFunction func(ctx context.Context),
+) *restartableServer {
+	r := &restartableServer{
+		ctx:           ctx,
+		cancelCurrent: func() {},
+		startFunction: func(ctx context.Context) {
+			if !grpcutils.CheckURLFree(serveURL) {
+				var timeout time.Duration
+				if deadline, ok := ctx.Deadline(); ok {
+					timeout = time.Until(deadline)
+				} else {
+					timeout = time.Second
+				}
+
+				require.Eventually(t, func() bool {
+					return grpcutils.CheckURLFree(serveURL)
+				}, timeout, timeout/100)
+			}
+			startFunction(ctx)
+		},
+	}
+
+	r.Restart()
+
+	return r
+}
+
+func (r *restartableServer) Restart() {
+	r.cancelCurrent()
+
+	r.currentCtx, r.cancelCurrent = context.WithCancel(r.ctx)
+	r.startFunction(r.currentCtx)
+}
+
+func (r *restartableServer) Cancel() {
+	r.cancelCurrent()
+}

--- a/pkg/tools/sandbox/restartable_server.go
+++ b/pkg/tools/sandbox/restartable_server.go
@@ -23,8 +23,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 )
 
 type restartableServer struct {
@@ -44,7 +42,7 @@ func newRestartableServer(
 		ctx:           ctx,
 		cancelCurrent: func() {},
 		startFunction: func(ctx context.Context) {
-			if !grpcutils.CheckURLFree(serveURL) {
+			if !CheckURLFree(serveURL) {
 				var timeout time.Duration
 				if deadline, ok := ctx.Deadline(); ok {
 					timeout = time.Until(deadline)
@@ -53,7 +51,7 @@ func newRestartableServer(
 				}
 
 				require.Eventually(t, func() bool {
-					return grpcutils.CheckURLFree(serveURL)
+					return CheckURLFree(serveURL)
 				}, timeout, timeout/100)
 			}
 			startFunction(ctx)

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -30,6 +30,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/dnsresolve"
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
@@ -95,7 +96,7 @@ func (d *Domain) NewNSRegistryClient(ctx context.Context, generatorFunc token.Ge
 	case d.Registry != nil:
 		registryURL = d.Registry.URL
 	case len(d.Nodes) != 0:
-		registryURL = d.Nodes[0].URL()
+		registryURL = grpcutils.CloneURL(d.Nodes[0].NSMgr.URL)
 	default:
 		return nil
 	}

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -61,6 +61,7 @@ type NSMgrEntry struct {
 	Name string
 	URL  *url.URL
 
+	*restartableServer
 	nsmgr.Nsmgr
 }
 

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -70,6 +70,7 @@ type EndpointEntry struct {
 	Name string
 	URL  *url.URL
 
+	*restartableServer
 	endpoint.Endpoint
 	registryapi.NetworkServiceEndpointRegistryClient
 }

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -52,6 +52,7 @@ type SetupNodeFunc func(ctx context.Context, node *Node, nodeNum int)
 type RegistryEntry struct {
 	URL *url.URL
 
+	*restartableServer
 	registry.Registry
 }
 

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -30,7 +30,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/dnsresolve"
-	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
@@ -96,7 +95,7 @@ func (d *Domain) NewNSRegistryClient(ctx context.Context, generatorFunc token.Ge
 	case d.Registry != nil:
 		registryURL = d.Registry.URL
 	case len(d.Nodes) != 0:
-		registryURL = grpcutils.CloneURL(d.Nodes[0].NSMgr.URL)
+		registryURL = CloneURL(d.Nodes[0].NSMgr.URL)
 	default:
 		return nil
 	}


### PR DESCRIPTION
## Description
Makes sandbox entries cancelable and restartable:
* `RegistryEntry`
* `NSMgrEntry`
* `EndpointEntry`

## Issue link
#999 

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
