### PR TITLE
Fix in level setting for log

### DIFF
--- a/pkg/networkservice/core/trace/common_test.go
+++ b/pkg/networkservice/core/trace/common_test.go
@@ -112,6 +112,7 @@ func TestTraceOutput(t *testing.T) {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		DisableTimestamp: true,
 	})
+	logrus.SetLevel(logrus.TraceLevel)
 	log.EnableTracing(true)
 
 	// Create a chain with modifying elements
@@ -166,6 +167,7 @@ func TestErrorOutput(t *testing.T) {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		DisableTimestamp: true,
 	})
+	logrus.SetLevel(logrus.TraceLevel)
 	log.EnableTracing(true)
 
 	// Create a chain with modifying elements

--- a/pkg/tools/log/logruslogger/logruslogger.go
+++ b/pkg/tools/log/logruslogger/logruslogger.go
@@ -199,7 +199,6 @@ func New(ctx context.Context) log.Logger {
 func FromSpan(ctx context.Context, span opentracing.Span, operation string) (context.Context, log.Logger, func()) {
 	entry := logrus.WithFields(log.Fields(ctx))
 	entry.Logger.SetFormatter(newFormatter())
-	entry.Logger.SetLevel(logrus.TraceLevel)
 
 	var info *traceCtxInfo
 	ctx, info = withTraceInfo(ctx)


### PR DESCRIPTION
Signed-off-by: Mikhail Avramenko <avramenkomihail15@gmail.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Log level trace was hardcoded for unknown reasons. It caused always setting log level to trace no matter what was passed from config in `cmd`.

## Issue link
closes https://github.com/networkservicemesh/cmd-nsmgr/issues/417

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
