### PR TITLE
fix: default registry dial timeout could be not enough for some clusters

### DIFF
--- a/pkg/registry/common/dial/ns_client.go
+++ b/pkg/registry/common/dial/ns_client.go
@@ -163,7 +163,7 @@ func (c *dialNSClient) Find(ctx context.Context, in *registry.NetworkServiceQuer
 // NewNetworkServiceRegistryClient - returns a new null client that does nothing but call next.NetworkServiceRegistryClient(ctx).
 func NewNetworkServiceRegistryClient(chainCtx context.Context, opts ...Option) registry.NetworkServiceRegistryClient {
 	o := &option{
-		dialTimeout: time.Millisecond * 100,
+		dialTimeout: time.Millisecond * 300,
 	}
 	for _, opt := range opts {
 		opt(o)

--- a/pkg/registry/common/dial/nse_client.go
+++ b/pkg/registry/common/dial/nse_client.go
@@ -163,7 +163,7 @@ func (c *dialNSEClient) Find(ctx context.Context, in *registry.NetworkServiceEnd
 // NewNetworkServiceEndpointRegistryClient - returns a new null client that does nothing but call next.NetworkServiceEndpointRegistryClient(ctx).
 func NewNetworkServiceEndpointRegistryClient(chainCtx context.Context, opts ...Option) registry.NetworkServiceEndpointRegistryClient {
 	o := &option{
-		dialTimeout: time.Millisecond * 100,
+		dialTimeout: time.Millisecond * 300,
 	}
 	for _, opt := range opts {
 		opt(o)


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Reported by  @damiankopyto in the nsm slack

We face with this on the real production cluster
```go
Apr 20 19:40:35.817[37m [TRAC] [type:registry] [0m(5.1)       find={"network_service":{"name":"nse-composition","payload":"ETHERNET"}}
Apr 20 19:40:35.992[31m [ERRO] [type:registry] [0m(5.2)       can not dial to registry:5002, err failed to dial registry:5002: context deadline exceeded. Deleting clientconn...
Apr 20 19:40:35.994[31m [ERRO] [type:registry] [0m(5.3)       failed to dial registry:5002: context deadline exceeded
Apr 20 19:40:35.994[31m [ERRO] [type:registry] [0m(4.2)      failed to dial registry:5002: context deadline exceeded
Apr 20 19:40:35.994[31m [ERRO] [type:registry] [0m(3.2)     failed to dial registry:5002: context deadline exceeded
Apr 20 19:40:35.994[31m [ERRO] [type:registry] [0m(2.3)    failed to dial registry:5002: context deadline exceeded
Apr 20 19:40:35.994[31m [ERRO] [type:registry] [0m(1.2)   failed to dial registry:5002: context deadline exceeded
```

We also tried to remove CPU limits for the nsmgr but it did not help to @damiankopyto

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [X] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
