### PR TITLE
fix: Add possible for long-living grpc connections to update expired certificates

### DIFF
--- a/pkg/tools/resetting/transport_credentials.go
+++ b/pkg/tools/resetting/transport_credentials.go
@@ -16,7 +16,7 @@
 
 // Package resetting provides grpc credentials.TransportCredentials wrapper that can init re-dial prodcudere for grpc connection on event receiving from the channel.
 // This might be useful for updating long-living connections with expired certificates on the server and client-side.
-// See at https://github.com/grpc/grpc-go/blob/45549242f79aacb850de77336a76777bef8bbe01/clientconn.go#L1138
+// See at https://github.com/grpc/grpc-go/blob/v1.39.0/clientconn.go#L1138
 package resetting
 
 import (
@@ -48,7 +48,7 @@ func (c *subscribableConn) Close() error {
 // NewCredentials adds to passed credentials.TransportCredentials a possible to reset all connections on receiving a update from the resetCh.
 func NewCredentials(creds credentials.TransportCredentials, resetCh <-chan struct{}) credentials.TransportCredentials {
 	if resetCh == nil {
-		panic("updateCh cannot be nil")
+		panic("resetCh cannot be nil")
 	}
 	var s = &transportCredentails{
 		TransportCredentials: creds,

--- a/pkg/tools/resetting/transport_credentials.go
+++ b/pkg/tools/resetting/transport_credentials.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resetting provides grpc credentials.TransportCredentials wrapper that can init re-dial prodcudere for grpc connection on event receiving from the channel.
+// This might be useful for updating long-living connections with expired certificates on the server and client-side.
+// See at https://github.com/grpc/grpc-go/blob/45549242f79aacb850de77336a76777bef8bbe01/clientconn.go#L1138
+package resetting
+
+import (
+	"context"
+	"net"
+
+	"github.com/edwarnicke/serialize"
+	"google.golang.org/grpc/credentials"
+)
+
+type transportCredentails struct {
+	credentials.TransportCredentials
+	exec  serialize.Executor
+	conns map[*net.Conn]net.Conn
+}
+
+type subscribableConn struct {
+	net.Conn
+	onClosing func()
+}
+
+func (c *subscribableConn) Close() error {
+	if c.onClosing != nil {
+		c.onClosing()
+	}
+	return c.Conn.Close()
+}
+
+// NewCredentials adds to passed credentials.TransportCredentials a possible to reset all connections on receiving a update from the resetCh.
+func NewCredentials(creds credentials.TransportCredentials, resetCh <-chan struct{}) credentials.TransportCredentials {
+	if resetCh == nil {
+		panic("updateCh cannot be nil")
+	}
+	var s = &transportCredentails{
+		TransportCredentials: creds,
+		conns:                make(map[*net.Conn]net.Conn),
+	}
+
+	go func() {
+		for range resetCh {
+			s.exec.AsyncExec(func() {
+				for _, conn := range s.conns {
+					_ = conn.Close()
+				}
+				s.conns = make(map[*net.Conn]net.Conn)
+			})
+		}
+	}()
+
+	return s
+}
+
+func (u *transportCredentails) ClientHandshake(ctx context.Context, authority string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	cc, authInfo, err := u.TransportCredentials.ClientHandshake(ctx, authority, conn)
+
+	if err != nil {
+		return cc, authInfo, err
+	}
+
+	u.exec.AsyncExec(func() {
+		u.conns[&cc] = cc
+	})
+
+	return &subscribableConn{
+		Conn: cc,
+		onClosing: func() {
+			u.exec.AsyncExec(func() {
+				delete(u.conns, &cc)
+			})
+		},
+	}, authInfo, err
+}

--- a/pkg/tools/resetting/transport_credentials_test.go
+++ b/pkg/tools/resetting/transport_credentials_test.go
@@ -79,7 +79,7 @@ func Test_ResetTransportCreds_Stream(t *testing.T) {
 	}
 }
 
-func testResetTransportCredsStream(t *testing.T, listemOn *url.URL) {
+func testResetTransportCredsStream(t *testing.T, listenOn *url.URL) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -96,11 +96,11 @@ func testResetTransportCredsStream(t *testing.T, listemOn *url.URL) {
 
 	grpc_health_v1.RegisterHealthServer(s, healthServer)
 	healthServer.SetServingStatus("test", grpc_health_v1.HealthCheckResponse_SERVING)
-	println(listemOn.String())
-	errCh := grpcutils.ListenAndServe(ctx, listemOn, s)
+
+	errCh := grpcutils.ListenAndServe(ctx, listenOn, s)
 	require.Equal(t, 0, len(errCh))
 
-	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(listemOn), grpc.WithTransportCredentials(creds), grpc.WithBlock())
+	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(listenOn), grpc.WithTransportCredentials(creds), grpc.WithBlock())
 	require.NoError(t, err)
 	defer func() {
 		_ = cc.Close()
@@ -133,7 +133,7 @@ func testResetTransportCredsStream(t *testing.T, listemOn *url.URL) {
 	}, time.Until(deadline), time.Millisecond*50)
 }
 
-func testResetTransportCredsRPC(t *testing.T, listemOn *url.URL) {
+func testResetTransportCredsRPC(t *testing.T, listenOn *url.URL) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -150,11 +150,11 @@ func testResetTransportCredsRPC(t *testing.T, listemOn *url.URL) {
 
 	grpc_health_v1.RegisterHealthServer(s, healthServer)
 	healthServer.SetServingStatus("test", grpc_health_v1.HealthCheckResponse_SERVING)
-	println(listemOn.String())
-	errCh := grpcutils.ListenAndServe(ctx, listemOn, s)
+	println(listenOn.String())
+	errCh := grpcutils.ListenAndServe(ctx, listenOn, s)
 	require.Equal(t, 0, len(errCh))
 
-	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(listemOn), grpc.WithTransportCredentials(creds), grpc.WithBlock())
+	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(listenOn), grpc.WithTransportCredentials(creds), grpc.WithBlock())
 	require.NoError(t, err)
 
 	defer func() {

--- a/pkg/tools/resetting/transport_credentials_test.go
+++ b/pkg/tools/resetting/transport_credentials_test.go
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package resetting_test
 
 import (

--- a/pkg/tools/resetting/transport_credentials_test.go
+++ b/pkg/tools/resetting/transport_credentials_test.go
@@ -1,0 +1,247 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resetting_test
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
+	"github.com/networkservicemesh/sdk/pkg/tools/resetting"
+)
+
+func Test_ResetTransportCreds_RPC(t *testing.T) {
+	tmpDir := filepath.Join(os.TempDir(), t.Name())
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	var urls = []*url.URL{
+		&(url.URL{Scheme: "tcp", Path: "127.0.0.1"}),
+		&(url.URL{Scheme: "udp", Path: "127.0.0.1"}),
+		&(url.URL{Scheme: "unix", Path: filepath.Join(tmpDir, "listen.on.socket")}),
+	}
+
+	for i := 0; i < len(urls); i++ {
+		u := urls[i]
+		t.Run(t.Name()+", scheme: "+u.Scheme, func(t *testing.T) {
+			testResetTransportCredsRPC(t, u)
+		})
+	}
+}
+
+func Test_ResetTransportCreds_Stream(t *testing.T) {
+	tmpDir := filepath.Join(os.TempDir(), t.Name())
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	var urls = []*url.URL{
+		&(url.URL{Scheme: "tcp", Path: "127.0.0.1"}),
+		&(url.URL{Scheme: "udp", Path: "127.0.0.1"}),
+		&(url.URL{Scheme: "unix", Path: filepath.Join(tmpDir, "listen.on.socket")}),
+	}
+
+	for i := 0; i < len(urls); i++ {
+		u := urls[i]
+		t.Run(t.Name()+", scheme: "+u.Scheme, func(t *testing.T) {
+			testResetTransportCredsStream(t, u)
+		})
+	}
+}
+
+func testResetTransportCredsStream(t *testing.T, listemOn *url.URL) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	deadline, _ := ctx.Deadline()
+
+	var notifyCh = make(chan struct{})
+	defer close(notifyCh)
+
+	creds := resetting.NewCredentials(insecure.NewCredentials(), notifyCh)
+
+	s := grpc.NewServer()
+
+	healthServer := health.NewServer()
+
+	grpc_health_v1.RegisterHealthServer(s, healthServer)
+	healthServer.SetServingStatus("test", grpc_health_v1.HealthCheckResponse_SERVING)
+	println(listemOn.String())
+	errCh := grpcutils.ListenAndServe(ctx, listemOn, s)
+	require.Equal(t, 0, len(errCh))
+
+	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(listemOn), grpc.WithTransportCredentials(creds), grpc.WithBlock())
+	require.NoError(t, err)
+	defer func() {
+		_ = cc.Close()
+	}()
+	c := grpc_health_v1.NewHealthClient(cc)
+
+	stream, err := c.Watch(ctx, &grpc_health_v1.HealthCheckRequest{
+		Service: "test",
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-ctx.Done():
+		t.Error("notifyCh is not read")
+		t.FailNow()
+	case notifyCh <- struct{}{}:
+	}
+
+	require.NoError(t, stream.Context().Err())
+
+	require.Eventually(t, func() bool {
+		stream, err = c.Watch(ctx, &grpc_health_v1.HealthCheckRequest{
+			Service: "test",
+		})
+		if err != nil {
+			return false
+		}
+		_, err = stream.Recv()
+		return err == nil
+	}, time.Until(deadline), time.Millisecond*50)
+}
+
+func testResetTransportCredsRPC(t *testing.T, listemOn *url.URL) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	deadline, _ := ctx.Deadline()
+
+	var notifyCh = make(chan struct{})
+	defer close(notifyCh)
+	creds := resetting.NewCredentials(insecure.NewCredentials(), notifyCh)
+
+	s := grpc.NewServer()
+
+	healthServer := health.NewServer()
+
+	grpc_health_v1.RegisterHealthServer(s, healthServer)
+	healthServer.SetServingStatus("test", grpc_health_v1.HealthCheckResponse_SERVING)
+	println(listemOn.String())
+	errCh := grpcutils.ListenAndServe(ctx, listemOn, s)
+	require.Equal(t, 0, len(errCh))
+
+	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(listemOn), grpc.WithTransportCredentials(creds), grpc.WithBlock())
+	require.NoError(t, err)
+
+	defer func() {
+		_ = cc.Close()
+	}()
+
+	c := grpc_health_v1.NewHealthClient(cc)
+
+	_, err = c.Check(ctx, &grpc_health_v1.HealthCheckRequest{
+		Service: "test",
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-ctx.Done():
+		t.Error("notifyCh is not read")
+		t.FailNow()
+	case notifyCh <- struct{}{}:
+	}
+
+	require.Eventually(t, func() bool {
+		_, err = c.Check(ctx, &grpc_health_v1.HealthCheckRequest{
+			Service: "test",
+		})
+		return err == nil
+	}, time.Until(deadline), time.Millisecond*50)
+}
+
+type closeCountConn struct {
+	net.Conn
+	closeCount int32
+}
+
+func (c *closeCountConn) Close() error {
+	atomic.AddInt32(&c.closeCount, 1)
+	return nil
+}
+
+func Test_ResettingTransportCreds_ShouldCorrectlyCleanupResources(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	const connLen = 100
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	deadline, _ := ctx.Deadline()
+
+	var notifyCh = make(chan struct{})
+	defer close(notifyCh)
+
+	creds := resetting.NewCredentials(insecure.NewCredentials(), notifyCh)
+
+	var inputConns = make([]closeCountConn, connLen)
+	var outputConns = make([]net.Conn, 0, connLen)
+
+	for i := 0; i < connLen; i++ {
+		conn, _, err := creds.ClientHandshake(ctx, "", &inputConns[i])
+		outputConns = append(outputConns, conn)
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < connLen; i++ {
+		require.Equal(t, int32(0), atomic.LoadInt32(&inputConns[i].closeCount))
+		_ = outputConns[i].Close()
+		require.Equal(t, int32(1), atomic.LoadInt32(&inputConns[i].closeCount))
+	}
+
+	notifyCh <- struct{}{}
+
+	for i := 0; i < connLen; i++ {
+		require.Equal(t, int32(1), atomic.LoadInt32(&inputConns[i].closeCount))
+	}
+
+	for i := 0; i < connLen; i++ {
+		_, _, err := creds.ClientHandshake(ctx, "", &inputConns[i])
+		require.NoError(t, err)
+		require.Equal(t, int32(1), atomic.LoadInt32(&inputConns[i].closeCount))
+	}
+
+	notifyCh <- struct{}{}
+
+	for i := 0; i < connLen; i++ {
+		id := i
+
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&inputConns[id].closeCount) == 2
+		}, time.Until(deadline), time.Millisecond, "expected 2 closes: actual: %v. Iteration: %v", atomic.LoadInt32(&inputConns[i].closeCount), i)
+
+		require.Equal(t, int32(2), atomic.LoadInt32(&inputConns[i].closeCount))
+	}
+}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
Part of https://github.com/networkservicemesh/deployments-k8s/issues/1929

To complete the issue we need also update each NSM repo.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [X] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
