### PR TITLE
fix: Actualise authorize server with latest main branch changes

### DIFF
--- a/pkg/networkservice/common/authorize/client.go
+++ b/pkg/networkservice/common/authorize/client.go
@@ -45,7 +45,7 @@ func NewClient(opts ...Option) networkservice.NetworkServiceClient {
 	var result = &authorizeClient{
 		policies: []Policy{
 			opa.WithTokensValidPolicy(),
-			opa.WithCurrentTokenSignedPolicy(),
+			opa.WithNextTokenSignedPolicy(),
 			opa.WithTokensExpiredPolicy(),
 			opa.WithTokenChainPolicy(),
 		},

--- a/pkg/networkservice/common/heal/server.go
+++ b/pkg/networkservice/common/heal/server.go
@@ -303,6 +303,5 @@ func (f *healServer) createHealContext(requestCtx, cachedCtx context.Context) co
 	if candidates := discover.Candidates(ctx); candidates != nil {
 		healCtx = discover.WithCandidates(healCtx, candidates.Endpoints, candidates.NetworkService)
 	}
-
 	return healCtx
 }

--- a/pkg/tools/opa/next_token_signed_policy_test.go
+++ b/pkg/tools/opa/next_token_signed_policy_test.go
@@ -44,9 +44,10 @@ func Test_CurrentTokenShouldBeSigned_Server(t *testing.T) {
 	validX509crt, err := x509.ParseCertificate(cert.Certificate[0])
 	require.Nil(t, err)
 
-	var p = opa.WithCurrentTokenSignedPolicy()
+	var p = opa.WithNextTokenSignedPolicy()
 	var input = &networkservice.Path{
 		PathSegments: []*networkservice.PathSegment{
+			{},
 			{
 				Token: token,
 			},

--- a/pkg/tools/opa/policies.go
+++ b/pkg/tools/opa/policies.go
@@ -24,7 +24,7 @@ var tokensValidPolicySource string
 //go:embed policies/prev_token_signed.rego
 var prevTokenSignedPolicySource string
 
-//go:embed policies/curr_token_signed.rego
+//go:embed policies/next_token_signed.rego
 var currTokenSignedPolicySource string
 
 //go:embed policies/tokens_chained.rego
@@ -42,12 +42,12 @@ func WithTokensValidPolicy() *AuthorizationPolicy {
 	}
 }
 
-// WithCurrentTokenSignedPolicy returns default policy for checking that last token in path is signed.
-func WithCurrentTokenSignedPolicy() *AuthorizationPolicy {
+// WithNextTokenSignedPolicy returns default policy for checking that last token in path is signed.
+func WithNextTokenSignedPolicy() *AuthorizationPolicy {
 	return &AuthorizationPolicy{
 		policySource: currTokenSignedPolicySource,
-		query:        "curr_token_signed",
-		checker:      True("curr_token_signed"),
+		query:        "next_token_signed",
+		checker:      True("next_token_signed"),
 	}
 }
 

--- a/pkg/tools/opa/policies/next_token_signed.rego
+++ b/pkg/tools/opa/policies/next_token_signed.rego
@@ -16,12 +16,13 @@
 
 package nsm
 
-default curr_token_signed = false
-default index = 0
+default next_token_signed = false
+default index = 1
 
-index = input.index
+index = input.index + 1
 
-curr_token_signed {
+next_token_signed {
+	count(input.path_segments) > index
 	token := input.path_segments[index].token	
 	cert := input.auth_info.certificate	
 	io.jwt.verify_es256(token, cert) = true


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description

https://github.com/networkservicemesh/sdk/pull/1018 was outdated with the main branch.  

For example, 

1. path.Index for the client in the main branch for the first client is 0 (previously it was 1).

2. heal can trigger authrorize server without peer in the context. In this case authorizer server shoudl allow the request.
 


## Issue link
Fixes https://github.com/networkservicemesh/integration-k8s-kind/pull/354


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [X] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
