### PR TITLE
[qfix] Manually cleanup old mechanism on Close in `mechanismtranslation`

### DIFF
--- a/pkg/networkservice/common/mechanismtranslation/client.go
+++ b/pkg/networkservice/common/mechanismtranslation/client.go
@@ -60,7 +60,7 @@ func (c *mechanismTranslationClient) Request(ctx context.Context, request *netwo
 func (c *mechanismTranslationClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
 	// 1. Translate connection mechanism
 	conn = conn.Clone()
-	conn.Mechanism = load(ctx)
+	conn.Mechanism = loadAndDelete(ctx)
 
 	// 2. Close client chain
 	return next.Client(ctx).Close(ctx, conn, opts...)

--- a/pkg/networkservice/common/mechanismtranslation/metadata.go
+++ b/pkg/networkservice/common/mechanismtranslation/metadata.go
@@ -37,3 +37,11 @@ func load(ctx context.Context) *networkservice.Mechanism {
 	}
 	return v.(*networkservice.Mechanism)
 }
+
+func loadAndDelete(ctx context.Context) *networkservice.Mechanism {
+	v, ok := metadata.Map(ctx, true).LoadAndDelete(keyType{})
+	if !ok {
+		return nil
+	}
+	return v.(*networkservice.Mechanism)
+}


### PR DESCRIPTION
## Description
Manually cleans up old mechanism on Close in `mechanismtranslation`.

## Motivation
If Close happens in the middle of the chain, `metadata` doesn't remove per-Request map, so mechanism should be manually cleaned up.

Found in https://github.com/networkservicemesh/deployments-k8s/issues/2381#issuecomment-940120379 logs:
[forwarder_old_8.zip](https://github.com/networkservicemesh/deployments-k8s/files/7322924/forwarder_old_8.zip)

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
