### PR TITLE
[deployments-k8s#2003] Add discover close for expired NSE

### DIFF
--- a/pkg/networkservice/common/roundrobin/server.go
+++ b/pkg/networkservice/common/roundrobin/server.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Cisco Systems, Inc.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,8 +71,5 @@ func (s *selectEndpointServer) Request(ctx context.Context, request *networkserv
 }
 
 func (s *selectEndpointServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
-	if clienturlctx.ClientURL(ctx) != nil {
-		return next.Server(ctx).Close(ctx, conn)
-	}
-	return nil, errors.Errorf("passed incorrect connection: %+v", conn)
+	return next.Server(ctx).Close(ctx, conn)
 }


### PR DESCRIPTION
## Description
Adds `Close` propagation for `discover` for not existing (probably expired) NSE case.

## Issue link
networkservicemesh/deployments-k8s#2003

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
