### PR TITLE
[qfix] Increase default dial timeout to 1 second

### DIFF
--- a/pkg/networkservice/common/connect/server.go
+++ b/pkg/networkservice/common/connect/server.go
@@ -72,7 +72,7 @@ func NewServer(
 	s := &connectServer{
 		ctx:               ctx,
 		clientFactory:     clientFactory,
-		clientDialTimeout: 100 * time.Millisecond,
+		clientDialTimeout: time.Second,
 	}
 
 	for _, opt := range options {


### PR DESCRIPTION
## Description
Default `100ms` dial timeout is too low sometimes, increased to `1s`.

## Issue link
Related to kind integration tests failure - https://github.com/networkservicemesh/integration-k8s-kind/runs/3136678807?check_suite_focus=true.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] ~Bug fix~ Modifying default value
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
