### PR TITLE
qfix: sendfd registry cases are not working

### DIFF
--- a/pkg/registry/chains/client/ns_client.go
+++ b/pkg/registry/chains/client/ns_client.go
@@ -41,15 +41,22 @@ func NewNetworkServiceRegistryClient(ctx context.Context, connectTo *url.URL, op
 	}
 
 	return chain.NewNetworkServiceRegistryClient(
-		begin.NewNetworkServiceRegistryClient(),
-		retry.NewNetworkServiceRegistryClient(ctx),
-		heal.NewNetworkServiceRegistryClient(ctx),
-		clienturl.NewNetworkServiceRegistryClient(connectTo),
-		clientconn.NewNetworkServiceRegistryClient(),
-		dial.NewNetworkServiceRegistryClient(ctx,
-			dial.WithDialOptions(clientOpts.dialOptions...),
-			dial.WithDialTimeout(time.Second),
-		),
-		connect.NewNetworkServiceRegistryClient(),
+		append(
+			[]registry.NetworkServiceRegistryClient{
+				begin.NewNetworkServiceRegistryClient(),
+				retry.NewNetworkServiceRegistryClient(ctx),
+				heal.NewNetworkServiceRegistryClient(ctx),
+				clienturl.NewNetworkServiceRegistryClient(connectTo),
+				clientconn.NewNetworkServiceRegistryClient(),
+				dial.NewNetworkServiceRegistryClient(ctx,
+					dial.WithDialOptions(clientOpts.dialOptions...),
+					dial.WithDialTimeout(time.Second),
+				),
+			},
+			append(
+				clientOpts.nsAdditionalFunctionality,
+				connect.NewNetworkServiceRegistryClient(),
+			)...,
+		)...,
 	)
 }

