### PR TITLE
[sdk-vpp#314] Support empty chains

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -279,3 +279,6 @@ issues:
     - path: pkg/networkservice/chains/nsmgrproxy/server_test.go
       linters:
         - funlen
+    - path: pkg/networkservice/core/next/.*_test.go
+      linters:
+        - dupl

--- a/pkg/networkservice/core/next/tests/client_test.go
+++ b/pkg/networkservice/core/next/tests/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -30,10 +30,10 @@ import (
 
 func TestNewNetworkServiceClientShouldNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
-		_, _ = next.NewNetworkServiceClient().Request(context.Context(nil), nil)
+		_, _ = next.NewNetworkServiceClient().Request(context.Background(), nil)
 		_, _ = next.NewWrappedNetworkServiceClient(func(client networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
 			return client
-		}).Request(context.Context(nil), nil)
+		}).Request(context.Background(), nil)
 	})
 }
 
@@ -53,8 +53,9 @@ func TestClientBranches(t *testing.T) {
 		{visitClient(), adapters.NewServerToClient(visitServer()), emptyClient()},
 		{visitClient(), next.NewNetworkServiceClient(next.NewNetworkServiceClient(visitClient())), visitClient()},
 		{visitClient(), next.NewNetworkServiceClient(next.NewNetworkServiceClient(emptyClient())), visitClient()},
+		{next.NewNetworkServiceClient(), next.NewNetworkServiceClient(visitClient(), next.NewNetworkServiceClient()), visitClient()},
 	}
-	expects := []int{1, 2, 3, 0, 1, 2, 1, 2, 3, 3, 1, 2, 3, 1}
+	expects := []int{1, 2, 3, 0, 1, 2, 1, 2, 3, 3, 1, 2, 3, 1, 2}
 	for i, sample := range samples {
 		msg := fmt.Sprintf("sample index: %v", i)
 		ctx := visit(context.Background())

--- a/pkg/networkservice/core/next/tests/server_test.go
+++ b/pkg/networkservice/core/next/tests/server_test.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
-//
 // Copyright (c) 2020 Cisco Systems, Inc.
+//
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -32,10 +32,10 @@ import (
 
 func TestNewNetworkServiceServerShouldNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
-		_, _ = next.NewNetworkServiceServer().Request(context.Context(nil), nil)
+		_, _ = next.NewNetworkServiceServer().Request(context.Background(), nil)
 		_, _ = next.NewWrappedNetworkServiceServer(func(server networkservice.NetworkServiceServer) networkservice.NetworkServiceServer {
 			return server
-		}).Request(context.Context(nil), nil)
+		}).Request(context.Background(), nil)
 	})
 }
 
@@ -55,8 +55,9 @@ func TestServerBranches(t *testing.T) {
 		{visitServer(), adapters.NewClientToServer(visitClient()), emptyServer()},
 		{visitServer(), next.NewNetworkServiceServer(next.NewNetworkServiceServer(visitServer())), visitServer()},
 		{visitServer(), next.NewNetworkServiceServer(next.NewNetworkServiceServer(emptyServer())), visitServer()},
+		{next.NewNetworkServiceServer(), next.NewNetworkServiceServer(visitServer(), next.NewNetworkServiceServer()), visitServer()},
 	}
-	expects := []int{1, 2, 3, 0, 1, 2, 1, 2, 3, 3, 1, 2, 3, 1}
+	expects := []int{1, 2, 3, 0, 1, 2, 1, 2, 3, 3, 1, 2, 3, 1, 2}
 	for i, sample := range servers {
 		ctx := visit(context.Background())
 		s := next.NewNetworkServiceServer(sample...)

--- a/pkg/registry/core/next/ns_registry_server_test.go
+++ b/pkg/registry/core/next/ns_registry_server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -75,10 +75,10 @@ func emptyNSRegistryServer() registry.NetworkServiceRegistryServer {
 
 func TestNewNetworkServiceRegistryServerShouldNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
-		_, _ = next.NewNetworkServiceRegistryServer().Register(context.Context(nil), nil)
+		_, _ = next.NewNetworkServiceRegistryServer().Register(context.Background(), nil)
 		_, _ = next.NewWrappedNetworkServiceRegistryServer(func(server registry.NetworkServiceRegistryServer) registry.NetworkServiceRegistryServer {
 			return server
-		}).Register(context.Context(nil), nil)
+		}).Register(context.Background(), nil)
 	})
 }
 
