### PR TITLE
qfix: Add support for empty routes with metadata

### DIFF
--- a/pkg/networkservice/common/discover/match_selector.go
+++ b/pkg/networkservice/common/discover/match_selector.go
@@ -59,7 +59,7 @@ func matchEndpoint(clockTime clock.Clock, nsLabels map[string]string, ns *regist
 			continue
 		}
 
-		if match.GetMetadata() != nil && len(match.Routes) == 0 {
+		if match.GetMetadata() != nil && len(match.Routes) == 0 && len(nseCandidates) == 0 {
 			break
 		}
 

--- a/pkg/networkservice/common/discover/match_selector.go
+++ b/pkg/networkservice/common/discover/match_selector.go
@@ -59,6 +59,10 @@ func matchEndpoint(clockTime clock.Clock, nsLabels map[string]string, ns *regist
 			continue
 		}
 
+		if match.GetMetadata() != nil && len(match.Routes) == 0 {
+			break
+		}
+
 		return nseCandidates
 	}
 

--- a/pkg/networkservice/common/discoverforwarder/server.go
+++ b/pkg/networkservice/common/discoverforwarder/server.go
@@ -107,6 +107,7 @@ func (d *discoverForwarderServer) Request(ctx context.Context, request *networks
 				storeForwarderName(ctx, candidate.Name)
 				return resp, nil
 			}
+			logger.Errorf("forwarder=%v url=%v returned error=%v", candidate.Name, candidate.Url, err.Error())
 		}
 
 		return nil, errors.New("all forwarders failed")


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Currently discover is not supported matches with empty routes but with metadata.


## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/pull/505


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
