### PR TITLE
IPContext merged in begin chain element (#1231)

### DIFF
--- a/pkg/networkservice/common/begin/merge.go
+++ b/pkg/networkservice/common/begin/merge.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2021 Cisco and/or its affiliates.
+// Copyright (c) 2021-2022 Cisco and/or its affiliates.
+// Copyright (c) 2022 Nordix Foundation
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -36,7 +37,8 @@ func mergeConnection(returnedConnection, requestedConnection, connection *networ
 func mergeConnectionContext(returnedConnectionContext, requestedConnectionContext, connectioncontext *networkservice.ConnectionContext) *networkservice.ConnectionContext {
 	rv := proto.Clone(connectioncontext).(*networkservice.ConnectionContext)
 	if !proto.Equal(returnedConnectionContext, requestedConnectionContext) {
-		// TODO: IPContext, DNSContext, EthernetContext, do we need to do MTU?
+		// TODO: DNSContext, EthernetContext, do we need to do MTU?
+		rv.IpContext = requestedConnectionContext.IpContext
 		rv.ExtraContext = mergeMapStringString(returnedConnectionContext.GetExtraContext(), requestedConnectionContext.GetExtraContext(), connectioncontext.GetExtraContext())
 	}
 	return rv


### PR DESCRIPTION
## Description
Using the Client chain, the network service client cannot update the IPContext without the `mergeConnectionContext` function implemented. A NSC might want to update it if it needs to add, update or delete routes, src IP addresses (VIPs...), policies...

## Issue link
https://github.com/networkservicemesh/sdk/issues/1231

## How Has This Been Tested?
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

I am not sure what would be the full impact in NSM, but in my environment, I managed to update IPs and policies without any issue.

## Types of changes
- [x] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
