### PR TITLE
[sdk#1039] Move counter chain element to networkservice/utils

### DIFF
--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -18,7 +18,6 @@ package nsmgr_test
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -256,10 +255,8 @@ func testNSMGRHealNSMgr(t *testing.T, nodeNum int, restored bool) {
 
 	if restored {
 		// Wait reconnecting through the restored NSMgr
-		require.Eventually(t, checkSecondRequestsReceived(func() int {
-			return int(atomic.LoadInt32(&counter.Requests))
-		}), timeout, tick)
-		require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+		require.Eventually(t, checkSecondRequestsReceived(counter.Requests), timeout, tick)
+		require.Equal(t, 2, counter.Requests())
 	} else {
 		// Wait reconnecting through the new NSMgr
 		require.Eventually(t, checkSecondRequestsReceived(counter.UniqueRequests), timeout, tick)
@@ -276,8 +273,8 @@ func testNSMGRHealNSMgr(t *testing.T, nodeNum int, restored bool) {
 	require.NoError(t, err)
 
 	if restored {
-		require.Equal(t, int32(3), atomic.LoadInt32(&counter.Requests))
-		require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+		require.Equal(t, 3, counter.Requests())
+		require.Equal(t, 1, counter.Closes())
 	} else {
 		require.Equal(t, 2, counter.UniqueRequests())
 		require.Equal(t, 1, counter.UniqueCloses())
@@ -327,7 +324,7 @@ func TestNSMGR_HealRegistry(t *testing.T) {
 	_, err = nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 
-	require.Equal(t, int32(3), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 3, counter.Requests())
 }
 
 func TestNSMGR_CloseHeal(t *testing.T) {

--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -76,7 +77,7 @@ func testNSMGRHealEndpoint(t *testing.T, nodeNum int) {
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 
-	counter := &counterServer{}
+	counter := new(count.Server)
 	nse := domain.Nodes[nodeNum].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	request := defaultRequest(nsReg.Name)
@@ -150,7 +151,7 @@ func testNSMGRHealForwarder(t *testing.T, nodeNum int) {
 	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService())
 	require.NoError(t, err)
 
-	counter := &counterServer{}
+	counter := new(count.Server)
 	domain.Nodes[1].NewEndpoint(ctx, defaultRegistryEndpoint(nsReg.Name), sandbox.GenerateTestToken, counter)
 
 	request := defaultRequest(nsReg.Name)
@@ -232,7 +233,7 @@ func testNSMGRHealNSMgr(t *testing.T, nodeNum int, restored bool) {
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 
-	counter := &counterServer{}
+	counter := new(count.Server)
 	domain.Nodes[1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	request := defaultRequest(nsReg.Name)
@@ -302,7 +303,7 @@ func TestNSMGR_HealRegistry(t *testing.T) {
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 
-	counter := &counterServer{}
+	counter := new(count.Server)
 	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 
 	request := defaultRequest(nsReg.Name)

--- a/pkg/networkservice/chains/nsmgr/scale_test.go
+++ b/pkg/networkservice/chains/nsmgr/scale_test.go
@@ -108,14 +108,14 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, flag.Load())
-	require.Equal(t, int32(1), requestCounter.Requests)
+	require.Equal(t, 1, requestCounter.Requests())
 
 	// check refresh
 	_, err = nsc.Request(ctx, &networkservice.NetworkServiceRequest{
 		Connection: conn,
 	})
 	require.NoError(t, err)
-	require.Equal(t, int32(2), requestCounter.Requests)
+	require.Equal(t, 2, requestCounter.Requests())
 
 	// check new request
 	_, err = nsc.Request(ctx, &networkservice.NetworkServiceRequest{
@@ -124,7 +124,7 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.Equal(t, int32(3), requestCounter.Requests)
+	require.Equal(t, 3, requestCounter.Requests())
 }
 
 type nseMaker struct {

--- a/pkg/networkservice/chains/nsmgr/scale_test.go
+++ b/pkg/networkservice/chains/nsmgr/scale_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -72,7 +73,7 @@ func TestCreateEndpointDuringRequest(t *testing.T) {
 	}
 
 	flag := atomic.Bool{}
-	requestCounter := &counterServer{}
+	requestCounter := new(count.Server)
 
 	makerServer := &nseMaker{
 		ctx:    ctx,

--- a/pkg/networkservice/chains/nsmgr/single_test.go
+++ b/pkg/networkservice/chains/nsmgr/single_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/dnscontext"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
 	"github.com/networkservicemesh/sdk/pkg/tools/clientinfo"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
@@ -216,7 +217,7 @@ func Test_Local_NoURLUsecase(t *testing.T) {
 
 	nseReg := defaultRegistryEndpoint(nsReg.Name)
 	request := defaultRequest(nsReg.Name)
-	counter := &counterServer{}
+	counter := new(count.Server)
 
 	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counter)
 

--- a/pkg/networkservice/chains/nsmgr/single_test.go
+++ b/pkg/networkservice/chains/nsmgr/single_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -226,7 +225,7 @@ func Test_Local_NoURLUsecase(t *testing.T) {
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 1, counter.Requests())
 	require.Equal(t, 5, len(conn.Path.PathSegments))
 
 	// Simulate refresh from client
@@ -237,12 +236,12 @@ func Test_Local_NoURLUsecase(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, conn2)
 	require.Equal(t, 5, len(conn2.Path.PathSegments))
-	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 2, counter.Requests())
 
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+	require.Equal(t, 1, counter.Closes())
 }
 
 func Test_ShouldParseNetworkServiceLabelsTemplate(t *testing.T) {

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -115,7 +114,7 @@ func (s *nsmgrSuite) Test_Remote_ParallelUsecase() {
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 1, counter.Requests())
 	require.Equal(t, 8, len(conn.Path.PathSegments))
 
 	// Simulate refresh from client.
@@ -126,12 +125,12 @@ func (s *nsmgrSuite) Test_Remote_ParallelUsecase() {
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	require.Equal(t, 8, len(conn.Path.PathSegments))
-	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 2, counter.Requests())
 
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+	require.Equal(t, 1, counter.Closes())
 
 	// Endpoint unregister
 	unregisterWG.Wait()
@@ -238,7 +237,7 @@ func (s *nsmgrSuite) Test_Remote_BusyEndpointsUsecase() {
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 1, counter.Requests())
 	require.Equal(t, 8, len(conn.Path.PathSegments))
 
 	// Simulate refresh from client
@@ -248,13 +247,13 @@ func (s *nsmgrSuite) Test_Remote_BusyEndpointsUsecase() {
 	conn, err = nsc.Request(ctx, refreshRequest)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 2, counter.Requests())
 	require.Equal(t, 8, len(conn.Path.PathSegments))
 
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+	require.Equal(t, 1, counter.Closes())
 
 	// Endpoint unregister
 	unregisterWG.Wait()
@@ -285,7 +284,7 @@ func (s *nsmgrSuite) Test_RemoteUsecase() {
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 1, counter.Requests())
 	require.Equal(t, 8, len(conn.Path.PathSegments))
 
 	// Simulate refresh from client
@@ -295,13 +294,13 @@ func (s *nsmgrSuite) Test_RemoteUsecase() {
 	conn, err = nsc.Request(ctx, refreshRequest)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 2, counter.Requests())
 	require.Equal(t, 8, len(conn.Path.PathSegments))
 
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+	require.Equal(t, 1, counter.Closes())
 
 	// Endpoint unregister
 	_, err = nse.Unregister(ctx, nseReg)
@@ -332,7 +331,7 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	conn, err := nsc.Request(reqCtx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 1, counter.Requests())
 	require.Equal(t, 5, len(conn.Path.PathSegments))
 
 	nse.Cancel()
@@ -374,7 +373,7 @@ func (s *nsmgrSuite) Test_LocalUsecase() {
 	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 1, counter.Requests())
 	require.Equal(t, 5, len(conn.Path.PathSegments))
 
 	// Simulate refresh from client
@@ -385,12 +384,12 @@ func (s *nsmgrSuite) Test_LocalUsecase() {
 	require.NoError(t, err)
 	require.NotNil(t, conn2)
 	require.Equal(t, 5, len(conn2.Path.PathSegments))
-	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 2, counter.Requests())
 
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+	require.Equal(t, 1, counter.Closes())
 
 	// Endpoint unregister
 	_, err = nse.Unregister(ctx, nseReg)
@@ -448,7 +447,7 @@ func (s *nsmgrSuite) Test_PassThroughRemoteUsecase() {
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(nodesCount), atomic.LoadInt32(&counterClose.Closes))
+	require.Equal(t, nodesCount, counterClose.Closes())
 
 	// Endpoint unregister
 	for i, nseReg := range nseRegs {
@@ -507,7 +506,7 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecase() {
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(nsesCount), atomic.LoadInt32(&counterClose.Closes))
+	require.Equal(t, nsesCount, counterClose.Closes())
 
 	// Endpoint unregister
 	for i, nseReg := range nseRegs {
@@ -585,7 +584,7 @@ func (s *nsmgrSuite) Test_PassThroughSameSourceSelector() {
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(nsesCount-1), atomic.LoadInt32(&counterClose.Closes))
+	require.Equal(t, nsesCount-1, counterClose.Closes())
 
 	// Endpoint unregister
 	for i, nseReg := range nseRegs {
@@ -653,7 +652,7 @@ func (s *nsmgrSuite) Test_PassThroughLocalUsecaseMultiLabel() {
 	// Close
 	_, err = nsc.Close(ctx, conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(len(expectedPath)), atomic.LoadInt32(&counterClose.Closes))
+	require.Equal(t, len(expectedPath), counterClose.Closes())
 
 	// Endpoint unregister
 	for i, nseReg := range nseRegs {

--- a/pkg/networkservice/common/connect/server_test.go
+++ b/pkg/networkservice/common/connect/server_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -265,23 +264,23 @@ func TestConnectServer_RequestParallel(t *testing.T) {
 	wg.Wait()
 	wg.Add(parallelCount)
 
-	assert.Equal(t, int32(parallelCount), atomic.LoadInt32(&serverClient.Requests))
-	assert.Equal(t, int32(0), atomic.LoadInt32(&serverClient.Closes))
-	assert.Equal(t, int32(parallelCount), atomic.LoadInt32(&serverA.Requests))
-	assert.Equal(t, int32(0), atomic.LoadInt32(&serverA.Closes))
-	assert.Equal(t, int32(parallelCount), atomic.LoadInt32(&serverNext.Requests))
-	assert.Equal(t, int32(0), atomic.LoadInt32(&serverNext.Closes))
+	assert.Equal(t, parallelCount, serverClient.Requests())
+	assert.Equal(t, 0, serverClient.Closes())
+	assert.Equal(t, parallelCount, serverA.Requests())
+	assert.Equal(t, 0, serverA.Closes())
+	assert.Equal(t, parallelCount, serverNext.Requests())
+	assert.Equal(t, 0, serverNext.Closes())
 
 	// IMPORTANT: now feel free to use `require` statements.
 	barrier.Done()
 	wg.Wait()
 
-	require.Equal(t, int32(2*parallelCount), atomic.LoadInt32(&serverClient.Requests))
-	require.Equal(t, int32(parallelCount), atomic.LoadInt32(&serverClient.Closes))
-	require.Equal(t, int32(2*parallelCount), atomic.LoadInt32(&serverA.Requests))
-	require.Equal(t, int32(parallelCount), atomic.LoadInt32(&serverA.Closes))
-	require.Equal(t, int32(2*parallelCount), atomic.LoadInt32(&serverNext.Requests))
-	require.Equal(t, int32(parallelCount), atomic.LoadInt32(&serverNext.Closes))
+	require.Equal(t, 2*parallelCount, serverClient.Requests())
+	require.Equal(t, parallelCount, serverClient.Closes())
+	require.Equal(t, 2*parallelCount, serverA.Requests())
+	require.Equal(t, parallelCount, serverA.Closes())
+	require.Equal(t, 2*parallelCount, serverNext.Requests())
+	require.Equal(t, parallelCount, serverNext.Closes())
 }
 
 func TestConnectServer_RequestFail(t *testing.T) {

--- a/pkg/networkservice/common/heal/heal_test.go
+++ b/pkg/networkservice/common/heal/heal_test.go
@@ -19,7 +19,6 @@ package heal_test
 import (
 	"context"
 	"net/url"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -101,6 +100,6 @@ func TestHeal_CloseChain(t *testing.T) {
 	remoteCancel()
 
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&counter.Closes) == 1
+		return counter.Closes() == 1
 	}, time.Second, 10*time.Millisecond)
 }

--- a/pkg/networkservice/common/heal/heal_test.go
+++ b/pkg/networkservice/common/heal/heal_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
@@ -37,6 +36,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatetoken"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
@@ -68,7 +68,7 @@ func TestHeal_CloseChain(t *testing.T) {
 	remoteURL, remoteCancel := startRemoteServer(ctx, t, 0)
 	defer remoteCancel()
 
-	counter := new(counterServer)
+	counter := new(count.Server)
 
 	serverChain := new(networkservice.NetworkServiceClient)
 	*serverChain = adapters.NewServerToClient(
@@ -101,24 +101,6 @@ func TestHeal_CloseChain(t *testing.T) {
 	remoteCancel()
 
 	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&counter.closes) == 1
+		return atomic.LoadInt32(&counter.Closes) == 1
 	}, time.Second, 10*time.Millisecond)
-}
-
-type counterServer struct {
-	closes int32
-}
-
-func (s *counterServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	return next.Server(ctx).Request(ctx, request)
-}
-
-func (s *counterServer) Close(ctx context.Context, conn *networkservice.Connection) (*emptypb.Empty, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-
-	atomic.AddInt32(&s.closes, 1)
-
-	return next.Server(ctx).Close(ctx, conn)
 }

--- a/pkg/networkservice/common/interpose/server_test.go
+++ b/pkg/networkservice/common/interpose/server_test.go
@@ -19,11 +19,11 @@ package interpose_test
 import (
 	"context"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
@@ -33,6 +33,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/checks/checkcontext"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
 	registryinterpose "github.com/networkservicemesh/sdk/pkg/registry/common/interpose"
 	registryadapters "github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
 	registrynext "github.com/networkservicemesh/sdk/pkg/registry/core/next"
@@ -55,7 +56,7 @@ func TestInterposeServer(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	touchServer := new(touchServer)
+	counter := new(count.Server)
 
 	client := next.NewNetworkServiceClient(
 		updatepath.NewClient("client"),
@@ -84,7 +85,7 @@ func TestInterposeServer(t *testing.T) {
 		)),
 		adapters.NewServerToClient(next.NewNetworkServiceServer(
 			updatepath.NewServer("endpoint"),
-			touchServer,
+			counter,
 		)),
 	)
 
@@ -96,40 +97,22 @@ func TestInterposeServer(t *testing.T) {
 
 	conn, err := client.Request(context.TODO(), request)
 	require.NoError(t, err)
-	require.True(t, touchServer.touched)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
 
 	// 2. Refresh
 
 	request = request.Clone()
 	request.Connection = conn.Clone()
 
-	touchServer.touched = false
-
 	conn, err = client.Request(context.TODO(), request)
 	require.NoError(t, err)
-	require.True(t, touchServer.touched)
+	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
 
 	// 3. Close
 
 	conn = conn.Clone()
 
-	touchServer.touched = false
-
 	_, err = client.Close(context.TODO(), conn)
 	require.NoError(t, err)
-	require.True(t, touchServer.touched)
-}
-
-type touchServer struct {
-	touched bool
-}
-
-func (s *touchServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	s.touched = true
-	return next.Server(ctx).Request(ctx, request)
-}
-
-func (s *touchServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
-	s.touched = true
-	return next.Server(ctx).Close(ctx, conn)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
 }

--- a/pkg/networkservice/common/interpose/server_test.go
+++ b/pkg/networkservice/common/interpose/server_test.go
@@ -19,7 +19,6 @@ package interpose_test
 import (
 	"context"
 	"net/url"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -97,7 +96,7 @@ func TestInterposeServer(t *testing.T) {
 
 	conn, err := client.Request(context.TODO(), request)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 1, counter.Requests())
 
 	// 2. Refresh
 
@@ -106,7 +105,7 @@ func TestInterposeServer(t *testing.T) {
 
 	conn, err = client.Request(context.TODO(), request)
 	require.NoError(t, err)
-	require.Equal(t, int32(2), atomic.LoadInt32(&counter.Requests))
+	require.Equal(t, 2, counter.Requests())
 
 	// 3. Close
 
@@ -114,5 +113,5 @@ func TestInterposeServer(t *testing.T) {
 
 	_, err = client.Close(context.TODO(), conn)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&counter.Closes))
+	require.Equal(t, 1, counter.Closes())
 }

--- a/pkg/networkservice/utils/count/client.go
+++ b/pkg/networkservice/utils/count/client.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package count
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+// Client is a client type for counting Requests/Closes
+type Client struct {
+	Requests, Closes int32
+	requests, closes map[string]int32
+	mu               sync.Mutex
+}
+
+// Request performs request and increments Requests
+func (c *Client) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	atomic.AddInt32(&c.Requests, 1)
+	if c.requests == nil {
+		c.requests = make(map[string]int32)
+	}
+	c.requests[request.GetConnection().GetId()]++
+
+	return next.Client(ctx).Request(ctx, request, opts...)
+}
+
+// Close performs close and increments Closes
+func (c *Client) Close(ctx context.Context, connection *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	atomic.AddInt32(&c.Closes, 1)
+	if c.closes == nil {
+		c.closes = make(map[string]int32)
+	}
+	c.closes[connection.GetId()]++
+
+	return next.Client(ctx).Close(ctx, connection, opts...)
+}
+
+// UniqueRequests returns unique requests count
+func (c *Client) UniqueRequests() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.requests == nil {
+		return 0
+	}
+	return len(c.requests)
+}
+
+// UniqueCloses returns unique closes count
+func (c *Client) UniqueCloses() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closes == nil {
+		return 0
+	}
+	return len(c.closes)
+}

--- a/pkg/networkservice/utils/count/doc.go
+++ b/pkg/networkservice/utils/count/doc.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package count provides test chain elements for counting Requests/Closes
+package count

--- a/pkg/networkservice/utils/count/server.go
+++ b/pkg/networkservice/utils/count/server.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package count
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/golang/protobuf/ptypes/empty"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+// Server is a server type for counting Requests/Closes
+type Server struct {
+	Requests, Closes int32
+	requests, closes map[string]int32
+	mu               sync.Mutex
+}
+
+// Request performs request and increments Requests
+func (s *Server) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	atomic.AddInt32(&s.Requests, 1)
+	if s.requests == nil {
+		s.requests = make(map[string]int32)
+	}
+	s.requests[request.GetConnection().GetId()]++
+
+	return next.Server(ctx).Request(ctx, request)
+}
+
+// Close performs close and increments Closes
+func (s *Server) Close(ctx context.Context, connection *networkservice.Connection) (*empty.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	atomic.AddInt32(&s.Closes, 1)
+	if s.closes == nil {
+		s.closes = make(map[string]int32)
+	}
+	s.closes[connection.GetId()]++
+
+	return next.Server(ctx).Close(ctx, connection)
+}
+
+// UniqueRequests returns unique requests count
+func (s *Server) UniqueRequests() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.requests == nil {
+		return 0
+	}
+	return len(s.requests)
+}
+
+// UniqueCloses returns unique closes count
+func (s *Server) UniqueCloses() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closes == nil {
+		return 0
+	}
+	return len(s.closes)
+}


### PR DESCRIPTION
## Description
Extracts `count` chain element to `networkservice/utils`.


## Issue link
Needed for #1039.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [x] Refactoring
- [ ] CI
