### PR TITLE
Set default kernel interface name

### DIFF
--- a/pkg/networkservice/common/mechanisms/kernel/server.go
+++ b/pkg/networkservice/common/mechanisms/kernel/server.go
@@ -39,7 +39,7 @@ func NewServer() networkservice.NetworkServiceServer {
 func (m *kernelMechanismServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	if mechanism := kernel.ToMechanism(request.GetConnection().GetMechanism()); mechanism != nil {
 		mechanism.SetNetNSURL((&url.URL{Scheme: "file", Path: netNSFilename}).String())
-		mechanism.SetInterfaceName(request.GetConnection().GetId())
+		mechanism.SetInterfaceName(GetNameFromConnection(request.GetConnection()))
 	}
 	return next.Server(ctx).Request(ctx, request)
 }

--- a/pkg/networkservice/common/mechanisms/kernel/server.go
+++ b/pkg/networkservice/common/mechanisms/kernel/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -39,6 +39,7 @@ func NewServer() networkservice.NetworkServiceServer {
 func (m *kernelMechanismServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	if mechanism := kernel.ToMechanism(request.GetConnection().GetMechanism()); mechanism != nil {
 		mechanism.SetNetNSURL((&url.URL{Scheme: "file", Path: netNSFilename}).String())
+		mechanism.SetInterfaceName(request.GetConnection().GetId())
 	}
 	return next.Server(ctx).Request(ctx, request)
 }

--- a/pkg/networkservice/common/mechanisms/kernel/utils.go
+++ b/pkg/networkservice/common/mechanisms/kernel/utils.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"fmt"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+)
+
+// GetNameFromConnection - returns a name computed from networkservice.Connection 'conn'
+func GetNameFromConnection(conn *networkservice.Connection) string {
+	ns := conn.GetNetworkService()
+	nsMaxLength := kernelmech.LinuxIfMaxLength - 5
+	if len(ns) > nsMaxLength {
+		ns = ns[:nsMaxLength]
+	}
+	name := fmt.Sprintf("%s-%s", ns, conn.GetId())
+	if len(name) > kernelmech.LinuxIfMaxLength {
+		name = name[:kernelmech.LinuxIfMaxLength]
+	}
+	return name
+}

--- a/pkg/networkservice/common/mechanismtranslation/client_test.go
+++ b/pkg/networkservice/common/mechanismtranslation/client_test.go
@@ -37,9 +37,10 @@ import (
 )
 
 func kernelMechanism() *networkservice.Mechanism {
-	request := new(networkservice.NetworkServiceRequest)
-	request.Connection = &networkservice.Connection{
-		Id: "id",
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &networkservice.Connection{
+			Id: "id",
+		},
 	}
 	_, _ = kernel.NewClient().Request(context.TODO(), request)
 	return request.MechanismPreferences[0]

--- a/pkg/networkservice/common/mechanismtranslation/client_test.go
+++ b/pkg/networkservice/common/mechanismtranslation/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -38,6 +38,9 @@ import (
 
 func kernelMechanism() *networkservice.Mechanism {
 	request := new(networkservice.NetworkServiceRequest)
+	request.Connection = &networkservice.Connection{
+		Id: "id",
+	}
 	_, _ = kernel.NewClient().Request(context.TODO(), request)
 	return request.MechanismPreferences[0]
 }


### PR DESCRIPTION
https://github.com/networkservicemesh/sdk-vpp/issues/254
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Set default name for kernel interface


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
