### PR TITLE
Add cidr chain element

### DIFF
--- a/pkg/networkservice/common/cidr/cidr_test.go
+++ b/pkg/networkservice/common/cidr/cidr_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/cidr"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newRequest() *networkservice.NetworkServiceRequest {
+	return &networkservice.NetworkServiceRequest{
+		Connection: &networkservice.Connection{
+			Context: &networkservice.ConnectionContext{
+				IpContext: new(networkservice.IPContext),
+			},
+		},
+	}
+}
+
+func newServer(prefixes, excludePrefixes []string) networkservice.NetworkServiceServer {
+	return next.NewNetworkServiceServer(
+		updatepath.NewServer("cidr-server"),
+		metadata.NewServer(),
+		cidr.NewServer(prefixes, excludePrefixes),
+	)
+}
+
+func newClient(prefixLen uint32, family networkservice.IpFamily_Family, server networkservice.NetworkServiceServer) networkservice.NetworkServiceClient {
+	return next.NewNetworkServiceClient(
+		updatepath.NewClient("cidr-client"),
+		metadata.NewClient(),
+		cidr.NewClient(prefixLen, family),
+		/* Server part */
+		adapters.NewServerToClient(
+			server,
+		),
+	)
+}
+
+func validateConn(t *testing.T, conn *networkservice.Connection, prefix, route string) {
+	require.Equal(t, conn.Context.IpContext.ExtraPrefixes[0], prefix)
+	require.Equal(t, conn.Context.IpContext.SrcRoutes, []*networkservice.Route{
+		{
+			Prefix: route,
+		},
+	})
+}
+
+//nolint:dupl
+func TestIPv4(t *testing.T) {
+	prefixes := []string{"192.168.0.0/16"}
+	server := newServer(prefixes, nil)
+
+	request := newRequest()
+	client1 := newClient(24, networkservice.IpFamily_IPV4, server)
+	conn1, err := client1.Request(context.Background(), request)
+	require.NoError(t, err)
+	validateConn(t, conn1, "192.168.0.0/24", "192.168.0.0/16")
+
+	// refresh
+	conn1, err = client1.Request(context.Background(), request)
+	require.NoError(t, err)
+	validateConn(t, conn1, "192.168.0.0/24", "192.168.0.0/16")
+
+	client2 := newClient(24, networkservice.IpFamily_IPV4, server)
+	conn2, err := client2.Request(context.Background(), newRequest())
+	require.NoError(t, err)
+	validateConn(t, conn2, "192.168.1.0/24", "192.168.0.0/16")
+
+	_, err = client1.Close(context.Background(), conn1)
+	require.NoError(t, err)
+
+	client3 := newClient(24, networkservice.IpFamily_IPV4, server)
+	conn3, err := client3.Request(context.Background(), newRequest())
+	require.NoError(t, err)
+	validateConn(t, conn3, "192.168.0.0/24", "192.168.0.0/16")
+
+	client4 := newClient(24, networkservice.IpFamily_IPV4, server)
+	conn4, err := client4.Request(context.Background(), newRequest())
+	require.NoError(t, err)
+	validateConn(t, conn4, "192.168.2.0/24", "192.168.0.0/16")
+}
+
+//nolint:dupl
+func TestIPv6(t *testing.T) {
+	prefixes := []string{"2001:db8::/96"}
+	server := newServer(prefixes, nil)
+
+	request := newRequest()
+	client1 := newClient(112, networkservice.IpFamily_IPV6, server)
+	conn1, err := client1.Request(context.Background(), request)
+	require.NoError(t, err)
+	validateConn(t, conn1, "2001:db8::/112", "2001:db8::/96")
+
+	// refresh
+	conn1, err = client1.Request(context.Background(), request)
+	require.NoError(t, err)
+	validateConn(t, conn1, "2001:db8::/112", "2001:db8::/96")
+
+	client2 := newClient(112, networkservice.IpFamily_IPV6, server)
+	conn2, err := client2.Request(context.Background(), newRequest())
+	require.NoError(t, err)
+	validateConn(t, conn2, "2001:db8::1:0/112", "2001:db8::/96")
+
+	_, err = client1.Close(context.Background(), conn1)
+	require.NoError(t, err)
+
+	client3 := newClient(112, networkservice.IpFamily_IPV6, server)
+	conn3, err := client3.Request(context.Background(), newRequest())
+	require.NoError(t, err)
+	validateConn(t, conn3, "2001:db8::/112", "2001:db8::/96")
+
+	client4 := newClient(112, networkservice.IpFamily_IPV6, server)
+	conn4, err := client4.Request(context.Background(), newRequest())
+	require.NoError(t, err)
+	validateConn(t, conn4, "2001:db8::2:0/112", "2001:db8::/96")
+}
+
+//nolint:dupl
+func TestIPv4Exclude(t *testing.T) {
+	prefixes := []string{"192.168.0.0/16"}
+	excludePrefixes := []string{"192.168.0.0/24"}
+	server := newServer(prefixes, excludePrefixes)
+
+	client1 := newClient(24, networkservice.IpFamily_IPV4, server)
+	conn1, err := client1.Request(context.Background(), newRequest())
+	require.NoError(t, err)
+	require.NotEqual(t, "192.168.0.0/24", conn1.Context.IpContext.ExtraPrefixes[0])
+	require.Equal(t, conn1.Context.IpContext.SrcRoutes, []*networkservice.Route{
+		{
+			Prefix: "192.168.0.0/16",
+		},
+	})
+}

