### PR TITLE
qfix: DNSNSEResolve server should correctly translate NSE for floating side and for querying side

### DIFF
--- a/pkg/registry/common/dnsresolve/common.go
+++ b/pkg/registry/common/dnsresolve/common.go
@@ -92,7 +92,7 @@ func resolveDomain(ctx context.Context, service, domain string, r Resolver) (*ur
 		return nil, err
 	}
 
-	log.FromContext(ctx).Debug("Resolved url: %v", u)
+	log.FromContext(ctx).Debugf("Resolved url: %v", u)
 	return u, nil
 }
 

--- a/pkg/registry/common/dnsresolve/nse_server.go
+++ b/pkg/registry/common/dnsresolve/nse_server.go
@@ -18,7 +18,6 @@ package dnsresolve
 
 import (
 	"context"
-	"errors"
 	"net"
 	"net/url"
 
@@ -61,75 +60,103 @@ func NewNetworkServiceEndpointRegistryServer(opts ...Option) registry.NetworkSer
 	return r
 }
 
-func (d *dnsNSEResolveServer) Register(ctx context.Context, ns *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	domain := interdomain.Domain(ns.Name)
-	u, err := resolveDomain(ctx, d.registryService, domain, d.resolver)
+func resolveNSE(nse *registry.NetworkServiceEndpoint) string {
+	var domain string
+
+	for _, name := range append([]string{nse.Name}, nse.GetNetworkServiceNames()...) {
+		if interdomain.Is(name) {
+			domain = interdomain.Domain(name)
+			break
+		}
+	}
+
+	nse.Name = interdomain.Target(nse.Name)
+
+	for i := 0; i < len(nse.GetNetworkServiceNames()); i++ {
+		var service = nse.GetNetworkServiceNames()[i]
+		var target = interdomain.Target(service)
+
+		nse.GetNetworkServiceNames()[i] = target
+
+		if nse.GetNetworkServiceNames() == nil {
+			continue
+		}
+
+		var labels = nse.GetNetworkServiceLabels()[service]
+
+		if labels == nil {
+			continue
+		}
+
+		delete(nse.GetNetworkServiceLabels(), service)
+
+		nse.GetNetworkServiceLabels()[target] = labels
+	}
+
+	return domain
+}
+
+func (d *dnsNSEResolveServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	var domain = resolveNSE(nse)
+	var u, err = resolveDomain(ctx, d.registryService, domain, d.resolver)
+
 	if err != nil {
 		return nil, err
 	}
+
 	ctx = clienturlctx.WithClientURL(ctx, u)
-	ns.Name = interdomain.Target(ns.Name)
-	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, ns)
+
+	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
 }
 
 type dnsFindNSEServer struct {
 	domain string
-	u      *url.URL
+	nseURL *url.URL
 	registry.NetworkServiceEndpointRegistry_FindServer
 }
 
 func (s *dnsFindNSEServer) Send(nse *registry.NetworkServiceEndpoint) error {
 	nse.Name = interdomain.Join(nse.Name, s.domain)
-	if s.u != nil {
-		nse.Url = s.u.String()
+
+	if s.nseURL != nil {
+		nse.Url = s.nseURL.String()
 	}
+
 	return s.NetworkServiceEndpointRegistry_FindServer.Send(nse)
 }
 
 func (d *dnsNSEResolveServer) Find(q *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
-	ctx := s.Context()
-	domain := domainOf(q.NetworkServiceEndpoint)
-	if domain == "" {
-		return errors.New("domain cannot be empty")
-	}
-	q.NetworkServiceEndpoint.Name = interdomain.Target(q.NetworkServiceEndpoint.Name)
-	u, err := resolveDomain(ctx, d.registryService, domain, d.resolver)
+	var ctx = s.Context()
+	var domain = resolveNSE(q.NetworkServiceEndpoint)
+	var nsmgrProxyURL, err = resolveDomain(ctx, d.registryService, domain, d.resolver)
+
 	if err != nil {
 		return err
 	}
-	ctx = clienturlctx.WithClientURL(s.Context(), u)
-	u, err = resolveDomain(ctx, d.nsmgrProxyService, domain, d.resolver)
+
+	ctx = clienturlctx.WithClientURL(s.Context(), nsmgrProxyURL)
+	nsmgrProxyURL, err = resolveDomain(ctx, d.nsmgrProxyService, domain, d.resolver)
+
 	if err != nil {
 		log.FromContext(ctx).Errorf("nsmgrProxyService is not reachable by domain: %v", domain)
 	}
+
 	s = streamcontext.NetworkServiceEndpointRegistryFindServer(ctx, s)
-	return next.NetworkServiceEndpointRegistryServer(s.Context()).Find(q, &dnsFindNSEServer{NetworkServiceEndpointRegistry_FindServer: s, domain: domain, u: u})
+
+	return next.NetworkServiceEndpointRegistryServer(s.Context()).Find(q, &dnsFindNSEServer{NetworkServiceEndpointRegistry_FindServer: s, domain: domain, nseURL: nsmgrProxyURL})
 }
 
-func (d *dnsNSEResolveServer) Unregister(ctx context.Context, ns *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
-	domain := interdomain.Domain(ns.Name)
-	u, err := resolveDomain(ctx, d.registryService, domain, d.resolver)
+func (d *dnsNSEResolveServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	var domain = resolveNSE(nse)
+	var u, err = resolveDomain(ctx, d.registryService, domain, d.resolver)
+
 	if err != nil {
 		return nil, err
 	}
+
 	ctx = clienturlctx.WithClientURL(ctx, u)
-	ns.Name = interdomain.Target(ns.Name)
-	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, ns)
-}
 
-func domainOf(nse *registry.NetworkServiceEndpoint) string {
-	if nse.Name != "" {
-		return interdomain.Domain(nse.Name)
-	}
-
-	for i, ns := range nse.NetworkServiceNames {
-		if interdomain.Is(ns) {
-			result := interdomain.Domain(ns)
-			nse.NetworkServiceNames[i] = interdomain.Target(ns)
-			return result
-		}
-	}
-	return ""
+	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
 }
 
 func (d *dnsNSEResolveServer) setResolver(r Resolver) {

--- a/pkg/registry/common/dnsresolve/nse_server_test.go
+++ b/pkg/registry/common/dnsresolve/nse_server_test.go
@@ -80,7 +80,7 @@ func Test_DNSResolve(t *testing.T) {
 
 	resp, err := s.Register(ctx, &registry.NetworkServiceEndpoint{Name: "nse-1@domain1"})
 	require.NoError(t, err)
-	require.Equal(t, "nse-1", resp.Name)
+	require.Equal(t, "nse-1@domain1", resp.Name)
 
 	resp, err = s.Register(ctx, &registry.NetworkServiceEndpoint{
 		Name:                "nse-1",
@@ -94,10 +94,10 @@ func Test_DNSResolve(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Equal(t, "nse-1", resp.Name)
+	require.Equal(t, "nse-1@domain1", resp.Name)
 	require.Len(t, resp.GetNetworkServiceLabels(), 1)
-	require.NotNil(t, resp.GetNetworkServiceLabels()["ns1"])
-	require.Equal(t, "myapp", resp.GetNetworkServiceLabels()["ns1"].Labels["app"])
+	require.NotNil(t, resp.GetNetworkServiceLabels()["ns1@domain1"])
+	require.Equal(t, "myapp", resp.GetNetworkServiceLabels()["ns1@domain1"].Labels["app"])
 
 	_, err = s.Register(ctx, &registry.NetworkServiceEndpoint{Name: "nse-1@domain1"})
 	require.NoError(t, err)

--- a/pkg/registry/common/dnsresolve/nse_server_test.go
+++ b/pkg/registry/common/dnsresolve/nse_server_test.go
@@ -78,8 +78,30 @@ func Test_DNSResolve(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
+	resp, err := s.Register(ctx, &registry.NetworkServiceEndpoint{Name: "nse-1@domain1"})
+	require.NoError(t, err)
+	require.Equal(t, "nse-1", resp.Name)
+
+	resp, err = s.Register(ctx, &registry.NetworkServiceEndpoint{
+		Name:                "nse-1",
+		NetworkServiceNames: []string{"ns1@domain1"},
+		NetworkServiceLabels: map[string]*registry.NetworkServiceLabels{
+			"ns1@domain1": {
+				Labels: map[string]string{
+					"app": "myapp",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "nse-1", resp.Name)
+	require.Len(t, resp.GetNetworkServiceLabels(), 1)
+	require.NotNil(t, resp.GetNetworkServiceLabels()["ns1"])
+	require.Equal(t, "myapp", resp.GetNetworkServiceLabels()["ns1"].Labels["app"])
+
 	_, err = s.Register(ctx, &registry.NetworkServiceEndpoint{Name: "nse-1@domain1"})
 	require.NoError(t, err)
+
 	err = s.Find(&registry.NetworkServiceEndpointQuery{NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: "nse-1@domain1"}}, streamchannel.NewNetworkServiceEndpointFindServer((ctx), nil))
 	require.NoError(t, err)
 	_, err = s.Unregister(ctx, &registry.NetworkServiceEndpoint{Name: "nse-1@domain1"})


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description

Problem scenario:

1. NSE "nse-1@floating" registers in the floating domain with labels: `"ns-1@floating" : {"app": "myapp"}`.
2. NSE "nse" registered in floating registry with labels: `"ns-1@floating" : {"app": "myapp"}`
3. Call Find request "nse-1@floaing" on local registry.
 
Actual: Returned **nse-1** with  labels: "ns-1@floating" : {"app": "myapp"}
Expected: Returned **nse-1@floating** with  labels: "ns-1@floaitng" : {"app": "myapp"}

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [X] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [X] Refactoring
- [ ] CI
