### PR TITLE
Don't directly update sdk-vpp

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         repository:
           - sdk-k8s
-          - sdk-vpp
           - sdk-kernel
           - cmd-nsmgr
           - cmd-nsmgr-proxy


### PR DESCRIPTION
sdk-vpp is now updated by sdk-kernel.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>

