### PR TITLE
Modified refresh client to calculate the shortest token expiry

### DIFF
--- a/pkg/networkservice/common/timeout/server_test.go
+++ b/pkg/networkservice/common/timeout/server_test.go
@@ -241,6 +241,9 @@ func TestTimeoutServer_RefreshFailure(t *testing.T) {
 				injecterror.WithRequestErrorTimes(1, -1),
 				injecterror.WithCloseErrorTimes(),
 			),
+			updatetoken.NewServer(func(_ credentials.AuthInfo) (string, time.Time, error) {
+				return "test", clock.FromContext(ctx).Now().Add(tokenTimeout), nil
+			}),
 			connServer,
 		),
 		tokenTimeout,


### PR DESCRIPTION
Signed-off-by: Oleg Solodkov <oleg.solodkov@xored.com>

## Description
Refresh client calculates the shortest token expiry and sets refresh time according to that value

## Issue link
Fixes #1189

## How Has This Been Tested?
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

## Types of changes
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
