### PR TITLE
[qfix] Delete only generated vxlan vni on error

### DIFF
--- a/pkg/networkservice/common/mechanisms/vxlan/vni/server.go
+++ b/pkg/networkservice/common/mechanisms/vxlan/vni/server.go
@@ -92,7 +92,8 @@ func (v *vniServer) Request(ctx context.Context, request *networkservice.Network
 		return conn, err
 	}
 
-	if vni, ok := load(ctx, metadata.IsClient(v)); ok {
+	vni, loaded := load(ctx, metadata.IsClient(v))
+	if loaded {
 		mechanism.SetVNI(vni)
 		logger.WithField("vni", vni).Debugf("vni loaded from metadata")
 	} else {
@@ -114,7 +115,7 @@ func (v *vniServer) Request(ctx context.Context, request *networkservice.Network
 	}
 
 	conn, err := next.Server(ctx).Request(ctx, request)
-	if err != nil {
+	if err != nil && !loaded {
 		delete(ctx, metadata.IsClient(v))
 		v.Map.Delete(k)
 


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

## Description
We need to delete `vni` on error only if we generated it on that `Request`

## Issue link
Fixes: https://github.com/networkservicemesh/integration-k8s-packet/issues/166


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing locally
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
