### PR TITLE
[sdk-vpp#314] Add `opa.Policies` with reading from string

### DIFF
--- a/pkg/tools/opa/allow.rego
+++ b/pkg/tools/opa/allow.rego
@@ -1,0 +1,19 @@
+# Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package test
+
+default allow = true

--- a/pkg/tools/opa/check_name.rego
+++ b/pkg/tools/opa/check_name.rego
@@ -1,0 +1,23 @@
+# Copyright (c) 2021 Doc.ai and/or its affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package test
+
+default check_name = false
+
+check_name {
+    input.path_segments[_].name == "test-name"
+}


### PR DESCRIPTION
## Description
Adds `opa.Policies` implementing `TextUnmarshaller` interface to make possible adding extra OPA policies using envconfig.

## Issue link
Needed for networkservicemesh/sdk-vpp#314.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
