### PR TITLE
[sdk#1042] Fix monitor blocking sending events on non-reading client

### DIFF
--- a/pkg/networkservice/common/monitor/filter.go
+++ b/pkg/networkservice/common/monitor/filter.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Cisco Systems, Inc.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +19,14 @@
 package monitor
 
 import (
+	"github.com/edwarnicke/serialize"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 )
 
 type monitorFilter struct {
 	selector *networkservice.MonitorScopeSelector
+	executor serialize.Executor
+
 	networkservice.MonitorConnection_MonitorConnectionsServer
 }
 

--- a/pkg/networkservice/core/adapters/monitor_server_to_client.go
+++ b/pkg/networkservice/core/adapters/monitor_server_to_client.go
@@ -38,8 +38,8 @@ func NewMonitorServerToClient(server networkservice.MonitorConnectionServer) net
 	return &monitorServerToClient{server: server}
 }
 
-func (m *monitorServerToClient) MonitorConnections(ctx context.Context, selector *networkservice.MonitorScopeSelector, opts ...grpc.CallOption) (networkservice.MonitorConnection_MonitorConnectionsClient, error) {
-	eventCh := make(chan *networkservice.ConnectionEvent, 100)
+func (m *monitorServerToClient) MonitorConnections(ctx context.Context, selector *networkservice.MonitorScopeSelector, _ ...grpc.CallOption) (networkservice.MonitorConnection_MonitorConnectionsClient, error) {
+	eventCh := make(chan *networkservice.ConnectionEvent, 1)
 	srv := eventchannel.NewMonitorConnectionMonitorConnectionsServer(ctx, eventCh)
 	go func() {
 		_ = m.server.MonitorConnections(selector, srv)

--- a/pkg/networkservice/core/eventchannel/monitor_connection_server.go
+++ b/pkg/networkservice/core/eventchannel/monitor_connection_server.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Cisco and/or its affiliates.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,11 +43,12 @@ func NewMonitorConnectionMonitorConnectionsServer(ctx context.Context, eventCh c
 }
 
 func (m *monitorConnectionMonitorConnectionsServer) Send(event *networkservice.ConnectionEvent) error {
-	if err := m.ctx.Err(); err != nil {
-		return errors.Wrap(err, "Can no longer Send")
+	select {
+	case <-m.ctx.Done():
+		return m.ctx.Err()
+	case m.eventCh <- event:
+		return nil
 	}
-	m.eventCh <- event
-	return nil
 }
 
 func (m *monitorConnectionMonitorConnectionsServer) Context() context.Context {


### PR DESCRIPTION
## Description
Creates separate executors for sending events to different monitor clients.

## Issue link
Closes #1042.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