--- a/pkg/registry/chains/client/nse_client.go
+++ b/pkg/registry/chains/client/nse_client.go
@@ -42,15 +42,22 @@ func NewNetworkServiceEndpointRegistryClient(ctx context.Context, connectTo *url
 	}
 
 	return chain.NewNetworkServiceEndpointRegistryClient(
-		begin.NewNetworkServiceEndpointRegistryClient(),
-		retry.NewNetworkServiceEndpointRegistryClient(ctx),
-		heal.NewNetworkServiceEndpointRegistryClient(ctx),
-		refresh.NewNetworkServiceEndpointRegistryClient(ctx),
-		clienturl.NewNetworkServiceEndpointRegistryClient(connectTo),
-		clientconn.NewNetworkServiceEndpointRegistryClient(),
-		dial.NewNetworkServiceEndpointRegistryClient(ctx,
-			dial.WithDialOptions(clientOpts.dialOptions...),
-		),
-		connect.NewNetworkServiceEndpointRegistryClient(),
+		append(
+			[]registry.NetworkServiceEndpointRegistryClient{
+				begin.NewNetworkServiceEndpointRegistryClient(),
+				retry.NewNetworkServiceEndpointRegistryClient(ctx),
+				heal.NewNetworkServiceEndpointRegistryClient(ctx),
+				refresh.NewNetworkServiceEndpointRegistryClient(ctx),
+				clienturl.NewNetworkServiceEndpointRegistryClient(connectTo),
+				clientconn.NewNetworkServiceEndpointRegistryClient(),
+				dial.NewNetworkServiceEndpointRegistryClient(ctx,
+					dial.WithDialOptions(clientOpts.dialOptions...),
+				),
+			},
+			append(
+				clientOpts.nseAdditionalFunctionality,
+				connect.NewNetworkServiceEndpointRegistryClient(),
+			)...,
+		)...,
 	)
 }

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -37,6 +37,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/roundrobin"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/recvfd"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
@@ -203,8 +204,12 @@ func (n *Node) NewEndpoint(
 
 		log.FromContext(ctx).Infof("%s: NSE %s serve on %v", n.domain.Name, nse.Name, serveURL)
 
-		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(ctx, CloneURL(n.NSMgr.URL),
-			registryclient.WithDialOptions(dialOptions...))
+		entry.NetworkServiceEndpointRegistryClient = registryclient.NewNetworkServiceEndpointRegistryClient(
+			ctx,
+			CloneURL(n.NSMgr.URL),
+			registryclient.WithDialOptions(dialOptions...),
+			registryclient.WithNSEAdditionalFunctionality(sendfd.NewNetworkServiceEndpointRegistryClient()),
+		)
 
 		n.registerEndpoint(ctx, nse, nseClone, entry.NetworkServiceEndpointRegistryClient)
 	})


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
```
    client_endpoint_test.go:173: 
        	Error Trace:	client_endpoint_test.go:173
        	Error:      	Expected nil, but got: Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = DeadlineExceeded desc = context deadline exceeded
        	Test:       	TestRegistryTestSuite/TestNSmgrEndpointSendFD
Jan 26 17:59:35.707[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(60.1)                                                              rpc error: code = Canceled desc = grpc: the client connection is closing;	Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.logError;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/common.go:206;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*beginTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:57;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*endTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:81;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/common/trimpath.(*trimpathClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/common/trimpath/client.go:38;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*beginTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:55;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*endTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:81;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/common/null.(*nullClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/common/null/client.go:43;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*beginTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:55;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*endTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:81;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/common/dial.(*dialClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/common/dial/client.go:95;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*beginTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:55;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*endTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:81;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/common/null.(*nullClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/common/null/client.go:43;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*beginTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:55;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*endTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:81;	github.com/networkservicemesh/sdk/pkg/networkservice/core/next.(*nextClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/next/client.go:60;	github.com/networkservicemesh/sdk/pkg/networkservice/common/clientconn.(*clientConnClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/common/clientconn/client.go:45;	github.com/networkservicemesh/sdk/pkg/networkservice/core/trace.(*beginTraceClient).Request;		/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220125183301-5eed3d991b70/pkg/networkservice/core/trace/client.go:55;	
Jan 26 17:59:35.707[31m [ERRO] [type:registry] [0m(7.1)         Error returned from api/pkg/api/registry/networkServiceRegistryFindClient.Recv: rpc error: code = DeadlineExceeded desc = context deadline exceeded
Jan 26 17:59:35.707[37m [TRAC] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(59.1)                                                             request-response=null
Jan 26 17:59:35.707[37m [TRAC] [type:registry] [0m(2.2)    find-response={"network_service_endpoint":{"name":"nse-1"},"watch":true}
Jan 26 17:59:35.707[37m [TRAC] [type:registry] [0m(1.2)   find-response={"network_service_endpoint":{"name":"nse-1"},"watch":true}
Jan 26 17:59:35.707[36m [INFO] [0m(1.4)   Exit requested. Uptime: 15.960303252s
Jan 26 17:59:35.707[37m [TRAC] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(37.1)                                       request-response=null
Jan 26 17:59:35.707[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(59.2)                                                             Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.707[31m [ERRO] [type:registry] [0m(7.1)         Error returned from api/pkg/api/registry/networkServiceRegistryFindClient.Recv: rpc error: code = DeadlineExceeded desc = context deadline exceeded
Jan 26 17:59:35.707[31m [ERRO] [type:registry] [0m(7.1)         Error returned from api/pkg/api/registry/networkServiceRegistryFindClient.Recv: rpc error: code = DeadlineExceeded desc = context deadline exceeded
Jan 26 17:59:35.707[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(58.1)                                                            Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.707[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(37.2)                                       Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.707[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(57.1)                                                           Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(56.1)                                                          Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(55.1)                                                         Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(54.1)                                                        Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(53.1)                                                       Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.708[37m [DEBU] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [connID:2d635a07-e687-48a9-8a9a-283d8a05449a] [metadata:client] [type:networkService] [0m(52.1)                                                      metadata deleted
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(52.2)                                                      Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.707[31m [ERRO] [cmd:NsmgrTestSetup] [fs.monitorFile:/var/lib/networkservicemesh/config/excluded_prefixes.yaml] [0mcontext canceled
Jan 26 17:59:35.708[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(36.1)                                      Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.708[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(35.1)                                     Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(51.1)                                                     Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.708[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(34.1)                                    Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.708[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(33.1)                                   Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(50.1)                                                    Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(49.1)                                                   Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing
Jan 26 17:59:35.708[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(32.1)                                  Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.708[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(31.1)                                 Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(48.3)                                                  0. An error during select endpoint nse-1 --> Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing: all candidates have failed
Jan 26 17:59:35.708[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(30.1)                                Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(47.1)                                                 0. An error during select endpoint nse-1 --> Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing: all candidates have failed
Jan 26 17:59:35.708[31m [ERRO] [id:5f9070f0-0f0d-49f9-a447-09b4d3de24d2] [type:networkService] [0m(29.1)                               Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Unavailable desc = error reading from server: EOF
Jan 26 17:59:35.708[31m [ERRO] [id:2d635a07-e687-48a9-8a9a-283d8a05449a] [type:networkService] [0m(46.1)                                                0. An error during select endpoint nse-1 --> Error returned from sdk/pkg/networkservice/common/connect/connectClient.Request: rpc error: code = Canceled desc = grpc: the client connection is closing: all candidates have failed
--- FAIL: TestRegistryTestSuite (17.87s)
    --- PASS: TestRegistryTestSuite/TestNSMgrEndpointRegister (1.06s)
    --- FAIL: TestRegistryTestSuite/TestNSmgrEndpointSendFD (16.05s)
```

## Issue link
Closes https://github.com/networkservicemesh/cmd-nsmgr/pull/445

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
