### PR TITLE
Update configuration to be consistent with spire v1.2.2

### DIFF
--- a/pkg/tools/spire/server.conf.go
+++ b/pkg/tools/spire/server.conf.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -18,11 +18,11 @@ package spire
 
 const (
 	spireServerConfFileName = "server/server.conf"
-	spireServerRegSock      = "spire-registration.sock"
+	spireServerRegSock      = "api.sock"
 	spireServerConfContents = `server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    registration_uds_path = "%[1]s/%[2]s"
+    socket_path = "%[1]s/%[2]s"
     trust_domain = "example.org"
     data_dir = "%[1]s/data"
     log_level = "WARN"
@@ -46,10 +46,6 @@ plugins {
     NodeAttestor "join_token" {
         plugin_data {
         }
-    }
-
-    NodeResolver "noop" {
-        plugin_data {}
     }
 
     KeyManager "memory" {

--- a/pkg/tools/spire/start.go
+++ b/pkg/tools/spire/start.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020 Cisco and/or its affiliates.
+// Copyright (c) 2020-2022 Cisco and/or its affiliates.
 //
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -61,7 +61,7 @@ func logrusEntry(ctx context.Context) *logrus.Entry {
 // AddEntry - adds an entry to the spire server for parentID, spiffeID, and selector
 //            parentID is usually the same as the agentID provided to Start()
 func AddEntry(ctx context.Context, parentID, spiffeID, selector string) error {
-	cmdStr := "spire-server entry create -parentID %s -spiffeID %s -selector %s -registrationUDSPath %s/spire-registration.sock"
+	cmdStr := "spire-server entry create -parentID %s -spiffeID %s -selector %s -socketPath %s/api.sock"
 	cmdStr = fmt.Sprintf(cmdStr, parentID, spiffeID, selector, spireRoot)
 	return exechelper.Run(cmdStr,
 		exechelper.WithStdout(logrusEntry(ctx).WithField("cmd", cmdStr).WriterLevel(logrus.InfoLevel)),
@@ -123,7 +123,7 @@ func Start(options ...Option) <-chan error {
 
 	// Health check the Spire Server
 	if err = execHealthCheck(opt.ctx,
-		fmt.Sprintf("spire-server healthcheck -registrationUDSPath %s/spire-registration.sock", spireRoot),
+		fmt.Sprintf("spire-server healthcheck -socketPath %s/api.sock", spireRoot),
 		exechelper.WithStdout(logrusEntry(opt.ctx).WithField("cmd", "spire-server healthcheck").WriterLevel(logrus.InfoLevel)),
 		exechelper.WithStderr(logrusEntry(opt.ctx).WithField("cmd", "spire-server healthcheck").WriterLevel(logrus.WarnLevel)),
 	); err != nil {
@@ -142,7 +142,7 @@ func Start(options ...Option) <-chan error {
 	}
 
 	// Get the SpireServers Token
-	cmdStr := "spire-server token generate -spiffeID %s -registrationUDSPath %s/spire-registration.sock"
+	cmdStr := "spire-server token generate -spiffeID %s -socketPath %s/api.sock"
 	cmdStr = fmt.Sprintf(cmdStr, opt.agentID, spireRoot)
 	outputBytes, err := exechelper.Output(cmdStr,
 		exechelper.WithStdout(logrusEntry(opt.ctx).WithField("cmd", cmdStr).WriterLevel(logrus.InfoLevel)),


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Spire `v1.2.2` has different configuration. The main update: `registrationUDSPath` was removed.


## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/5379


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
