### PR TITLE
[deployments-k8s#2689] Use DNS cache plugin

### DIFF
--- a/pkg/networkservice/chains/nsmgr/single_test.go
+++ b/pkg/networkservice/chains/nsmgr/single_test.go
@@ -73,7 +73,7 @@ func Test_DNSUsecase(t *testing.T) {
 	err = ioutil.WriteFile(resolveConfigPath, []byte("nameserver 8.8.4.4\nsearch example.com\n"), os.ModePerm)
 	require.NoError(t, err)
 
-	const expectedCorefile = ". {\n\tlog\n\treload\n}\nmy.domain1 {\n\tfanout . 8.8.4.4 8.8.8.8\n\tlog\n}\n"
+	const expectedCorefile = ". {\n\tlog\n\treload\n}\nmy.domain1 {\n\tfanout . 8.8.4.4 8.8.8.8\n\tcache\n\tlog\n}\n"
 
 	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken, dnscontext.NewClient(
 		dnscontext.WithChainContext(ctx),

--- a/pkg/networkservice/connectioncontext/dnscontext/client_test.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client_test.go
@@ -52,6 +52,7 @@ search example.com
 `
 	expectedEmptyCoreFileWithServer = `. {
 	forward . %s
+	cache
 	log
 	reload
 }
@@ -78,7 +79,7 @@ func TestDNSContextClient(t *testing.T) {
 					DnsServerIps:  []string{"8.8.8.8"},
 				},
 			},
-			expectedCorefile: ". {\n\tlog\n\treload\n}\nexample.com {\n\tforward . 8.8.8.8\n\tlog\n}\n",
+			expectedCorefile: ". {\n\tlog\n\treload\n}\nexample.com {\n\tforward . 8.8.8.8\n\tcache\n\tlog\n}\n",
 		},
 		{
 			name:                "with default, without conflicts",
@@ -89,7 +90,7 @@ func TestDNSContextClient(t *testing.T) {
 					DnsServerIps:  []string{"8.8.8.8"},
 				},
 			},
-			expectedCorefile: ". {\n\tforward . 10.10.10.10\n\tlog\n\treload\n}\nexample.com {\n\tforward . 8.8.8.8\n\tlog\n}\n",
+			expectedCorefile: ". {\n\tforward . 10.10.10.10\n\tcache\n\tlog\n\treload\n}\nexample.com {\n\tforward . 8.8.8.8\n\tcache\n\tlog\n}\n",
 		},
 		{
 			name: "without default, with conflicts",
@@ -107,7 +108,7 @@ func TestDNSContextClient(t *testing.T) {
 					DnsServerIps:  []string{"9.9.9.9"},
 				},
 			},
-			expectedCorefile: ". {\n\tlog\n\treload\n}\nexample.com {\n\tfanout . 7.7.7.7 8.8.8.8 9.9.9.9\n\tlog\n}\n",
+			expectedCorefile: ". {\n\tlog\n\treload\n}\nexample.com {\n\tfanout . 7.7.7.7 8.8.8.8 9.9.9.9\n\tcache\n\tlog\n}\n",
 		},
 	}
 

--- a/pkg/tools/dnscontext/manager.go
+++ b/pkg/tools/dnscontext/manager.go
@@ -74,6 +74,7 @@ func (m *Manager) String() string {
 		_, _ = sb.WriteString(fmt.Sprintf("%s {\n", domain))
 		if ipsString != "" {
 			_, _ = sb.WriteString(fmt.Sprintf("\t%s . %s\n", plugin, ipsString))
+			_, _ = sb.WriteString("\tcache\n")
 		}
 		_, _ = sb.WriteString("\tlog\n")
 		if domain == anyDomain {

--- a/pkg/tools/dnscontext/manager_test.go
+++ b/pkg/tools/dnscontext/manager_test.go
@@ -28,6 +28,7 @@ import (
 func TestManager_StoreAnyDomain(t *testing.T) {
 	const expected = `. {
 	forward . IP1 IP2
+	cache
 	log
 	reload
 }
@@ -42,6 +43,7 @@ func TestManager_StoreAnyDomain(t *testing.T) {
 func TestManager_StoreAnyDomainConflict(t *testing.T) {
 	const expected = `. {
 	fanout . IP1 IP2 IP3
+	cache
 	log
 	reload
 }
@@ -62,9 +64,11 @@ func TestManager_StoreAnyDomainConflict(t *testing.T) {
 func TestManager_Store(t *testing.T) {
 	expected := []string{`zone-a {
 	forward . IP1 IP2
+	cache
 	log
 }`, `zone-b zone-c {
 	forward . IP3 IP4
+	cache
 	log
 }
 `}
@@ -86,6 +90,7 @@ func TestManager_Store(t *testing.T) {
 func TestManager_StoreConflict(t *testing.T) {
 	const expected = `zone-a {
 	fanout . IP1 IP2 IP3
+	cache
 	log
 }
 `
@@ -105,6 +110,7 @@ func TestManager_StoreConflict(t *testing.T) {
 func TestManger_Remove(t *testing.T) {
 	const expected = `zone-a {
 	forward . IP1 IP2
+	cache
 	log
 }
 `
@@ -124,6 +130,7 @@ func TestManger_Remove(t *testing.T) {
 func TestManger_RemoveConflict(t *testing.T) {
 	const expected = `zone-a {
 	forward . IP1 IP2
+	cache
 	log
 }
 `


### PR DESCRIPTION
## Description
Use coredns `cache` plugin.

## Issue link
networkservicemesh/deployments-k8s#2689

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] ~Bug~ Test fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
