### PR TITLE
[sdk#1109] Add `WithReturnConnectionError` and default timeout to dialer

### DIFF
--- a/pkg/networkservice/chains/client/client.go
+++ b/pkg/networkservice/chains/client/client.go
@@ -59,10 +59,7 @@ func NewClient(ctx context.Context, clientOpts ...Option) networkservice.Network
 			},
 			append(
 				opts.additionalFunctionality,
-				dial.NewClient(ctx,
-					dial.WithDialOptions(opts.dialOptions...),
-					dial.WithDialTimeout(opts.dialTimeout),
-				),
+				dial.NewClient(ctx, opts.dialOptions...),
 				opts.authorizeClient,
 				connect.NewClient(),
 			)...,

--- a/pkg/networkservice/chains/client/options.go
+++ b/pkg/networkservice/chains/client/options.go
@@ -18,11 +18,12 @@ package client
 
 import (
 	"net/url"
-	"time"
 
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"google.golang.org/grpc"
 
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
 )
 
@@ -33,8 +34,7 @@ type clientOptions struct {
 	additionalFunctionality []networkservice.NetworkServiceClient
 	authorizeClient         networkservice.NetworkServiceClient
 	refreshClient           networkservice.NetworkServiceClient
-	dialOptions             []grpc.DialOption
-	dialTimeout             time.Duration
+	dialOptions             []dial.Option
 }
 
 // Option modifies default client chain values.
@@ -79,16 +79,9 @@ func WithAuthorizeClient(authorizeClient networkservice.NetworkServiceClient) Op
 }
 
 // WithDialOptions sets dial options
