### PR TITLE
fix: Issue when register endpoints with same name

### DIFF
--- a/pkg/registry/chains/proxydns/server_ns_test.go
+++ b/pkg/registry/chains/proxydns/server_ns_test.go
@@ -18,6 +18,7 @@ package proxydns_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -132,6 +133,7 @@ func TestLocalDomain_NetworkServiceRegistry(t *testing.T) {
 		},
 	)
 	require.Nil(t, err)
+	require.True(t, strings.Contains(expected.GetName(), "@"+domain1.Name))
 
 	cc, err := grpc.DialContext(ctx, grpcutils.URLToTarget(domain1.Registry.URL), grpc.WithBlock(), grpc.WithInsecure())
 	require.Nil(t, err)
@@ -142,7 +144,7 @@ func TestLocalDomain_NetworkServiceRegistry(t *testing.T) {
 
 	stream, err := client.Find(context.Background(), &registryapi.NetworkServiceQuery{
 		NetworkService: &registryapi.NetworkService{
-			Name: expected.Name + "@" + domain1.Name,
+			Name: expected.Name,
 		},
 	})
 

--- a/pkg/registry/common/dnsresolve/ns_server.go
+++ b/pkg/registry/common/dnsresolve/ns_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -66,6 +66,8 @@ func (d *dnsNSResolveServer) Register(ctx context.Context, ns *registry.NetworkS
 	ns.Name = interdomain.Target(ns.Name)
 	resp, err := next.NetworkServiceRegistryServer(ctx).Register(ctx, ns)
 
+	resp.Name = interdomain.Join(resp.Name, domain)
+
 	return resp, err
 }
 
@@ -103,6 +105,9 @@ func (d *dnsNSResolveServer) Unregister(ctx context.Context, ns *registry.Networ
 	}
 	ctx = clienturlctx.WithClientURL(ctx, url)
 	ns.Name = interdomain.Target(ns.Name)
+	defer func() {
+		ns.Name = interdomain.Join(ns.Name, domain)
+	}()
 	return next.NetworkServiceRegistryServer(ctx).Unregister(ctx, ns)
 }
 

--- a/pkg/registry/common/dnsresolve/nse_server.go
+++ b/pkg/registry/common/dnsresolve/nse_server.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2022 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -117,7 +119,7 @@ func (d *dnsNSEResolveServer) Register(ctx context.Context, nse *registry.Networ
 		return nil, err
 	}
 
-	translateNSE(nse, func(s string) string {
+	translateNSE(resp, func(s string) string {
 		return interdomain.Join(s, domain)
 	})
 


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Previously we reworked the registry https://github.com/networkservicemesh/sdk/pull/1213.

This conceptually fixes https://github.com/networkservicemesh/cmd-registry-k8s/issues/250 but during testing it, I found a few missed nits in https://github.com/networkservicemesh/sdk/pull/1213.

This PR covers case https://github.com/networkservicemesh/cmd-registry-k8s/issues/250 and fixes it.


## Issue link
Fixes https://github.com/networkservicemesh/cmd-registry-k8s/issues/250


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [X] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
