### PR TITLE
remove cmd-nse-icmp-responder as dependent repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,6 @@ jobs:
           - cmd-nsmgr-proxy
           - cmd-registry-memory
           - cmd-registry-proxy-dns
-          - cmd-nse-icmp-responder
           - cmd-nse-vfio
           - cmd-nsc-init
     name: Update ${{ matrix.repository }}

--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -22,7 +22,6 @@ jobs:
           - cmd-nsmgr-proxy
           - cmd-registry-memory
           - cmd-registry-proxy-dns
-          - cmd-nse-icmp-responder
           - cmd-nse-vfio
           - cmd-nsc-init
     name: Update ${{ matrix.repository }}


### PR DESCRIPTION
now cmd-nse-icmp-responder is made as dependent to sdk-sriov, so now this is redundant.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [x] Refactoring
- [ ] CI