-func WithDialOptions(dialOptions ...grpc.DialOption) Option {
-	return Option(func(c *clientOptions) {
-		c.dialOptions = dialOptions
-	})
-}
-
-// WithDialTimeout sets dial timeout
-func WithDialTimeout(dialTimeout time.Duration) Option {
+func WithDialOptions(dialOptions ...dial.Option) Option {
 	return func(c *clientOptions) {
-		c.dialTimeout = dialTimeout
+		c.dialOptions = dialOptions
 	}
 }
 

--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -25,18 +25,17 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
-	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
-
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clientinfo"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/discover"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/excludedprefixes"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/filtermechanisms"
@@ -77,8 +76,7 @@ type nsmgrServer struct {
 
 type serverOptions struct {
 	authorizeServer networkservice.NetworkServiceServer
-	dialOptions     []grpc.DialOption
-	dialTimeout     time.Duration
+	dialOptions     []dial.Option
 	regURL          *url.URL
 	regDialOptions  []grpc.DialOption
 	name            string
@@ -88,17 +86,10 @@ type serverOptions struct {
 // Option modifies server option value
 type Option func(o *serverOptions)
 
-// WithDialOptions sets grpc.DialOptions for the client
-func WithDialOptions(dialOptions ...grpc.DialOption) Option {
+// WithDialOptions sets dial options for the client
+func WithDialOptions(dialOptions ...dial.Option) Option {
 	return func(o *serverOptions) {
 		o.dialOptions = dialOptions
-	}
-}
-
-// WithDialTimeout sets dial timeout for the client
-func WithDialTimeout(dialTimeout time.Duration) Option {
-	return func(o *serverOptions) {
-		o.dialTimeout = dialTimeout
 	}
 }
 
@@ -206,10 +197,8 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 					client.WithName(opts.name),
 					client.WithAdditionalFunctionality(
 						recvfd.NewClient(),
-						sendfd.NewClient(),
-					),
+						sendfd.NewClient()),
 					client.WithDialOptions(opts.dialOptions...),
-					client.WithDialTimeout(opts.dialTimeout),
 					client.WithoutRefresh(),
 				),
 			),

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -325,10 +325,7 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 
 	request := defaultRequest(nsReg.Name)
 
-	reqCtx, reqCancel := context.WithTimeout(ctx, time.Second)
-	defer reqCancel()
-
-	conn, err := nsc.Request(reqCtx, request.Clone())
+	conn, err := nsc.Request(ctx, request.Clone())
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 	require.Equal(t, 1, counter.Requests())
@@ -340,16 +337,12 @@ func (s *nsmgrSuite) Test_ConnectToDeadNSEUsecase() {
 	refreshRequest := request.Clone()
 	refreshRequest.Connection = conn.Clone()
 
-	refreshCtx, refreshCancel := context.WithTimeout(ctx, time.Second)
-	defer refreshCancel()
-	_, err = nsc.Request(refreshCtx, refreshRequest)
+	_, err = nsc.Request(ctx, refreshRequest)
 	require.Error(t, err)
 	require.NoError(t, ctx.Err())
 
 	// Close
-	closeCtx, closeCancel := context.WithTimeout(ctx, time.Second)
-	defer closeCancel()
-	_, _ = nsc.Close(closeCtx, conn)
+	_, _ = nsc.Close(ctx, conn)
 
 	// Endpoint unregister
 	_, err = s.domain.Nodes[0].NSMgr.NetworkServiceEndpointRegistryServer().Unregister(ctx, nseReg)

--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanismtranslation"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/replacelabels"
@@ -789,8 +790,10 @@ func additionalFunctionalityChain(ctx context.Context, clientURL *url.URL, clien
 						replacelabels.NewClient(labels),
 						kernel.NewClient(),
 					),
-					client.WithDialOptions(sandbox.DialOptions()...),
-					client.WithDialTimeout(sandbox.DialTimeout),
+					client.WithDialOptions(
+						dial.WithDialTimeout(sandbox.DialTimeout),
+						dial.WithDialOptions(sandbox.DialOptions()...),
+					),
 					client.WithoutRefresh(),
 				),
 			),

--- a/pkg/networkservice/chains/nsmgrproxy/server.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server.go
@@ -20,13 +20,12 @@ package nsmgrproxy
 import (
 	"context"
 	"net/url"
-	"time"
 
 	"github.com/google/uuid"
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
 
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
@@ -34,6 +33,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/discover"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/interdomainurl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/swapip"
@@ -69,8 +69,7 @@ type serverOptions struct {
 	mapipFilePath          string
 	listenOn               *url.URL
 	authorizeServer        networkservice.NetworkServiceServer
-	dialOptions            []grpc.DialOption
-	dialTimeout            time.Duration
+	dialOptions            []dial.Option
 	registryConnectOptions []registryconnect.Option
 }
 
@@ -137,17 +136,10 @@ func WithMapIPFilePath(p string) Option {
 	}
 }
 
-// WithDialOptions sets connect Options for the server
-func WithDialOptions(dialOptions ...grpc.DialOption) Option {
+// WithDialOptions sets dial options for the client
+func WithDialOptions(dialOptions ...dial.Option) Option {
 	return func(o *serverOptions) {
 		o.dialOptions = dialOptions
-	}
-}
-
-// WithDialTimeout sets dial timeout for the server
-func WithDialTimeout(dialTimeout time.Duration) Option {
-	return func(o *serverOptions) {
-		o.dialTimeout = dialTimeout
 	}
 }
 
@@ -193,7 +185,6 @@ func NewServer(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator to
 					ctx,
 					client.WithName(opts.name),
 					client.WithDialOptions(opts.dialOptions...),
-					client.WithDialTimeout(opts.dialTimeout),
 					client.WithoutRefresh(),
 				),
 			),

--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	kernelmech "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
@@ -579,8 +580,9 @@ func Test_Interdomain_PassThroughUsecase(t *testing.T) {
 								newPassTroughClient(fmt.Sprintf("my-service-remote-%v@cluster%v", i-1, i-1)),
 								kernelmech.NewClient(),
 							),
-							client.WithDialTimeout(sandbox.DialTimeout),
-							client.WithDialOptions(sandbox.DialOptions()...),
+							client.WithDialOptions(
+								dial.WithDialTimeout(sandbox.DialTimeout),
+								dial.WithDialOptions(sandbox.DialOptions()...)),
 							client.WithoutRefresh(),
 						),
 					),

