### PR TITLE
Refactor: nsmgr WithrRgistry option has useless registry dial options

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -78,7 +78,6 @@ type serverOptions struct {
 	dialOptions          []grpc.DialOption
 	dialTimeout          time.Duration
 	regURL               *url.URL
-	regDialOptions       []grpc.DialOption
 	name                 string
 	url                  string
 	forwarderServiceName string
@@ -120,10 +119,9 @@ func WithAuthorizeServer(authorizeServer networkservice.NetworkServiceServer) Op
 }
 
 // WithRegistry sets URL and dial options to reach the upstream registry, if not passed memory storage will be used.
-func WithRegistry(regURL *url.URL, regDialOptions ...grpc.DialOption) Option {
+func WithRegistry(regURL *url.URL) Option {
 	return func(o *serverOptions) {
 		o.regURL = regURL
-		o.regDialOptions = regDialOptions
 	}
 }
 

--- a/pkg/tools/sandbox/node.go
+++ b/pkg/tools/sandbox/node.go
@@ -74,7 +74,7 @@ func (n *Node) NewNSMgr(
 	}
 
 	if n.domain.Registry != nil {
-		options = append(options, nsmgr.WithRegistry(CloneURL(n.domain.Registry.URL), dialOptions...))
+		options = append(options, nsmgr.WithRegistry(CloneURL(n.domain.Registry.URL)))
 	}
 
 	if serveURL.Scheme != "unix" {


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
regDialOptions are not used more.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [X] Refactoring
- [ ] CI
