### PR TITLE
Add localcache chain element

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -48,6 +48,7 @@ import (
 	registryconnect "github.com/networkservicemesh/sdk/pkg/registry/common/connect"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/expire"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/localbypass"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/localcache"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
 	registryrecvfd "github.com/networkservicemesh/sdk/pkg/registry/common/recvfd"
 	registrysendfd "github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
@@ -173,7 +174,9 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		nsRegistry,
 	)
 
-	var nseInMemoryRegistry = memory.NewNetworkServiceEndpointRegistryServer()
+	var nseInMemoryRegistry = localcache.NewNetworkServiceEndpointRegistryServer(
+		memory.NewNetworkServiceEndpointRegistryServer(),
+	)
 
 	var nseRegistry = registrychain.NewNetworkServiceEndpointRegistryServer(
 		setlogoption.NewNetworkServiceEndpointRegistryServer(map[string]string{"name": fmt.Sprintf("NetworkServiceRegistryServer.%v", opts.name)}),

--- a/pkg/registry/common/localcache/doc.go
+++ b/pkg/registry/common/localcache/doc.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package localcache adds possible to cache nses even if remote registry is not available
+package localcache

--- a/pkg/registry/common/localcache/nse_server.go
+++ b/pkg/registry/common/localcache/nse_server.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localcache
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+)
+
+type tail struct{}
+
+func (t *tail) Register(_ context.Context, r *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	return r, nil
+}
+
+func (t *tail) Find(_ *registry.NetworkServiceEndpointQuery, _ registry.NetworkServiceEndpointRegistry_FindServer) error {
+	return nil
+}
+
+func (t *tail) Unregister(context.Context, *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	return new(empty.Empty), nil
+}
+
+var _ registry.NetworkServiceEndpointRegistryServer = &tail{}
+
+type localcacheNSEServer struct {
+	cache registry.NetworkServiceEndpointRegistryServer
+}
+
+// NewNetworkServiceEndpointRegistryServer - returns a new chain element that stores registered nses even if remote registry is unavailable
+func NewNetworkServiceEndpointRegistryServer(cache registry.NetworkServiceEndpointRegistryServer) registry.NetworkServiceEndpointRegistryServer {
+	c := next.NewNetworkServiceEndpointRegistryServer(cache, &tail{})
+	return &localcacheNSEServer{
+		cache: c,
+	}
+}
+
+func (n *localcacheNSEServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	r, err := next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
+	if err != nil {
+		return n.cache.Register(ctx, nse)
+	}
+	return n.cache.Register(ctx, r)
+}
+
+func (n *localcacheNSEServer) Find(query *registry.NetworkServiceEndpointQuery, server registry.NetworkServiceEndpointRegistry_FindServer) error {
+	_ = next.NetworkServiceEndpointRegistryServer(server.Context()).Find(query, server)
+	return n.cache.Find(query, server)
+}
+
+func (n *localcacheNSEServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	ret, err := next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
+	retC, errC := n.cache.Unregister(ctx, nse)
+	if err != nil && errC != nil {
+		return ret, errors.Wrap(err, errC.Error())
+	}
+	if errC != nil {
+		return retC, errC
+	}
+	return ret, err
+}


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

## Description
`Nsmgr` shouldn't return an error on `Register()` call even if remote `registry` is not available.

## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/issues/460


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