--- a/pkg/networkservice/common/connect/example_test.go
+++ b/pkg/networkservice/common/connect/example_test.go
@@ -18,18 +18,22 @@ package connect_test
 
 import (
 	"context"
+	"time"
+
+	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
 // ExampleForwarder - example of how to use the connect chain element in a forwarder
 func ExampleNewServer() {
+	var dialTimeout time.Duration
 	var dialOptions []grpc.DialOption
 	var callOptions []grpc.CallOption
 	var additonalClientFunctionality []networkservice.NetworkServiceClient
@@ -49,7 +53,9 @@ func ExampleNewServer() {
 				client.NewClient(
 					chainCtx,
 					client.WithAdditionalFunctionality(additonalClientFunctionality...),
-					client.WithDialOptions(dialOptions...),
+					client.WithDialOptions(
+						dial.WithDialTimeout(dialTimeout),
+						dial.WithDialOptions(dialOptions...)),
 					client.WithoutRefresh(),
 					client.WithName(name),
 				),

--- a/pkg/networkservice/common/connect/server_test.go
+++ b/pkg/networkservice/common/connect/server_test.go
@@ -501,7 +501,7 @@ func TestConnectServer_DialTimeout(t *testing.T) {
 			next.NewNetworkServiceClient(
 				dial.NewClient(context.Background(),
 					dial.WithDialTimeout(100*time.Millisecond),
-					dial.WithDialOptions(grpc.WithInsecure(), grpc.WithBlock()),
+					dial.WithDialOptions(grpc.WithInsecure()),
 				),
 				connect.NewClient(),
 			),

--- a/pkg/networkservice/common/dial/client.go
+++ b/pkg/networkservice/common/dial/client.go
@@ -42,7 +42,9 @@ type dialClient struct {
 
 // NewClient - returns new dial chain element
 func NewClient(chainCtx context.Context, opts ...Option) networkservice.NetworkServiceClient {
-	o := &option{}
+	o := &option{
+		dialTimeout: time.Second,
+	}
 	for _, opt := range opts {
 		opt(o)
 	}

--- a/pkg/networkservice/common/dial/dialer.go
+++ b/pkg/networkservice/common/dial/dialer.go
@@ -42,7 +42,7 @@ type dialer struct {
 func newDialer(ctx context.Context, dialTimeout time.Duration, dialOptions ...grpc.DialOption) *dialer {
 	return &dialer{
 		ctx:         ctx,
-		dialOptions: dialOptions,
+		dialOptions: append(append([]grpc.DialOption{}, dialOptions...), grpc.WithReturnConnectionError()),
 		dialTimeout: dialTimeout,
 	}
 }

--- a/pkg/networkservice/common/monitor/passthrough_test.go
+++ b/pkg/networkservice/common/monitor/passthrough_test.go
@@ -23,15 +23,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
@@ -126,8 +128,8 @@ func (m *MonitorPassThroughSuite) StartPassThroughEndpoints(connectTo *url.URL) 
 						client.WithoutRefresh(),
 						client.WithAuthorizeClient(null.NewClient()),
 						client.WithDialOptions(
-							sandbox.DialOptions()...,
-						),
+							dial.WithDialTimeout(sandbox.DialTimeout),
+							dial.WithDialOptions(sandbox.DialOptions()...)),
 					),
 				),
 			),
@@ -166,8 +168,8 @@ func (m *MonitorPassThroughSuite) StartClient(connectTo *url.URL) {
 		client.WithClientURL(connectTo),
 		client.WithAuthorizeClient(null.NewClient()),
 		client.WithDialOptions(
-			sandbox.DialOptions()...,
-		),
+			dial.WithDialTimeout(sandbox.DialTimeout),
+			dial.WithDialOptions(sandbox.DialOptions()...)),
 	)
 }
 

--- a/pkg/tools/sandbox/builder.go
+++ b/pkg/tools/sandbox/builder.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgrproxy"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/memory"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/proxydns"
 	registryconnect "github.com/networkservicemesh/sdk/pkg/registry/common/connect"
@@ -293,10 +294,11 @@ func (b *Builder) newNSMgrProxy() *NSMgrEntry {
 			b.generateTokenFunc,
 			nsmgrproxy.WithListenOn(entry.URL),
 			nsmgrproxy.WithName(entry.Name),
-			nsmgrproxy.WithDialOptions(dialOptions...),
+			nsmgrproxy.WithDialOptions(
+				dial.WithDialTimeout(DialTimeout),
+				dial.WithDialOptions(dialOptions...)),
 			nsmgrproxy.WithRegistryConnectOptions(
-				registryconnect.WithDialOptions(dialOptions...),
-			),
+				registryconnect.WithDialOptions(dialOptions...)),
 		)
 		serve(ctx, b.t, entry.URL, entry.Register)
 

