### PR TITLE
call livenessCheck periodically

### DIFF
--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Cisco and/or its affiliates.
+// Copyright (c) 2021-2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -37,9 +37,7 @@ type healClient struct {
 
 // NewClient - returns a new heal client chain element
 func NewClient(chainCtx context.Context, opts ...Option) networkservice.NetworkServiceClient {
-	o := &option{
-		livelinessCheck: func(_ *networkservice.Connection) bool { return false },
-	}
+	o := &option{}
 	for _, opt := range opts {
 		opt(o)
 	}

--- a/pkg/networkservice/common/heal/eventloop.go
+++ b/pkg/networkservice/common/heal/eventloop.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	attemptAfter          = time.Millisecond * 200
-	livenessCheckInterval = time.Microsecond * 200
+	livenessCheckInterval = time.Millisecond * 500
 )
 
 type eventLoop struct {
@@ -150,7 +150,7 @@ func (cev *eventLoop) waitDataPlaneEvent() <-chan struct{} {
 			case <-ticker.C():
 				if !cev.livelinessCheck(cev.conn) {
 					// Datapath broken, start healing
-					println("EVENT Datapath broken, start healing")
+					log.FromContext(cev.chainCtx).Info("Datapath broken, start healing")
 					return
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Nikolay Chunosov <n.chunosov@yandex.ru>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Check data-plane aliveness periodically, not only after a control-plane event happens

## Issue link
https://github.com/networkservicemesh/sdk/issues/1187


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
