### PR TITLE
qfix: memory registry should be used directly in nsmgr on discovering forwarders

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -174,7 +174,9 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		nsRegistry,
 	)
 
-	var nseInMemoryRegistry = registrychain.NewNetworkServiceEndpointRegistryServer(
+	var nseInMemoryRegistry = memory.NewNetworkServiceEndpointRegistryServer()
+
+	var nseRegistry = registrychain.NewNetworkServiceEndpointRegistryServer(
 		setlogoption.NewNetworkServiceEndpointRegistryServer(map[string]string{"name": fmt.Sprintf("NetworkServiceRegistryServer.%v", opts.name)}),
 		registryclientinfo.NewNetworkServiceEndpointRegistryServer(),
 		registryserialize.NewNetworkServiceEndpointRegistryServer(),
@@ -182,11 +184,9 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
 		registryrecvfd.NewNetworkServiceEndpointRegistryServer(), // Allow to receive a passed files
 		registrysendfd.NewNetworkServiceEndpointRegistryServer(),
-		memory.NewNetworkServiceEndpointRegistryServer(),
+		nseInMemoryRegistry,
 		localbypass.NewNetworkServiceEndpointRegistryServer(opts.url),
 	)
-
-	var nseRegistry = nseInMemoryRegistry
 
 	if opts.regURL != nil {
 		// Add remote registry

--- a/pkg/networkservice/chains/nsmgr/unix_test.go
+++ b/pkg/networkservice/chains/nsmgr/unix_test.go
@@ -39,7 +39,6 @@ import (
 )
 
 func Test_Local_NoURLUsecase(t *testing.T) {
-	t.Skip("https://github.com/networkservicemesh/sdk/issues/1118")
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
@@ -85,7 +84,6 @@ func Test_Local_NoURLUsecase(t *testing.T) {
 }
 
 func Test_MultiForwarderSendfd(t *testing.T) {
-	t.Skip("https://github.com/networkservicemesh/sdk/issues/1118")
 	if runtime.GOOS != "linux" {
 		t.Skip("sendfd works only on linux")
 	}


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
