### PR TITLE
Remove debug.Stack() from logger

### DIFF
--- a/pkg/tools/log/spanlogger/spanlogger.go
+++ b/pkg/tools/log/spanlogger/spanlogger.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -61,11 +60,11 @@ func (s *spanLogger) Warnf(format string, v ...interface{}) {
 }
 
 func (s *spanLogger) Error(v ...interface{}) {
-	s.WithField("stacktrace", limitString(string(debug.Stack()))).(*spanLogger).log("error", v...)
+	s.log("error", v...)
 }
 
 func (s *spanLogger) Errorf(format string, v ...interface{}) {
-	s.WithField("stacktrace", limitString(string(debug.Stack()))).(*spanLogger).logf("error", format, v...)
+	s.logf("error", format, v...)
 }
 
 func (s *spanLogger) Fatal(v ...interface{}) {


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

## Description
It seems we don't actually need `debug.Stack()`, because `errors.New()` already [has a stack](https://github.com/pkg/errors/blob/master/errors.go#L68-L73): 
```
// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
// invoked. This information can be retrieved with the following interface:
//
//     type stackTracer interface {
//             StackTrace() errors.StackTrace
//     }
```
Even if we create `error` without  using `errors` package, `trace` chain element will wrap it to the struct with stack trace (`errors.Wrapf(...)`).

We do not need to call `debug.Stack()` for every `Errorf()` call, because we already have this information.
And we need to set `"%+v"`  if we want to print error with stack trace - [link](https://github.com/pkg/errors/blob/master/errors.go#L63-L64) 

## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/2368


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