@@ -97,8 +97,9 @@ func TestNSServerBranches(t *testing.T) {
 		{visitNSRegistryServer(), adapters.NetworkServiceClientToServer(emptyNSRegistryClient()), visitNSRegistryServer()},
 		{visitNSRegistryServer(), adapters.NetworkServiceClientToServer(visitNSRegistryClient()), emptyNSRegistryServer()},
 		{adapters.NetworkServiceClientToServer(visitNSRegistryClient()), adapters.NetworkServiceClientToServer(emptyNSRegistryClient()), visitNSRegistryServer()},
+		{next.NewNetworkServiceRegistryServer(), next.NewNetworkServiceRegistryServer(visitNSRegistryServer(), next.NewNetworkServiceRegistryServer()), visitNSRegistryServer()},
 	}
-	expects := []int{1, 2, 3, 0, 1, 2, 2, 2, 3, 3, 1, 2, 1}
+	expects := []int{1, 2, 3, 0, 1, 2, 2, 2, 3, 3, 1, 2, 1, 2}
 	for i, sample := range servers {
 		s := next.NewNetworkServiceRegistryServer(sample...)
 
@@ -168,10 +169,10 @@ func emptyNSRegistryClient() registry.NetworkServiceRegistryClient {
 
 func TestNewNetworkServiceRegistryClientShouldNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
-		_, _ = next.NewNetworkServiceRegistryClient().Register(context.Context(nil), nil)
+		_, _ = next.NewNetworkServiceRegistryClient().Register(context.Background(), nil)
 		_, _ = next.NewWrappedNetworkServiceRegistryClient(func(client registry.NetworkServiceRegistryClient) registry.NetworkServiceRegistryClient {
 			return client
-		}).Register(context.Context(nil), nil)
+		}).Register(context.Background(), nil)
 	})
 }
 
@@ -235,8 +236,9 @@ func TestNetworkServiceRegistryClientBranches(t *testing.T) {
 		{visitNSRegistryClient(), adapters.NetworkServiceServerToClient(emptyNSRegistryServer()), visitNSRegistryClient()},
 		{visitNSRegistryClient(), adapters.NetworkServiceServerToClient(visitNSRegistryServer()), emptyNSRegistryClient()},
 		{adapters.NetworkServiceServerToClient(visitNSRegistryServer()), adapters.NetworkServiceServerToClient(emptyNSRegistryServer()), visitNSRegistryClient()},
+		{next.NewNetworkServiceRegistryClient(), next.NewNetworkServiceRegistryClient(visitNSRegistryClient(), next.NewNetworkServiceRegistryClient()), visitNSRegistryClient()},
 	}
-	expects := []int{1, 2, 3, 0, 1, 2, 2, 2, 3, 3, 1, 2, 1}
+	expects := []int{1, 2, 3, 0, 1, 2, 2, 2, 3, 3, 1, 2, 1, 2}
 	for i, sample := range samples {
 		msg := fmt.Sprintf("sample index: %v", i)
 		s := next.NewNetworkServiceRegistryClient(sample...)

--- a/pkg/registry/core/next/nse_registry_server_test.go
+++ b/pkg/registry/core/next/nse_registry_server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -75,10 +75,10 @@ func emptyNSERegistryServer() registry.NetworkServiceEndpointRegistryServer {
 
 func TestNewNetworkServiceEndpointRegistryServerShouldNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
-		_, _ = next.NewNetworkServiceEndpointRegistryServer().Register(context.Context(nil), nil)
+		_, _ = next.NewNetworkServiceEndpointRegistryServer().Register(context.Background(), nil)
 		_, _ = next.NewWrappedNetworkServiceEndpointRegistryServer(func(server registry.NetworkServiceEndpointRegistryServer) registry.NetworkServiceEndpointRegistryServer {
 			return server
-		}).Register(context.Context(nil), nil)
+		}).Register(context.Background(), nil)
 	})
 }
 