--- a/pkg/networkservice/common/cidr/client.go
+++ b/pkg/networkservice/common/cidr/client.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+)
+
+type cidrClient struct {
+	prefixLen uint32
+	family    networkservice.IpFamily_Family
+}
+
+// NewClient creates a NetworkServiceClient chain element that requests ExtraPrefix
+func NewClient(prefixLen uint32, family networkservice.IpFamily_Family) networkservice.NetworkServiceClient {
+	return &cidrClient{
+		prefixLen: prefixLen,
+		family:    family,
+	}
+}
+
+func (c *cidrClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	conn := request.GetConnection()
+	if conn.GetContext() == nil {
+		conn.Context = &networkservice.ConnectionContext{}
+	}
+	if conn.GetContext().GetIpContext() == nil {
+		conn.Context.IpContext = &networkservice.IPContext{}
+	}
+	ipContext := conn.GetContext().GetIpContext()
+
+	// Add ExtraPrefixRequest if there is no extra prefix
+	if ipContext.GetExtraPrefixes() == nil {
+		ipContext.ExtraPrefixRequest = append(ipContext.ExtraPrefixRequest, &networkservice.ExtraPrefixRequest{
+			AddrFamily:      &networkservice.IpFamily{Family: c.family},
+			PrefixLen:       c.prefixLen,
+			RequiredNumber:  1,
+			RequestedNumber: 1,
+		})
+	}
+
+	// Add ExtraPrefix to the route for the remote side
+	loaded := load(ctx, metadata.IsClient(c))
+	if !loaded && ipContext.GetExtraPrefixes() != nil {
+		for _, item := range ipContext.ExtraPrefixes {
+			ipContext.DstRoutes = append(ipContext.DstRoutes, &networkservice.Route{
+				Prefix: item,
+			})
+		}
+		store(ctx, metadata.IsClient(c))
+	}
+
+	conn, err := next.Client(ctx).Request(ctx, request, opts...)
+	if err != nil && !loaded {
+		delete(ctx, metadata.IsClient(c))
+	}
+
+	return conn, err
+}
+
+func (c *cidrClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	delete(ctx, metadata.IsClient(c))
+	return next.Client(ctx).Close(ctx, conn, opts...)
+}

--- a/pkg/networkservice/common/cidr/doc.go
+++ b/pkg/networkservice/common/cidr/doc.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cidr provides networkservice.NetworkService chain elements for creating loopback interface
+package cidr

--- a/pkg/networkservice/common/cidr/metadata.go
+++ b/pkg/networkservice/common/cidr/metadata.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr
+
+import (
+	"context"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+)
+
+type key struct{}
+
+func store(ctx context.Context, isClient bool) {
+	metadata.Map(ctx, isClient).Store(key{}, struct{}{})
+}
+
+func delete(ctx context.Context, isClient bool) {
+	metadata.Map(ctx, isClient).Delete(key{})
+}
+
+func load(ctx context.Context, isClient bool) (ok bool) {
+	_, ok = metadata.Map(ctx, isClient).Load(key{})
+	return ok
+}

