### PR TITLE
Added protection for log data races

### DIFF
--- a/pkg/tools/expire/manager.go
+++ b/pkg/tools/expire/manager.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/clock"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
 // Executor is a serialize.Executor interface
@@ -46,7 +47,7 @@ type timer struct {
 // NewManager creates a new Manager
 func NewManager(ctx context.Context) *Manager {
 	return &Manager{
-		ctx:       ctx,
+		ctx:       log.WithCopyFields(ctx),
 		clockTime: clock.FromContext(ctx),
 	}
 }

--- a/pkg/tools/log/logger.go
+++ b/pkg/tools/log/logger.go
@@ -89,6 +89,18 @@ func WithFields(ctx context.Context, fields map[string]interface{}) context.Cont
 	return context.WithValue(ctx, logFieldsKey, fields)
 }
 
+// WithCopyFields - returns context with copied log fields to prevent data races
+func WithCopyFields(ctx context.Context) context.Context {
+	fields := Fields(ctx)
+
+	newFields := map[string]interface{}{}
+	for k, v := range fields {
+		newFields[k] = v
+	}
+
+	return WithFields(ctx, newFields)
+}
+
 // IsTracingEnabled - checks if it is allowed to use traces
 func IsTracingEnabled() bool {
 	return atomic.LoadInt32(&isTracingEnabled) != 0


### PR DESCRIPTION
Signed-off-by: Mikhail Avramenko <avramenkomihail15@gmail.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Should prevent data races in expire chain element

## Issue link
https://github.com/networkservicemesh/cmd-nsmgr/issues/419

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [x] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
