### PR TITLE
fix: remove leaking of client connections on find queries

### DIFF
--- a/pkg/registry/common/dial/ns_client.go
+++ b/pkg/registry/common/dial/ns_client.go
@@ -140,6 +140,7 @@ func (c *dialNSClient) Find(ctx context.Context, in *registry.NetworkServiceQuer
 	}
 
 	clientconn.Store(ctx, di)
+	defer clientconn.Delete(ctx)
 
 	resp, err := next.NetworkServiceRegistryClient(ctx).Find(ctx, in, opts...)
 	if err != nil {

--- a/pkg/registry/common/dial/nse_client.go
+++ b/pkg/registry/common/dial/nse_client.go
@@ -140,6 +140,7 @@ func (c *dialNSEClient) Find(ctx context.Context, in *registry.NetworkServiceEnd
 	}
 
 	clientconn.Store(ctx, di)
+	defer clientconn.Delete(ctx)
 
 	resp, err := next.NetworkServiceEndpointRegistryClient(ctx).Find(ctx, in, opts...)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description

Memory profile for 100 refreshes before the fix is:

[Before fix.pdf](https://github.com/networkservicemesh/sdk/files/8045106/no-fix.pdf)


Memory profile for 100 refreshes after the fix is:

[After fix.pdf](https://github.com/networkservicemesh/sdk/files/8045107/fix.pdf)



## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
