### PR TITLE
Remove forwarder name from discoverforwarder metadata

### DIFF
--- a/pkg/networkservice/common/discoverforwarder/server.go
+++ b/pkg/networkservice/common/discoverforwarder/server.go
@@ -137,7 +137,11 @@ func (d *discoverForwarderServer) Request(ctx context.Context, request *networks
 		return nil, errors.WithStack(err)
 	}
 
-	return next.Server(ctx).Request(clienturlctx.WithClientURL(ctx, u), request)
+	conn, err := next.Server(ctx).Request(clienturlctx.WithClientURL(ctx, u), request)
+	if err != nil {
+		storeForwarderName(ctx, "")
+	}
+	return conn, err
 }
 
 func (d *discoverForwarderServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Remove forwarder name from discoverforwarder metadata if it is not available

For example, heal case :
`nsc -> nsmgr1(restarted) -> fwd1 -> nsmgr2 -> fwd2(restarted) -> nse`
If `nsmgr1` dies, `nsmgr2` doesn't receive `Close()` and continues to store old `fwd2` name in metadata


## Issue link
https://github.com/networkservicemesh/sdk/issues/1196


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
