### PR TITLE
fix: enable trace logging only if logrus.LogLevel() is TRACE

### DIFF
--- a/pkg/tools/log/logger.go
+++ b/pkg/tools/log/logger.go
@@ -20,6 +20,8 @@ package log
 import (
 	"context"
 	"sync/atomic"
+
+	"github.com/sirupsen/logrus"
 )
 
 type contextKeyType string
@@ -77,7 +79,8 @@ func WithLog(ctx context.Context, log ...Logger) context.Context {
 
 // IsTracingEnabled - checks if it is allowed to use traces
 func IsTracingEnabled() bool {
-	return atomic.LoadInt32(&isTracingEnabled) != 0
+	// TODO: Rework this within https://github.com/networkservicemesh/sdk/issues/1272
+	return atomic.LoadInt32(&isTracingEnabled) != 0 && logrus.GetLevel() == logrus.TraceLevel
 }
 
 // EnableTracing - enable/disable traces


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Description

> Error prints can still be seen in the logs after deploying the basic kernel2kernel example from the repo:

```
Apr 21 11:31:46.821 [ERRO] [type:registry] (7.3)         failed to dial unix:///var/lib/networkservicemesh/nsm.io.sock: context deadline exceeded
Apr 21 11:31:46.821 [ERRO] [type:registry] (6.2)        failed to dial unix:///var/lib/networkservicemesh/nsm.io.sock: context deadline exceeded
Apr 21 11:31:46.821 [ERRO] [type:registry] (5.3)       failed to dial unix:///var/lib/networkservicemesh/nsm.io.sock: context deadline exceeded
Apr 21 11:31:46.821 [ERRO] [type:registry] (4.2)      failed to dial unix:///var/lib/networkservicemesh/nsm.io.sock: context deadline exceeded
Apr 21 11:31:46.821 [ERRO] [type:registry] (3.2)     failed to dial unix:///var/lib/networkservicemesh/nsm.io.sock: context deadline exceeded
Apr 21 11:31:46.821 [ERRO] [retryNSEClient:Register] [type:registry] (2.89)    try attempt has failed: failed to dial unix:///var/lib/networkservicemesh/nsm.io.sock: context deadline exceeded

[Richárd Kővári](https://app.slack.com/team/U02U0J7LGU8)  [6 days ago](https://cloud-native.slack.com/archives/CHQNNUPN1/p1650540992192639?thread_ts=1648557444.028369&cid=CHQNNUPN1)
Apr 21 11:32:27.401 [ERRO] [type:registry] (7.1)         rpc error: code = Canceled desc = context canceled;    Error returned from api/pkg/api/registry/networkServiceEndpointRegistryFindClient.Recv; github.com/networkservicemesh/sdk/pkg/registry/core/trace.logError;              /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/core/trace/common.go:38;   github.com/networkservicemesh/sdk/pkg/registry/core/trace.(*traceNetworkServiceEndpointRegistryFindClient).Recv;         /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/core/trace/nse_registry.go:56;      github.com/networkservicemesh/sdk/pkg/registry/core/trace.(*traceNetworkServiceEndpointRegistryFindClient).Recv;                /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/core/trace/nse_registry.go:47;      github.com/networkservicemesh/sdk/pkg/registry/common/dial.(*dialNSEFindClient).Recv;           /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/common/dial/nse_client.go:118;      github.com/networkservicemesh/sdk/pkg/registry/core/trace.(*traceNetworkServiceEndpointRegistryFindClient).Recv;         /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/core/trace/nse_registry.go:47;     github.com/networkservicemesh/sdk/pkg/registry/core/trace.(*traceNetworkServiceEndpointRegistryFindClient).Recv;         /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/core/trace/nse_registry.go:47;      github.com/networkservicemesh/sdk/pkg/registry/core/trace.(*traceNetworkServiceEndpointRegistryFindClient).Recv;                /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/core/trace/nse_registry.go:47;      github.com/networkservicemesh/sdk/pkg/registry/core/trace.(*traceNetworkServiceEndpointRegistryFindClient).Recv;                /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/core/trace/nse_registry.go:47;      github.com/networkservicemesh/sdk/pkg/registry/common/heal.(*healNSEClient).Register.func1;              /root/go/pkg/mod/github.com/networkservicemesh/sdk@v0.5.1-0.20220415125440-009c3f3a16bd/pkg/registry/common/heal/nse_client.go:68;      runtime.goexit;         /go/src/runtime/asm_amd64.s:1371;
Apr 21 11:32:27.401 [ERRO] [type:registry] (7.1)         Error returned from api/pkg/api/registry/networkServiceEndpointRegistryFindClient.Recv: rpc error: code = Canceled desc = context canceled
Apr 21 11:32:27.401 [ERRO] [type:registry] (7.1)         Error returned from api/pkg/api/registry/networkServiceEndpointRegistryFindClient.Recv: rpc error: code = Canceled desc = context canceled
Apr 21 11:32:27.401 [ERRO] [type:registry] (7.1)         Error returned from api/pkg/api/registry/networkServiceEndpointRegistryFindClient.Recv: rpc error: code = Canceled desc = context canceled
Apr 21 11:32:27.401 [ERRO] [type:registry] (7.1)         Error returned from api/pkg/api/registry/networkServiceEndpointRegistryFindClient.Recv: rpc error: code = Canceled desc = context canceled
Apr 21 11:32:27.401 [ERRO] [type:registry] (7.1)         Error returned from api/pkg/api/registry/networkServiceEndpointRegistryFindClient.Recv: rpc error: code = Canceled desc = context cancele
```

This PR temporary fixes the problem with logging from the community for all NSM applications.

## Issue link
<!--- Please link to the issue here. -->


We're planning to rework and simplify logging within https://github.com/networkservicemesh/sdk/issues/1272

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
