### PR TITLE
heal: use path from previous connection

### DIFF
--- a/pkg/networkservice/common/begin/event_factory.go
+++ b/pkg/networkservice/common/begin/event_factory.go
@@ -99,7 +99,6 @@ func (f *eventFactoryClient) Request(opts ...Option) <-chan error {
 				if request.GetConnection() != nil {
 					request.GetConnection().Mechanism = nil
 					request.GetConnection().NetworkServiceEndpointName = ""
-					request.GetConnection().GetPath().PathSegments = request.GetConnection().GetPath().PathSegments[:request.GetConnection().GetPath().GetIndex()+1]
 				}
 			}
 			ctx, cancel := f.ctxFunc()


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
We need to use old path for heal request to check resources from a previous connection 


## Issue link
https://github.com/networkservicemesh/sdk/issues/1166


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
