### PR TITLE
qfix: remove extra registry lookup for the inter-domain network service resolve

### DIFF
--- a/pkg/networkservice/chains/nsmgrproxy/server_test.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server_test.go
@@ -38,7 +38,9 @@ import (
 	kernelmech "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/checks/checkrequest"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/tools/interdomain"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -79,7 +81,9 @@ func TestNSMGR_InterdomainUseCase(t *testing.T) {
 		NetworkServiceNames: []string{nsReg.Name},
 	}
 
-	cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken)
+	cluster2.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, checkrequest.NewServer(t, func(t *testing.T, nsr *networkservice.NetworkServiceRequest) {
+		require.False(t, interdomain.Is(nsr.GetConnection().GetNetworkService()))
+	}))
 
 	nsc := cluster1.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken)
 

--- a/pkg/networkservice/common/interdomainbypass/server.go
+++ b/pkg/networkservice/common/interdomainbypass/server.go
@@ -52,12 +52,15 @@ func (n *interdomainBypassServer) Request(ctx context.Context, request *networks
 		return next.Server(ctx).Request(ctx, request)
 	}
 	originalNSEName := request.GetConnection().NetworkServiceEndpointName
+	originalNS := request.GetConnection().NetworkService
 	request.GetConnection().NetworkServiceEndpointName = interdomain.Target(originalNSEName)
+	request.GetConnection().NetworkService = interdomain.Target(originalNS)
 	resp, err := next.Server(ctx).Request(ctx, request)
 	if err != nil {
 		return nil, err
 	}
 	resp.NetworkServiceEndpointName = originalNSEName
+	resp.NetworkService = originalNS
 	return resp, nil
 }
 
@@ -69,12 +72,15 @@ func (n *interdomainBypassServer) Close(ctx context.Context, conn *networkservic
 		ctx = clienturlctx.WithClientURL(ctx, u)
 		return next.Server(ctx).Close(ctx, conn)
 	}
-	originalNSEName := conn.NetworkServiceEndpointName
+	originalNSEName := conn.GetNetworkServiceEndpointName()
+	originalNS := conn.GetNetworkService()
 	conn.NetworkServiceEndpointName = interdomain.Target(originalNSEName)
+	conn.NetworkService = interdomain.Target(originalNS)
 	resp, err := next.Server(ctx).Close(ctx, conn)
 	if err != nil {
 		return nil, err
 	}
 	conn.NetworkServiceEndpointName = originalNSEName
+	conn.NetworkService = originalNS
 	return resp, nil
 }


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
This PR fixes problem with translating interdomain queries from the remote site to the local. 
It is also fixes  vl3 + interdomain cases, because we are selecing fib table based on the service name. 

As an additional benifit it also removes extra registry lookup for the inter-domain network service resolve




## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