--- a/pkg/tools/sandbox/dial_options.go
+++ b/pkg/tools/sandbox/dial_options.go
@@ -55,7 +55,6 @@ func DialOptions(options ...DialOption) []grpc.DialOption {
 		grpc.WithTransportCredentials(
 			grpcfdTransportCredentials(insecure.NewCredentials()),
 		),
-		grpc.WithBlock(),
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
 			grpc.PerRPCCredentials(token.NewPerRPCCredentials(opts.tokenGenerator)),

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -21,9 +21,10 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
-	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
@@ -31,6 +32,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/connect"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/dial"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanismtranslation"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -63,8 +65,9 @@ func (n *Node) NewNSMgr(
 	options := []nsmgr.Option{
 		nsmgr.WithName(name),
 		nsmgr.WithAuthorizeServer(authorize.NewServer(authorize.Any())),
-		nsmgr.WithDialOptions(dialOptions...),
-		nsmgr.WithDialTimeout(DialTimeout),
+		nsmgr.WithDialOptions(
+			dial.WithDialTimeout(DialTimeout),
+			dial.WithDialOptions(dialOptions...)),
 	}
 
 	if n.domain.Registry != nil {
@@ -127,10 +130,10 @@ func (n *Node) NewForwarder(
 							ctx,
 							client.WithName(entry.Name),
 							client.WithAdditionalFunctionality(
-								mechanismtranslation.NewClient(),
-							),
-							client.WithDialOptions(dialOptions...),
-							client.WithDialTimeout(DialTimeout),
+								mechanismtranslation.NewClient()),
+							client.WithDialOptions(
+								dial.WithDialTimeout(DialTimeout),
+								dial.WithDialOptions(dialOptions...)),
 							client.WithoutRefresh(),
 						),
 					),
@@ -212,9 +215,10 @@ func (n *Node) NewClient(
 	return client.NewClient(
 		ctx,
 		client.WithClientURL(CloneURL(n.NSMgr.URL)),
-		client.WithDialOptions(DialOptions(WithTokenGenerator(generatorFunc))...),
 		client.WithAuthorizeClient(authorize.NewClient(authorize.Any())),
 		client.WithAdditionalFunctionality(additionalFunctionality...),
-		client.WithDialTimeout(DialTimeout),
+		client.WithDialOptions(
+			dial.WithDialTimeout(DialTimeout),
+			dial.WithDialOptions(DialOptions(WithTokenGenerator(generatorFunc))...)),
 	)
 }


### PR DESCRIPTION
## Description
1. Adds `WithReturnConnectionError` to dialer gRPC dial options.

`grpc.DialContext` needs either `WithBlock` or `WithReturnConnectionError` to be set as a dial option if we want context cancel/timeout to stop dial attempt. `WithReturnConnectionError` is more verbose in case of error, so it should be always used with dialer.

2. Makes client use `dial.Option` instead of `grpcDialOption` and timeout, adds default timeout to dialer.

Dialer should have its own default timeout. No timeout in such case is a bad solution, because we need to manually set some default `1s` timeout in all places where we are using it.

## Issue
Closes #1109.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
