### PR TITLE
improve logs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -194,6 +194,10 @@ issues:
       linters:
         - funlen
       text: "Function 'TestConnectServerShouldNotPanicOnRequest' is too long"
+    - path: pkg/networkservice/core/trace/common_test.go
+      linters:
+        - funlen
+      text: "Function 'TestTraceOutput' is too long"
     - path: pkg/networkservice/utils/checks/checkerror/server_test.go
       linters:
         - dupl

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect
+	github.com/antonfisher/nested-logrus-formatter v1.3.1
 	github.com/benbjohnson/clock v1.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/edwarnicke/exechelper v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/OneOfOne/xxhash v1.2.3 h1:wS8NNaIgtzapuArKIAjsyXtEN/IUjQkbw90xszUdS40=
 github.com/OneOfOne/xxhash v1.2.3/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/antonfisher/nested-logrus-formatter v1.3.1 h1:NFJIr+pzwv5QLHTPyKz9UMEoHck02Q9L0FP13b/xSbQ=
+github.com/antonfisher/nested-logrus-formatter v1.3.1/go.mod h1:6WTfyWFkBc9+zyBaKIqRrg/KwMqBbodBjgbHjDz7zjA=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 h1:EFSB7Zo9Eg91v7MJPVsifUysc/wPdN+NOnVe6bWbdBM=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -59,6 +61,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v0.0.0-20181025225059-d3de96c4c28e/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -160,6 +163,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/r3labs/diff/v2 v2.13.6 h1:OwxATYI673fTkqzQFcf154Lck9DZNgJsSdYKEg+3tC0=
+github.com/r3labs/diff/v2 v2.13.6/go.mod h1:I8noH9Fc2fjSaMxqF3G2lhDdC0b+JXCfyx85tWFM9kc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -184,6 +189,8 @@ github.com/uber/jaeger-client-go v2.21.1+incompatible h1:oozboeZmWz+tyh3VZttJWlF
 github.com/uber/jaeger-client-go v2.21.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.0+incompatible h1:fY7QsGQWiCt8pajv4r7JEvmATdCVaWxXbjwyYwsNaLQ=
 github.com/uber/jaeger-lib v2.4.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
+github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b h1:vVRagRXf67ESqAb72hG2C/ZwI8NtJF2u2V76EsuOHGY=
 github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b/go.mod h1:HptNXiXVDcJjXe9SqMd0v2FsL9f8dz4GnXgltU6q/co=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -220,6 +227,7 @@ golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -248,6 +256,7 @@ golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -277,6 +286,8 @@ gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6d
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
+google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=

--- a/go.sum
+++ b/go.sum
@@ -61,7 +61,6 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v0.0.0-20181025225059-d3de96c4c28e/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -163,8 +162,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/r3labs/diff/v2 v2.13.6 h1:OwxATYI673fTkqzQFcf154Lck9DZNgJsSdYKEg+3tC0=
-github.com/r3labs/diff/v2 v2.13.6/go.mod h1:I8noH9Fc2fjSaMxqF3G2lhDdC0b+JXCfyx85tWFM9kc=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -189,8 +186,6 @@ github.com/uber/jaeger-client-go v2.21.1+incompatible h1:oozboeZmWz+tyh3VZttJWlF
 github.com/uber/jaeger-client-go v2.21.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.0+incompatible h1:fY7QsGQWiCt8pajv4r7JEvmATdCVaWxXbjwyYwsNaLQ=
 github.com/uber/jaeger-lib v2.4.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
-github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b h1:vVRagRXf67ESqAb72hG2C/ZwI8NtJF2u2V76EsuOHGY=
 github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b/go.mod h1:HptNXiXVDcJjXe9SqMd0v2FsL9f8dz4GnXgltU6q/co=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -227,7 +222,6 @@ golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -256,7 +250,6 @@ golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -286,8 +279,6 @@ gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6d
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
-google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=

