### PR TITLE
[vxlan] store generated vni in metadata

### DIFF
--- a/pkg/networkservice/common/mechanisms/vxlan/vni/metadata.go
+++ b/pkg/networkservice/common/mechanisms/vxlan/vni/metadata.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vni
+
+import (
+	"context"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+)
+
+type key struct{}
+
+func store(ctx context.Context, isClient bool, vni uint32) {
+	metadata.Map(ctx, isClient).Store(key{}, vni)
+}
+
+func delete(ctx context.Context, isClient bool) {
+	metadata.Map(ctx, isClient).Delete(key{})
+}
+
+func load(ctx context.Context, isClient bool) (value uint32, ok bool) {
+	rawValue, ok := metadata.Map(ctx, isClient).Load(key{})
+	if !ok {
+		return
+	}
+	value, ok = rawValue.(uint32)
+	return value, ok
+}
+
+func loadOrStore(ctx context.Context, isClient bool, vni uint32) (value uint32, ok bool) {
+	rawValue, ok := metadata.Map(ctx, isClient).LoadOrStore(key{}, vni)
+	if !ok {
+		return
+	}
+	value, ok = rawValue.(uint32)
+	return value, ok
+}

--- a/pkg/networkservice/common/mechanisms/vxlan/vni/server_test.go
+++ b/pkg/networkservice/common/mechanisms/vxlan/vni/server_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/vxlan/vni"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 )
 
 func TestVNIServer(t *testing.T) {
@@ -49,7 +50,10 @@ func TestVNIServer(t *testing.T) {
 	}
 	vxlan.ToMechanism(request.GetConnection().GetMechanism()).SetSrcIP(net.ParseIP("192.0.2.1"))
 	var port uint16 = 0
-	server := next.NewNetworkServiceServer(vni.NewServer(net.ParseIP("192.0.2.2")))
+	server := next.NewNetworkServiceServer(
+		metadata.NewServer(),
+		vni.NewServer(net.ParseIP("192.0.2.2")),
+	)
 	conn, err := server.Request(context.Background(), request)
 	assert.Nil(t, err)
 	assert.NotNil(t, conn)
@@ -60,7 +64,10 @@ func TestVNIServer(t *testing.T) {
 	assert.NotEqual(t, 0, mechanism.VNI())
 
 	port = 4466
-	server = next.NewNetworkServiceServer(vni.NewServer(net.ParseIP("192.0.2.2"), vni.WithTunnelPort(port)))
+	server = next.NewNetworkServiceServer(
+		metadata.NewServer(),
+		vni.NewServer(net.ParseIP("192.0.2.2"), vni.WithTunnelPort(port)),
+	)
 	conn, err = server.Request(context.Background(), request)
 	assert.Nil(t, err)
 	assert.NotNil(t, conn)


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
If we already created `vxlan` interface but in the next request we received mechanism with empty parameters (one of the healing situation) - we will re-generate `vni`, which is wrong.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
