### PR TITLE
qfix: Stabilize SwapIPNSERegistry tests

### DIFF
--- a/pkg/registry/common/swapip/nse_registry_test.go
+++ b/pkg/registry/common/swapip/nse_registry_test.go
@@ -50,6 +50,10 @@ func TestSwapIPNSERegistryServer_Register(t *testing.T) {
 		"127.0.0.1": "8.8.8.8",
 		"8.8.8.8":   "127.0.0.1",
 	}
+	ipMapCh <- map[string]string{
+		"127.0.0.1": "8.8.8.8",
+		"8.8.8.8":   "127.0.0.1",
+	}
 
 	defer close(ipMapCh)
 
@@ -75,6 +79,11 @@ func TestSwapIPNSERegistryServer_Unregister(t *testing.T) {
 		}),
 	)
 	defer close(ipMapCh)
+
+	ipMapCh <- map[string]string{
+		"127.0.0.1": "8.8.8.8",
+		"8.8.8.8":   "127.0.0.1",
+	}
 
 	ipMapCh <- map[string]string{
 		"127.0.0.1": "8.8.8.8",
@@ -110,6 +119,11 @@ func TestSwapIPNSERegistryServer_Find(t *testing.T) {
 		m,
 	)
 	defer close(ipMapCh)
+
+	ipMapCh <- map[string]string{
+		"127.0.0.1": "8.8.8.8",
+		"8.8.8.8":   "127.0.0.1",
+	}
 
 	ipMapCh <- map[string]string{
 		"127.0.0.1": "8.8.8.8",

--- a/pkg/registry/common/swapip/nse_registry_test.go
+++ b/pkg/registry/common/swapip/nse_registry_test.go
@@ -46,14 +46,13 @@ func TestSwapIPNSERegistryServer_Register(t *testing.T) {
 		}),
 	)
 
-	ipMapCh <- map[string]string{
+	event := map[string]string{
 		"127.0.0.1": "8.8.8.8",
 		"8.8.8.8":   "127.0.0.1",
 	}
-	ipMapCh <- map[string]string{
-		"127.0.0.1": "8.8.8.8",
-		"8.8.8.8":   "127.0.0.1",
-	}
+
+	ipMapCh <- event
+	ipMapCh <- event
 
 	defer close(ipMapCh)
 
@@ -80,15 +79,13 @@ func TestSwapIPNSERegistryServer_Unregister(t *testing.T) {
 	)
 	defer close(ipMapCh)
 
-	ipMapCh <- map[string]string{
+	event := map[string]string{
 		"127.0.0.1": "8.8.8.8",
 		"8.8.8.8":   "127.0.0.1",
 	}
 
-	ipMapCh <- map[string]string{
-		"127.0.0.1": "8.8.8.8",
-		"8.8.8.8":   "127.0.0.1",
-	}
+	ipMapCh <- event
+	ipMapCh <- event
 
 	_, err := s.Unregister(ctx, &registry.NetworkServiceEndpoint{
 		Url: "tcp://127.0.0.1:5001",
@@ -120,15 +117,13 @@ func TestSwapIPNSERegistryServer_Find(t *testing.T) {
 	)
 	defer close(ipMapCh)
 
-	ipMapCh <- map[string]string{
+	event := map[string]string{
 		"127.0.0.1": "8.8.8.8",
 		"8.8.8.8":   "127.0.0.1",
 	}
 
-	ipMapCh <- map[string]string{
-		"127.0.0.1": "8.8.8.8",
-		"8.8.8.8":   "127.0.0.1",
-	}
+	ipMapCh <- event
+	ipMapCh <- event
 
 	stream, err := adapters.NetworkServiceEndpointServerToClient(s).Find(ctx, &registry.NetworkServiceEndpointQuery{
 		NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Fixes SwapIPNSERegistry tests instability.

## Issue link
https://github.com/networkservicemesh/sdk/runs/3063203054?check_suite_focus=true#step:5:100


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [X] CI
