### PR TITLE
Limit kernel interface name

### DIFF
--- a/pkg/networkservice/common/mechanisms/kernel/client.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client.go
@@ -56,7 +56,7 @@ func (k *kernelMechanismClient) Request(ctx context.Context, request *networkser
 			},
 		}
 		if k.interfaceName != "" {
-			mechanism.Parameters[kernel.InterfaceNameKey] = k.interfaceName
+			mechanism.Parameters[kernel.InterfaceNameKey] = limitName(k.interfaceName)
 		}
 		request.MechanismPreferences = append(request.GetMechanismPreferences(), mechanism)
 	}

--- a/pkg/networkservice/common/mechanisms/kernel/utils.go
+++ b/pkg/networkservice/common/mechanisms/kernel/utils.go
@@ -31,8 +31,12 @@ func GetNameFromConnection(conn *networkservice.Connection) string {
 		ns = ns[:nsMaxLength]
 	}
 	name := fmt.Sprintf("%s-%s", ns, conn.GetId())
+	return limitName(name)
+}
+
+func limitName(name string) string {
 	if len(name) > kernelmech.LinuxIfMaxLength {
-		name = name[:kernelmech.LinuxIfMaxLength]
+		return name[:kernelmech.LinuxIfMaxLength]
 	}
 	return name
 }


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Limit kernel interface name.
Moved from api.
https://github.com/networkservicemesh/api/pull/108/


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