--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -22,16 +22,15 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/ptypes/empty"
-
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/networkservicemesh/sdk/pkg/tools/clock"
-	"github.com/networkservicemesh/sdk/pkg/tools/log"
-
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/cancelctx"
+	"github.com/networkservicemesh/sdk/pkg/tools/clock"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
 type connectionInfo struct {

--- a/pkg/networkservice/common/heal/server.go
+++ b/pkg/networkservice/common/heal/server.go
@@ -112,6 +112,7 @@ func (f *healServer) Request(ctx context.Context, request *networkservice.Networ
 		defer cw.mut.Unlock()
 
 		if cw.cancel != nil {
+			log.FromContext(ctx).Debug("canceling previous heal")
 			cw.cancel()
 			cw.cancel = nil
 		}
@@ -162,6 +163,7 @@ func (f *healServer) getHealContext(
 	defer cw.mut.Unlock()
 
 	if cw.cancel != nil {
+		log.FromContext(cw.ctx).Debug("canceling previous heal")
 		cw.cancel()
 	}
 	ctx, cancel := context.WithCancel(cw.ctx)
@@ -174,6 +176,7 @@ func (f *healServer) getHealContext(
 func (f *healServer) handleHealConnectionRequest(conn *networkservice.Connection) {
 	ctx, request, requestTimeout := f.getHealContext(conn)
 	if request == nil {
+		log.FromContext(f.ctx).WithField("healServer", "healRequest").Warnf("can't find context for conn %v, skipping heal", conn.GetId())
 		return
 	}
 
@@ -186,6 +189,7 @@ func (f *healServer) handleHealConnectionRequest(conn *networkservice.Connection
 func (f *healServer) handleRestoreConnectionRequest(conn *networkservice.Connection) {
 	ctx, request, requestTimeout := f.getHealContext(conn)
 	if request == nil {
+		log.FromContext(f.ctx).WithField("healServer", "restoreRequest").Warnf("can't find context for conn %v, skipping restore", conn.GetId())
 		return
 	}
 
@@ -204,6 +208,7 @@ func (f *healServer) stopHeal(conn *networkservice.Connection) {
 	defer cw.mut.Unlock()
 
 	if cw.cancel != nil {
+		log.FromContext(cw.ctx).Debug("canceling previous heal")
 		cw.cancel()
 	}
 }
@@ -216,6 +221,7 @@ func (f *healServer) restoreConnection(
 	clockTime := clock.FromContext(ctx)
 
 	if ctx.Err() != nil {
+		log.FromContext(ctx).Warnf("skipping restore: heal context error: %v", ctx.Err())
 		return
 	}
 
@@ -252,9 +258,19 @@ func (f *healServer) processHeal(
 	requestTimeout time.Duration,
 ) {
 	clockTime := clock.FromContext(ctx)
+
+	fields := make(map[string]interface{})
+	if prevFields := log.Fields(ctx); prevFields != nil {
+		for k, v := range prevFields {
+			fields[k] = v
+		}
+	}
+	fields["healServer"] = "processHeal"
+	ctx = log.WithFields(ctx, fields)
 	logger := log.FromContext(ctx).WithField("healServer", "processHeal")
 
 	if ctx.Err() != nil {
+		logger.Warnf("skipping heal: heal context error: %v", ctx.Err())
 		return
 	}
 
@@ -279,6 +295,7 @@ func (f *healServer) processHeal(
 			}
 		}
 	} else {
+		logger.Warn("closing the connection")
 		// Huge timeout is not required to close connection on a current path segment
 		closeCtx, closeCancel := clockTime.WithTimeout(ctx, time.Second)
 		defer closeCancel()
@@ -299,7 +316,11 @@ func (f *healServer) createHealContext(requestCtx, cachedCtx context.Context) co
 			ctx = cachedCtx
 		}
 	}
+
 	healCtx := f.ctx
+	healCtx = log.WithLog(healCtx, log.FromContext(requestCtx))
+	healCtx = log.WithFields(healCtx, log.Fields(requestCtx))
+
 	if candidates := discover.Candidates(ctx); candidates != nil {
 		healCtx = discover.WithCandidates(healCtx, candidates.Endpoints, candidates.NetworkService)
 	}

--- a/pkg/networkservice/common/setlogoption/server.go
+++ b/pkg/networkservice/common/setlogoption/server.go
@@ -45,6 +45,9 @@ func (s *setLogOptionServer) Request(ctx context.Context, request *networkservic
 
 func (s *setLogOptionServer) withFields(ctx context.Context) context.Context {
 	fields := make(map[string]interface{})
+	for k, v := range log.Fields(ctx) {
+		fields[k] = v
+	}
 	for k, v := range s.options {
 		fields[k] = v
 	}

--- a/pkg/networkservice/core/trace/client.go
+++ b/pkg/networkservice/core/trace/client.go
@@ -49,6 +49,12 @@ func NewNetworkServiceClient(traced networkservice.NetworkServiceClient) network
 func (t *beginTraceClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
 	// Create a new logger
 	operation := typeutils.GetFuncName(t.traced, "Request")
+	fields := make(map[string]interface{})
+	for k, v := range log.Fields(ctx) {
+		fields[k] = v
+	}
+	fields["id"] = request.GetConnection().GetId()
+	ctx = log.WithFields(ctx, fields)
 	ctx, finish := withLog(ctx, operation)
 	defer finish()
 
@@ -74,6 +80,12 @@ func (t *beginTraceClient) Request(ctx context.Context, request *networkservice.
 func (t *beginTraceClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
 	// Create a new logger
 	operation := typeutils.GetFuncName(t.traced, "Close")
+	fields := make(map[string]interface{})
+	for k, v := range log.Fields(ctx) {
+		fields[k] = v
+	}
+	fields["id"] = conn.GetId()
+	ctx = log.WithFields(ctx, fields)
 	ctx, finish := withLog(ctx, operation)
 	defer finish()
 

--- a/pkg/networkservice/core/trace/common_test.go
+++ b/pkg/networkservice/core/trace/common_test.go
@@ -23,14 +23,16 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/require"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
-	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
@@ -106,9 +108,7 @@ func TestTraceOutput(t *testing.T) {
 	// Set output to buffer
 	var buff bytes.Buffer
 	logrus.SetOutput(&buff)
-	logrus.SetFormatter(&logrus.TextFormatter{
-		DisableTimestamp: true,
-	})
+	logrus.SetLevel(logrus.DebugLevel)
 	log.EnableTracing(true)
 
 	// Create a chain with modifying elements
@@ -128,31 +128,123 @@ func TestTraceOutput(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, e)
 
-	expectedOutput :=
-		"level=info msg=\"(1) ⎆ sdk/pkg/networkservice/core/trace_test/labelChangerFirstServer.Request()\" name=TestTraceOutput\n" +
-			"level=info msg=\"(1.1)   request={\\\"connection\\\":{\\\"id\\\":\\\"conn-1\\\",\\\"context\\\":" +
-			"{\\\"ip_context\\\":{\\\"src_ip_required\\\":true}}},\\\"mechanism_preferences\\\":[{\\\"cls\\\":\\\"LOCAL\\\"," +
-			"\\\"type\\\":\\\"KERNEL\\\"},{\\\"cls\\\":\\\"LOCAL\\\",\\\"type\\\":\\\"KERNEL\\\",\\\"parameters\\\":{\\\"label\\\"" +
-			":\\\"v2\\\"}}]}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(1.2)   request-diff={\\\"connection\\\":{\\\"labels\\\":{\\\"+Label\\\":\\\"A\\\"}}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(2)  ⎆ sdk/pkg/networkservice/core/trace_test/labelChangerSecondServer.Request()\" name=TestTraceOutput\n" +
-			"level=info msg=\"(2.1)    request-diff={\\\"connection\\\":{\\\"labels\\\":{\\\"Label\\\":\\\"B\\\"}}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(2.2)    response={\\\"id\\\":\\\"conn-1\\\",\\\"context\\\":{\\\"ip_context\\\":{\\\"src_ip_required\\\":true}}," +
-			"\\\"labels\\\":{\\\"Label\\\":\\\"B\\\"}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(2.3)    response-diff={\\\"labels\\\":{\\\"Label\\\":\\\"C\\\"}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(1.3)   response-diff={\\\"labels\\\":{\\\"Label\\\":\\\"D\\\"}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(1) ⎆ sdk/pkg/networkservice/core/trace_test/labelChangerFirstServer.Close()\" name=TestTraceOutput\n" +
-			"level=info msg=\"(1.1)   request={\\\"id\\\":\\\"conn-1\\\",\\\"context\\\":{\\\"ip_context\\\":{\\\"src_ip_required\\\":true}}," +
-			"\\\"labels\\\":{\\\"Label\\\":\\\"D\\\"}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(1.2)   request-diff={\\\"labels\\\":{\\\"Label\\\":\\\"W\\\"}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(2)  ⎆ sdk/pkg/networkservice/core/trace_test/labelChangerSecondServer.Close()\" name=TestTraceOutput\n" +
-			"level=info msg=\"(2.1)    request-diff={\\\"labels\\\":{\\\"Label\\\":\\\"X\\\"}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(2.2)    response={\\\"id\\\":\\\"conn-1\\\",\\\"context\\\":{\\\"ip_context\\\":{\\\"src_ip_required\\\"" +
-			":true}},\\\"labels\\\":{\\\"Label\\\":\\\"X\\\"}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(2.3)    response-diff={\\\"labels\\\":{\\\"Label\\\":\\\"Y\\\"}}\" name=TestTraceOutput\n" +
-			"level=info msg=\"(1.3)   response-diff={\\\"labels\\\":{\\\"Label\\\":\\\"Z\\\"}}\" name=TestTraceOutput\n"
+	//nolint:stylecheck // disable ST1018: string literal contains Unicode control characters
+	expectedOutput := `[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(1) ⎆ sdk/pkg/networkservice/core/trace_test/labelChangerFirstServer.Request()
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(1.1)   request: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"connection": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"id": "conn-1",
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"context": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"ip_context": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m				"src_ip_required": true
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	},
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"mechanism_preferences": [
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		{
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"cls": "LOCAL",
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"type": "KERNEL"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		},
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		{
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"cls": "LOCAL",
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"type": "KERNEL",
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"parameters": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m				"label": "v2"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	]
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(1.2)   request-diff: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"connection": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"+Label": "A"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(2)  ⎆ sdk/pkg/networkservice/core/trace_test/labelChangerSecondServer.Request()
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(2.1)    request-diff: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"connection": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"Label": "B"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(2.2)    response: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"id": "conn-1",
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"context": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"ip_context": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"src_ip_required": true
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	},
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "B"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(2.3)    response-diff: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "C"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(1.3)   response-diff: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "D"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(1) ⎆ sdk/pkg/networkservice/core/trace_test/labelChangerFirstServer.Close()
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(1.1)   request: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"id": "conn-1",
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"context": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"ip_context": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"src_ip_required": true
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	},
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "D"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(1.2)   request-diff: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "W"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(2)  ⎆ sdk/pkg/networkservice/core/trace_test/labelChangerSecondServer.Close()
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(2.1)    request-diff: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "X"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(2.2)    response: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"id": "conn-1",
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"context": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"ip_context": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m			"src_ip_required": true
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	},
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "X"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(2.3)    response-diff: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "Y"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m(1.3)   response-diff: {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	"labels": {
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m		"Label": "Z"
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m	}
+[37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
+`
 
-	require.Equal(t, expectedOutput, buff.String())
+	result := ""
+	for _, line := range strings.Split(buff.String(), "\n") {
+		if len(line) > 19 {
+			result += line[19:] + "\n"
+		} else {
+			result += line
+		}
+	}
+
+	require.Equal(t, expectedOutput, result)
 }
 
 func newConnection() *networkservice.NetworkServiceRequest {

--- a/pkg/networkservice/core/trace/common_test.go
+++ b/pkg/networkservice/core/trace/common_test.go
@@ -235,10 +235,20 @@ func TestTraceOutput(t *testing.T) {
 [37m [DEBU] [id:conn-1] [name:TestTraceOutput] [0m}
 `
 
+	// Logger created by the trace chain element uses custom formatter, which prints date and time info in each line
+	// To check if output matches our expectations, we need to somehow get rid of this info.
+	// We have the following options:
+	// 1. Configure formatter options on logger creation in trace element
+	// 2. Use some global configuration (either set global default formatter
+	// 	  instead of creating it in trace element or use global config for our formatter)
+	// 3. Remove datetime information from the output
+	// Since we are unlikely to need to remove date in any case except these tests,
+	// it seems like the third option would be the most convenient.
 	result := ""
+	datetimeLength := 19
 	for _, line := range strings.Split(buff.String(), "\n") {
-		if len(line) > 19 {
-			result += line[19:] + "\n"
+		if len(line) > datetimeLength {
+			result += line[datetimeLength:] + "\n"
 		} else {
 			result += line
 		}

--- a/pkg/networkservice/core/trace/server.go
+++ b/pkg/networkservice/core/trace/server.go
@@ -22,8 +22,9 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -47,6 +48,12 @@ func NewNetworkServiceServer(traced networkservice.NetworkServiceServer) network
 func (t *beginTraceServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	// Create a new logger
 	operation := typeutils.GetFuncName(t.traced, "Request")
+	fields := make(map[string]interface{})
+	for k, v := range log.Fields(ctx) {
+		fields[k] = v
+	}
+	fields["id"] = request.GetConnection().GetId()
+	ctx = log.WithFields(ctx, fields)
 	ctx, finish := withLog(ctx, operation)
 	defer finish()
 
@@ -72,6 +79,12 @@ func (t *beginTraceServer) Request(ctx context.Context, request *networkservice.
 func (t *beginTraceServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
 	// Create a new logger
 	operation := typeutils.GetFuncName(t.traced, "Close")
+	fields := make(map[string]interface{})
+	for k, v := range log.Fields(ctx) {
+		fields[k] = v
+	}
+	fields["id"] = conn.GetId()
+	ctx = log.WithFields(ctx, fields)
 	ctx, finish := withLog(ctx, operation)
 	defer finish()
 

--- a/pkg/tools/clientinfo/clientinfo.go
+++ b/pkg/tools/clientinfo/clientinfo.go
@@ -44,12 +44,12 @@ func AddClientInfo(ctx context.Context, labels map[string]string) {
 	for envName, labelName := range names {
 		value, exists := os.LookupEnv(envName)
 		if !exists {
-			log.FromContext(ctx).Warnf("Environment variable %s is not set. Skipping.", envName)
+			log.FromContext(ctx).Tracef("Environment variable %s is not set. Skipping.", envName)
 			continue
 		}
 		oldValue, isPresent := labels[labelName]
 		if isPresent {
-			log.FromContext(ctx).Warnf("The label %s was already assigned to %s. Skipping.", labelName, oldValue)
+			log.FromContext(ctx).Tracef("The label %s was already assigned to %s. Skipping.", labelName, oldValue)
 			continue
 		}
 		labels[labelName] = value

--- a/pkg/tools/clienturlctx/context.go
+++ b/pkg/tools/clienturlctx/context.go
@@ -38,7 +38,7 @@ func WithClientURL(parent context.Context, clientURL *url.URL) context.Context {
 	if parent == nil {
 		panic("cannot create context from nil parent")
 	}
-	log.FromContext(parent).Debugf("passed clientURL: %v", clientURL)
+	log.FromContext(parent).Tracef("passed clientURL: %v", clientURL)
 	return context.WithValue(parent, clientURLKey, clientURL)
 }
 

--- a/pkg/tools/log/logruslogger/formatter/formatter.go
+++ b/pkg/tools/log/logruslogger/formatter/formatter.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatter
+
+import (
+	"bytes"
+	"strings"
+
+	nested "github.com/antonfisher/nested-logrus-formatter"
+	"github.com/sirupsen/logrus"
+)
+
+// Formatter - logrus formatter, implements logrus.Formatter
+// Duplicates fields and other metadata from nested-logrus-formatter to each line of the message
+type Formatter struct {
+	nf nested.Formatter
+}
+
+func New() *Formatter {
+	f := Formatter{}
+	f.nf.FieldsOrder = []string{"id", "name"}
+	return &f
+}
+
+// Format an log entry
+func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
+	formattedBytes, err := f.nf.Format(entry)
+	if err != nil {
+		return nil, err
+	}
+	bytesString := string(formattedBytes)
+	lineBreakIndex := strings.Index(bytesString, "\n")
+	if lineBreakIndex == -1 || lineBreakIndex == len(bytesString)-1 {
+		return formattedBytes, nil
+	}
+
+	// output buffer
+	bb := &bytes.Buffer{}
+
+	split := strings.SplitN(bytesString, "\x1b[0m", 2)
+	prefix := split[0] + "\x1b[0m"
+	split[1] = split[1][:len(split[1])-1] // remove trailing \n
+	for _, line := range strings.Split(split[1], "\n") {
+		bb.WriteString(prefix)
+		bb.WriteString(line)
+		bb.WriteString("\n")
+	}
+
+	return bb.Bytes(), nil
+}

--- a/pkg/tools/log/logruslogger/formatter/formatter.go
+++ b/pkg/tools/log/logruslogger/formatter/formatter.go
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package formatter contains custom logrus formatter that duplicates fields and other metadata from nested-logrus-formatter to each line of the message
 package formatter
 
 import (
@@ -24,12 +25,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Formatter - logrus formatter, implements logrus.Formatter
-// Duplicates fields and other metadata from nested-logrus-formatter to each line of the message
+// Formatter - implements logrus.Formatter
+// Duplicates fields and other metadata from nested-logrus-Formatter to each line of the message
 type Formatter struct {
 	nf nested.Formatter
 }
 
+// New creates new Formatter and initializes it
 func New() *Formatter {
 	f := Formatter{}
 	f.nf.FieldsOrder = []string{"id", "name"}


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
- Changes log level for chain traces from info to debug
- Adds connection id to each line where connection id is applicable
- Changes diff function to google's go-cmp

Here is how nsmgr logs look after these changes: [nsmgr-2021-07-08T210938+0700.log](https://github.com/networkservicemesh/sdk/files/6785131/nsmgr-2021-07-08T21.09.38%2B07.00.log)
Few examples:
1. Command `grep <id>`, for example `grep 017302e6-00bb-40e3-b60d-48c157d59e9f`, will give you full information about one of the connections
2. Here is an example of how the new diff function result looks like:
<details>

```log
Jul  8 14:07:41.644[37m [DEBU] [id:nsc-kernel-5c64846f8b-vvbk2-0] [name:nsmgr-42n5j] [0m(1) ⎆ cmd-nsmgr/pkg/networkservice/common/updatepath/updatePathServer.Request() span=3b6b58f676e54ae0:2016e43e717b762c:07cf4a3b3994e904:1
Jul  8 14:07:41.644[37m [DEBU] [id:nsc-kernel-5c64846f8b-vvbk2-0] [name:nsmgr-42n5j] [0m(1.1)   request: connection:{id:"nsc-kernel-5c64846f8b-vvbk2-0"  network_service:"scalability-local-ns-0"  path:{path_segments:{name:"nsc-kernel-5c64846f8b-vvbk2"  id:"nsc-kernel-5c64846f8b-vvbk2-0"}}}  mechanism_preferences:{cls:"LOCAL"  type:"KERNEL"  parameters:{key:"inodeURL"  value:"inode://4/4026533747"}  parameters:{key:"name"  value:"nsm-0"}} span=3b6b58f676e54ae0:2016e43e717b762c:07cf4a3b3994e904:1
Jul  8 14:07:41.645[37m [DEBU] [id:nsc-kernel-5c64846f8b-vvbk2-0] [name:nsmgr-42n5j] [0m(1.2)   request-diff:   (*networkservice.NetworkServiceRequest)(Inverse(protocmp.Transform, protocmp.Message{
  	"@type": s"networkservice.NetworkServiceRequest",
  	"connection": protocmp.Message{
  		"@type":           s"connection.Connection",
- 		"id":              string("nsc-kernel-5c64846f8b-vvbk2-0"),
+ 		"id":              string("811ddd8f-2fa6-431b-9c68-6ea9787a916b"),
  		"network_service": string("scalability-local-ns-0"),
  		"path": protocmp.Message{
  			"@type": s"connection.Path",
+ 			"index": uint32(1),
  			"path_segments": []protocmp.Message{
  				{
  					"@type":   s"connection.PathSegment",
+ 					"expires": s"2021-07-08T14:43:44Z",
  					"id":      string("nsc-kernel-5c64846f8b-vvbk2-0"),
  					"name":    string("nsc-kernel-5c64846f8b-vvbk2"),
+ 					"token":   string("eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJzcGlmZmU6Ly9leGFtcGxlLm9yZy9ucy9uc20tc3lzdGVtL3NhL2RlZmF1bHQiLCJleHAiOjE2MjU3NTY4NjEsInN1YiI6InNwaWZmZTovL2V4YW1wbGUub3JnL25zL25zLXB2bGduL3NhL2RlZmF1bHQifQ.OdKQvFASPnko6ajIihkOu3w4vSMrM5HRoHKglvUdnF0M9hTS_-3E"...),
  				},
+ 				s`{name:"nsmgr-42n5j"  id:"811ddd8f-2fa6-431b-9c68-6ea9787a916b"}`,
  			},
  		},
  	},
  	"mechanism_preferences": []protocmp.Message{{"@type": s"connection.Mechanism", "cls": string("LOCAL"), "parameters": map[string]string{"inodeURL": "inode://4/4026533747", "name": "nsm-0"}, "type": string("KERNEL")}},
  }))
 span=3b6b58f676e54ae0:2016e43e717b762c:07cf4a3b3994e904:1
Jul  8 14:07:41.646[37m [DEBU] [id:811ddd8f-2fa6-431b-9c68-6ea9787a916b] [name:nsmgr-42n5j] [0m(2)  ⎆ cmd-nsmgr/pkg/networkservice/common/authorize/authorizeServer.Request() span=3b6b58f676e54ae0:73546bd0f17acfc7:2016e43e717b762c:1
Jul  8 14:07:41.646[37m [DEBU] [id:811ddd8f-2fa6-431b-9c68-6ea9787a916b] [name:nsmgr-42n5j] [0m(3)   ⎆ cmd-nsmgr/pkg/networkservice/common/serialize/serializeServer.Request() span=3b6b58f676e54ae0:101643fe9105ba5b:73546bd0f17acfc7:1
Jul  8 14:07:41.646[37m [DEBU] [id:811ddd8f-2fa6-431b-9c68-6ea9787a916b] [name:nsmgr-42n5j] [0m(4)    ⎆ cmd-nsmgr/pkg/networkservice/common/timeout/timeoutServer.Request() span=3b6b58f676e54ae0:041ff490c5ab8fcf:101643fe9105ba5b:1
Jul  8 14:07:41.646[37m [DEBU] [id:811ddd8f-2fa6-431b-9c68-6ea9787a916b] [name:nsmgr-42n5j] [0m(5)     ⎆ cmd-nsmgr/pkg/networkservice/utils/metadata/metadataServer.Request() span=3b6b58f676e54ae0:22ffe0748ef93866:041ff490c5ab8fcf:1
Jul  8 14:07:41.646[37m [DEBU] [id:811ddd8f-2fa6-431b-9c68-6ea9787a916b] [name:nsmgr-42n5j] [0m(6)      ⎆ cmd-nsmgr/pkg/networkservice/common/monitor/monitorServer.Request() span=3b6b58f676e54ae0:3fe8953d481790d8:22ffe0748ef93866:1
Jul  8 14:07:41.646[37m [DEBU] [id:811ddd8f-2fa6-431b-9c68-6ea9787a916b] [name:nsmgr-42n5j] [0m(7)       ⎆ cmd-nsmgr/pkg/networkservice/common/updatetoken/updateTokenServer.Request() span=3b6b58f676e54ae0:21d564863d5f7e2e:3fe8953d481790d8:1
Jul  8 14:07:41.648[37m [DEBU] [id:811ddd8f-2fa6-431b-9c68-6ea9787a916b] [name:nsmgr-42n5j] [0m(7.1)         request-diff:   (*networkservice.NetworkServiceRequest)(Inverse(protocmp.Transform, protocmp.Message{
  	"@type": s"networkservice.NetworkServiceRequest",
  	"connection": protocmp.Message{
  		"@type":           s"connection.Connection",
  		"id":              string("811ddd8f-2fa6-431b-9c68-6ea9787a916b"),
  		"network_service": string("scalability-local-ns-0"),
  		"path": protocmp.Message{
  			"@type": s"connection.Path",
  			"index": uint32(1),
  			"path_segments": []protocmp.Message{
  				{"@type": s"connection.PathSegment", "expires": protocmp.Message{"@type": s"google.protobuf.Timestamp", "seconds": int64(1625755424)}, "id": string("nsc-kernel-5c64846f8b-vvbk2-0"), "name": string("nsc-kernel-5c64846f8b-vvbk2"), ...},
  				{
  					"@type":   s"connection.PathSegment",
+ 					"expires": s"2021-07-08T14:43:44Z",
  					"id":      string("811ddd8f-2fa6-431b-9c68-6ea9787a916b"),
  					"name":    string("nsmgr-42n5j"),
+ 					"token":   string("eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJzcGlmZmU6Ly9leGFtcGxlLm9yZy9ucy9ucy1wdmxnbi9zYS9kZWZhdWx0IiwiZXhwIjoxNjI1NzU1NDI0LCJzdWIiOiJzcGlmZmU6Ly9leGFtcGxlLm9yZy9ucy9uc20tc3lzdGVtL3NhL2RlZmF1bHQifQ.k2ePQyI-2ADQIAYp1RZTelveqwaDurwS32sFaVGDJGuxeJsteVPw"...),
  				},
  			},
  		},
  	},
  	"mechanism_preferences": []protocmp.Message{{"@type": s"connection.Mechanism", "cls": string("LOCAL"), "parameters": map[string]string{"inodeURL": "inode://4/4026533747", "name": "nsm-0"}, "type": string("KERNEL")}},
  }))
```
</details>
New diff function actually doesn't work that well with IDs in each line, because it produces multiline output, only first line of which contains logger fields.

Here is how nsmgr logs with log level set to `info` look like: [nsmgr-2021-07-08T212330+0700.log](https://github.com/networkservicemesh/sdk/files/6785283/nsmgr-2021-07-08T21.23.30%2B07.00.log)
These logs are actually not as useful as I had hoped.
We have few issues with them:
1. Log pollution by "Reporting span" messages
2. Registry trace chain elements use [Object](https://github.com/networkservicemesh/sdk/blob/6d7c5b4e2cbcf721d51b8fef8b007ef5c4771441/pkg/registry/core/trace/ns_registry.go#L70) log method, which still uses `info` level.
We can probably add log level as an argument for this method.
3. There are a lot of errors that are not really errors. EOF, "the client connection is closing" next part of the connection was deleted before current one, etc.
4. We don't do much logging, except by trace element, so it's hard to find anything really useful here.

I'm really not sure if we need to do anything with these issues in context of this task, though. Probably not.

## Issue link
<!--- Please link to the issue here. -->
Closes https://github.com/networkservicemesh/sdk/issues/1008

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
