### PR TITLE
fix: use max of ctx.deadline and requestDuration for healing

### DIFF
--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -359,8 +359,11 @@ func TestNSMGR_CloseHeal(t *testing.T) {
 
 	nsc := domain.Nodes[0].NewClient(nscCtx, sandbox.GenerateTestToken)
 
+	reqCtx, reqCancel := context.WithTimeout(ctx, time.Second)
+	defer reqCancel()
+
 	// 1. Request
-	conn, err := nsc.Request(ctx, request.Clone())
+	conn, err := nsc.Request(reqCtx, request.Clone())
 	require.NoError(t, err)
 
 	ignoreCurrent := goleak.IgnoreCurrent()
@@ -368,7 +371,7 @@ func TestNSMGR_CloseHeal(t *testing.T) {
 	// 2. Refresh
 	request.Connection = conn
 
-	conn, err = nsc.Request(ctx, request.Clone())
+	conn, err = nsc.Request(reqCtx, request.Clone())
 	require.NoError(t, err)
 
 	// 3. Stop endpoint and wait for the heal to start

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -326,7 +326,10 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 
 	request := defaultRequest(nsReg.Name)
 
-	conn, err := nsc.Request(ctx, request.Clone())
+	reqCtx, reqCancel := context.WithTimeout(ctx, time.Second)
+	defer reqCancel()
+
+	conn, err := nsc.Request(reqCtx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
@@ -338,9 +341,9 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	refreshRequest := request.Clone()
 	refreshRequest.Connection = conn.Clone()
 
-	_, err = nsc.Request(ctx, refreshRequest)
+	_, err = nsc.Request(reqCtx, refreshRequest)
 	require.Error(t, err)
-	require.NoError(t, ctx.Err())
+	require.NoError(t, reqCtx.Err())
 
 	// Close
 	_, _ = nsc.Close(ctx, conn)


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Current request duration in not enough for healing.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