@@ -97,8 +97,9 @@ func TestNSEServerBranches(t *testing.T) {
 		{visitNSERegistryServer(), adapters.NetworkServiceEndpointClientToServer(emptyNSERegistryClient()), visitNSERegistryServer()},
 		{visitNSERegistryServer(), adapters.NetworkServiceEndpointClientToServer(visitNSERegistryClient()), emptyNSERegistryServer()},
 		{adapters.NetworkServiceEndpointClientToServer(visitNSERegistryClient()), adapters.NetworkServiceEndpointClientToServer(emptyNSERegistryClient()), visitNSERegistryServer()},
+		{next.NewNetworkServiceEndpointRegistryServer(), next.NewNetworkServiceEndpointRegistryServer(visitNSERegistryServer(), next.NewNetworkServiceEndpointRegistryServer()), visitNSERegistryServer()},
 	}
-	expects := []int{1, 2, 3, 0, 1, 2, 2, 2, 3, 3, 1, 2, 1}
+	expects := []int{1, 2, 3, 0, 1, 2, 2, 2, 3, 3, 1, 2, 1, 2}
 	for i, sample := range servers {
 		s := next.NewNetworkServiceEndpointRegistryServer(sample...)
 
@@ -168,10 +169,10 @@ func emptyNSERegistryClient() registry.NetworkServiceEndpointRegistryClient {
 
 func TestNewNetworkServiceEndpointRegistryClientShouldNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
-		_, _ = next.NewNetworkServiceEndpointRegistryClient().Register(context.Context(nil), nil)
+		_, _ = next.NewNetworkServiceEndpointRegistryClient().Register(context.Background(), nil)
 		_, _ = next.NewWrappedNetworkServiceEndpointRegistryClient(func(client registry.NetworkServiceEndpointRegistryClient) registry.NetworkServiceEndpointRegistryClient {
 			return client
-		}).Register(context.Context(nil), nil)
+		}).Register(context.Background(), nil)
 	})
 }
 
@@ -190,8 +191,9 @@ func TestNetworkServiceEndpointRegistryClientBranches(t *testing.T) {
 		{visitNSERegistryClient(), adapters.NetworkServiceEndpointServerToClient(emptyNSERegistryServer()), visitNSERegistryClient()},
 		{visitNSERegistryClient(), adapters.NetworkServiceEndpointServerToClient(visitNSERegistryServer()), emptyNSERegistryClient()},
 		{adapters.NetworkServiceEndpointServerToClient(visitNSERegistryServer()), adapters.NetworkServiceEndpointServerToClient(emptyNSERegistryServer()), visitNSERegistryClient()},
+		{next.NewNetworkServiceEndpointRegistryClient(), next.NewNetworkServiceEndpointRegistryClient(visitNSERegistryClient(), next.NewNetworkServiceEndpointRegistryClient()), visitNSERegistryClient()},
 	}
-	expects := []int{1, 2, 3, 0, 1, 2, 2, 2, 3, 3, 1, 2, 1}
+	expects := []int{1, 2, 3, 0, 1, 2, 2, 2, 3, 3, 1, 2, 1, 2}
 	for i, sample := range samples {
 		msg := fmt.Sprintf("sample index: %v", i)
 		s := next.NewNetworkServiceEndpointRegistryClient(sample...)


### PR DESCRIPTION
## Description
Add support for empty subchains (networkservice, NS registry, NSE registry):
```go
var serversA, serversB, serversC []networkservice.Server
...
server := chain.NewServer(
    chain.NewServer(serversA...), // <-- now can be empty
    chain.NewServer(serversB...), // <-- now can be empty
    chain.NewServer(serversC...), // <-- now can be empty
)
```

## Issue link
Needed for networkservicemesh/sdk-vpp#314.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [x] Refactoring
- [ ] CI