--- a/pkg/networkservice/common/cidr/server.go
+++ b/pkg/networkservice/common/cidr/server.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr
+
+import (
+	"context"
+	"sync"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+	"github.com/networkservicemesh/sdk/pkg/tools/prefixpool"
+)
+
+type cidrServer struct {
+	pool *prefixpool.PrefixPool
+
+	prefixes        []string
+	excludePrefixes []string
+	once            sync.Once
+	initErr         error
+}
+
+// NewServer creates a NetworkServiceServer chain element that allocates CIDR from some global prefix
+// and saves it in ExtraPrefix
+func NewServer(prefixes, excludePrefixes []string) networkservice.NetworkServiceServer {
+	return &cidrServer{
+		prefixes:        prefixes,
+		excludePrefixes: excludePrefixes,
+	}
+}
+
+func (c *cidrServer) init() {
+	if len(c.prefixes) == 0 {
+		c.initErr = errors.New("required one or more prefixes")
+		return
+	}
+	var err error
+	if c.pool, err = prefixpool.New(c.prefixes...); err != nil {
+		c.initErr = errors.New("required one or more prefixes")
+		return
+	}
+	if _, err = c.pool.ExcludePrefixes(c.excludePrefixes); err != nil {
+		c.initErr = errors.New("unable to exclude additional prefixes")
+		return
+	}
+}
+
+func (c *cidrServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	c.once.Do(c.init)
+	if c.initErr != nil {
+		return nil, c.initErr
+	}
+
+	conn := request.GetConnection()
+	if conn.GetContext() == nil {
+		conn.Context = &networkservice.ConnectionContext{}
+	}
+	if conn.GetContext().GetIpContext() == nil {
+		conn.Context.IpContext = &networkservice.IPContext{}
+	}
+	ipContext := conn.GetContext().GetIpContext()
+
+	/* If we already have extra prefixes, exclude them from the next CIDR allocations */
+	if ipContext.GetExtraPrefixes() != nil {
+		if _, err := c.pool.ExcludePrefixes(ipContext.GetExtraPrefixes()); err != nil {
+			return nil, err
+		}
+	} else if ipContext.GetExtraPrefixRequest() != nil {
+		/* Else, extract a new one if there is ExtraPrefixRequest */
+		requested, err := c.pool.ExtractPrefixes(request.GetConnection().GetId(), ipContext.GetExtraPrefixRequest()...)
+		if err != nil {
+			return nil, err
+		}
+		ipContext.ExtraPrefixes = append(ipContext.ExtraPrefixes, requested...)
+		ipContext.ExtraPrefixRequest = nil
+
+		for i := 0; i < len(requested); i++ {
+			ipContext.DstRoutes = append(ipContext.DstRoutes, &networkservice.Route{
+				Prefix: requested[i],
+			})
+		}
+	}
+
+	conn, err := next.Server(ctx).Request(ctx, request)
+	if err != nil {
+		extraPrefixes := request.GetConnection().GetContext().GetIpContext().GetExtraPrefixes()
+		if len(extraPrefixes) != 0 {
+			_ = c.pool.ReleaseExcludedPrefixes(extraPrefixes)
+		}
+		return conn, err
+	}
+
+	ipContext = conn.GetContext().GetIpContext()
+	if ok := load(ctx, metadata.IsClient(c)); !ok {
+		/* Set srcRoutes = prefixes because these hosts should be available through this element */
+		for i := 0; i < len(c.prefixes); i++ {
+			ipContext.SrcRoutes = append(ipContext.SrcRoutes, &networkservice.Route{
+				Prefix: c.prefixes[i],
+			})
+		}
+		store(ctx, metadata.IsClient(c))
+	}
+
+	return conn, err
+}
+
+func (c *cidrServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	extraPrefixes := conn.GetContext().GetIpContext().GetExtraPrefixes()
+	if len(extraPrefixes) != 0 {
+		_ = c.pool.ReleaseExcludedPrefixes(extraPrefixes)
+	}
+	delete(ctx, metadata.IsClient(c))
+
+	return next.Server(ctx).Close(ctx, conn)
+}


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
This chain element extracts prefix from some global prefix and writes it to `ExtraPrefixes` - [Link](https://github.com/networkservicemesh/api/blob/main/pkg/api/networkservice/connectioncontext.proto#L65) 


## Issue link
https://github.com/networkservicemesh/cmd-nse-vl3-vpp/issues/1


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
