### PR TITLE
qfix: Localbypass is not working properly in integration-tests scenarious

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -177,12 +177,7 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		nsRegistry,
 	)
 
-	var nseRegistry = chain.NewNetworkServiceEndpointRegistryServer(
-		begin.NewNetworkServiceEndpointRegistryServer(),
-		registryclientinfo.NewNetworkServiceEndpointRegistryServer(),
-		expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
-		registryrecvfd.NewNetworkServiceEndpointRegistryServer(), // Allow to receive a passed files
-		registrysendfd.NewNetworkServiceEndpointRegistryServer(),
+	var remoteOrLocalRegistry = chain.NewNetworkServiceEndpointRegistryServer(
 		localbypass.NewNetworkServiceEndpointRegistryServer(opts.url),
 		registryconnect.NewNetworkServiceEndpointRegistryServer(
 			chain.NewNetworkServiceEndpointRegistryClient(
@@ -196,21 +191,22 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 			),
 		),
 	)
-	var remoteOrLocalRegistry = nseRegistry
 
 	if opts.regURL == nil {
-		remoteOrLocalRegistry = memory.NewNetworkServiceEndpointRegistryServer()
-
-		nseRegistry = chain.NewNetworkServiceEndpointRegistryServer(
-			begin.NewNetworkServiceEndpointRegistryServer(),
-			registryclientinfo.NewNetworkServiceEndpointRegistryServer(),
-			expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
-			registryrecvfd.NewNetworkServiceEndpointRegistryServer(),
-			registrysendfd.NewNetworkServiceEndpointRegistryServer(),
-			remoteOrLocalRegistry,
+		remoteOrLocalRegistry = chain.NewNetworkServiceEndpointRegistryServer(
+			memory.NewNetworkServiceEndpointRegistryServer(),
 			localbypass.NewNetworkServiceEndpointRegistryServer(opts.url),
 		)
 	}
+
+	var nseRegistry = chain.NewNetworkServiceEndpointRegistryServer(
+		begin.NewNetworkServiceEndpointRegistryServer(),
+		registryclientinfo.NewNetworkServiceEndpointRegistryServer(),
+		expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
+		registryrecvfd.NewNetworkServiceEndpointRegistryServer(), // Allow to receive a passed files
+		registrysendfd.NewNetworkServiceEndpointRegistryServer(),
+		remoteOrLocalRegistry,
+	)
 
 	// Construct Endpoint
 	rv.Endpoint = endpoint.NewServer(ctx, tokenGenerator,


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description

The current localbypass order is not correct.

Actual:
```
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(18.1)                    network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"tcp://10.244.1.20:5001","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(23)                       ⎆ api/pkg/api/registry/networkServiceEndpointRegistryFindClient.Recv()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(17)                 ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(17.1)                   network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"unix:///proc/1/fd/11","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(16)                ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(16.1)                  network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"inode://1048806/7095217","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(15)               ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(15.1)                 network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"inode://1048806/7095217","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(14)              ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(14.1)                network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"inode://1048806/7095217","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(13)             ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(13.1)               network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"inode://1048806/7095217","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(12)            ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(12.1)              network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"inode://1048806/7095217","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
```
Expected
```
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(18.1)                    network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"tcp://10.244.1.20:5001","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(23)                       ⎆ api/pkg/api/registry/networkServiceEndpointRegistryFindClient.Recv()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(17)                 ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(17.1)                   network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":"unix:///proc/1/fd/11","expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(16)                ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(16.1)                  network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":**"unix:///proc/1/fd/11"**,"expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(15)               ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(15.1)                 network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":**"unix:///proc/1/fd/11"**,"expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(14)              ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(14.1)                network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":**"unix:///proc/1/fd/11"**,"expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(13)             ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(13.1)               network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},**"unix:///proc/1/fd/11"**,"expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(12)            ⎆ sdk/pkg/registry/core/streamcontext/networkServiceEndpointRegistryFindServer.Send()
Jan 27 17:56:54.379[37m [TRAC] [type:registry] [0m(12.1)              network service endpoint={"name":"forwarder-vpp-pt2q7","network_service_names":["forwarder"],"network_service_labels":{"forwarder":{"labels":{"nodeName":"kind-worker","p2p":"true"}}},"url":**"unix:///proc/1/fd/11"**,"expiration_time":{"seconds":1643306254,"nanos":137086614},"initial_registration_time":{"seconds":1643306194,"nanos":143158306}}
```

## Issue link
Closes https://github.com/networkservicemesh/integration-k8s-kind/pull/565


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [X] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
