### PR TITLE
[qfix] Fix panic on metadata chain elements double Close

### DIFF
--- a/pkg/networkservice/utils/metadata/client.go
+++ b/pkg/networkservice/utils/metadata/client.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020-2021 Cisco and/or its affiliates.
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -41,7 +43,7 @@ func (m *metaDataClient) Request(ctx context.Context, request *networkservice.Ne
 
 	conn, err := next.Client(ctx).Request(store(ctx, connID, &m.Map), request, opts...)
 	if err != nil {
-		m.Map.Delete(connID)
+		del(ctx, connID, &m.Map)
 		return nil, err
 	}
 
@@ -49,9 +51,5 @@ func (m *metaDataClient) Request(ctx context.Context, request *networkservice.Ne
 }
 
 func (m *metaDataClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
-	rv, err := next.Client(ctx).Close(store(ctx, conn.GetId(), &m.Map), conn, opts...)
-
-	m.Map.Delete(conn.GetId())
-
-	return rv, err
+	return next.Client(ctx).Close(del(ctx, conn.GetId(), &m.Map), conn, opts...)
 }

--- a/pkg/networkservice/utils/metadata/context.go
+++ b/pkg/networkservice/utils/metadata/context.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2021 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -29,15 +29,6 @@ func store(parent context.Context, id string, mdMap *metaDataMap) context.Contex
 	_, ok := parent.Value(metaDataKey{}).(*metaData)
 	if !ok {
 		md, _ := mdMap.LoadOrStore(id, &metaData{})
-		return context.WithValue(parent, metaDataKey{}, md)
-	}
-	return parent
-}
-
-func del(parent context.Context, id string, mdMap *metaDataMap) context.Context {
-	_, ok := parent.Value(metaDataKey{}).(*metaData)
-	if !ok {
-		md, _ := mdMap.LoadAndDelete(id)
 		return context.WithValue(parent, metaDataKey{}, md)
 	}
 	return parent

--- a/pkg/networkservice/utils/metadata/context.go
+++ b/pkg/networkservice/utils/metadata/context.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020-2021 Cisco and/or its affiliates.
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -26,10 +28,19 @@ import (
 type metaDataKey struct{}
 
 func store(parent context.Context, id string, mdMap *metaDataMap) context.Context {
-	_, ok := parent.Value(metaDataKey{}).(*metaData)
-	if !ok {
+	if _, ok := parent.Value(metaDataKey{}).(*metaData); !ok {
 		md, _ := mdMap.LoadOrStore(id, &metaData{})
 		return context.WithValue(parent, metaDataKey{}, md)
+	}
+	return parent
+}
+
+func del(parent context.Context, id string, mdMap *metaDataMap) context.Context {
+	if _, ok := parent.Value(metaDataKey{}).(*metaData); !ok {
+		if md, ok := mdMap.LoadAndDelete(id); ok {
+			return context.WithValue(parent, metaDataKey{}, md)
+		}
+		return context.WithValue(parent, metaDataKey{}, new(metaData))
 	}
 	return parent
 }

--- a/pkg/networkservice/utils/metadata/server.go
+++ b/pkg/networkservice/utils/metadata/server.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020-2021 Cisco and/or its affiliates.
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -40,7 +42,7 @@ func (m *metadataServer) Request(ctx context.Context, request *networkservice.Ne
 
 	conn, err := next.Server(ctx).Request(store(ctx, connID, &m.Map), request)
 	if err != nil {
-		m.Map.Delete(connID)
+		del(ctx, connID, &m.Map)
 		return nil, err
 	}
 
@@ -48,9 +50,5 @@ func (m *metadataServer) Request(ctx context.Context, request *networkservice.Ne
 }
 
 func (m *metadataServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
-	rv, err := next.Server(ctx).Close(store(ctx, conn.GetId(), &m.Map), conn)
-
-	m.Map.Delete(conn.GetId())
-
-	return rv, err
+	return next.Server(ctx).Close(del(ctx, conn.GetId(), &m.Map), conn)
 }


### PR DESCRIPTION
## Description
Fixes `metadata.Map(ctx)` panic on double Close.

## Issue link
Related to kind integration tests failure - https://github.com/networkservicemesh/integration-k8s-kind/runs/3136678807?check_suite_focus=true.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
