### PR TITLE
[qfix] Use register response in registry heal

### DIFF
--- a/pkg/registry/common/heal/ns_client.go
+++ b/pkg/registry/common/heal/ns_client.go
@@ -49,19 +49,19 @@ func (c *healNSClient) Register(ctx context.Context, ns *registry.NetworkService
 
 	factory := begin.FromContext(ctx)
 
-	if v, ok := c.LoadAndDelete(ns.GetName()); ok {
+	if v, ok := c.LoadAndDelete(resp.GetName()); ok {
 		v()
 	}
 	healCtx, cancel := context.WithCancel(c.ctx)
 
-	stream, streamErr := next.NetworkServiceRegistryClient(ctx).Find(healCtx, &registry.NetworkServiceQuery{NetworkService: &registry.NetworkService{Name: ns.GetName()}, Watch: true}, opts...)
+	stream, streamErr := next.NetworkServiceRegistryClient(ctx).Find(healCtx, &registry.NetworkServiceQuery{NetworkService: &registry.NetworkService{Name: resp.GetName()}, Watch: true}, opts...)
 
 	if streamErr != nil {
 		cancel()
 		return nil, streamErr
 	}
 
-	c.Store(ns.GetName(), cancel)
+	c.Store(resp.GetName(), cancel)
 
 	go func() {
 		for {

--- a/pkg/registry/common/heal/nse_client.go
+++ b/pkg/registry/common/heal/nse_client.go
@@ -49,19 +49,19 @@ func (c *healNSEClient) Register(ctx context.Context, nse *registry.NetworkServi
 
 	factory := begin.FromContext(ctx)
 
-	if v, ok := c.LoadAndDelete(nse.GetName()); ok {
+	if v, ok := c.LoadAndDelete(resp.GetName()); ok {
 		v()
 	}
 	healCtx, cancel := context.WithCancel(c.ctx)
 
-	stream, streamErr := next.NetworkServiceEndpointRegistryClient(ctx).Find(healCtx, &registry.NetworkServiceEndpointQuery{NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: nse.GetName()}, Watch: true}, opts...)
+	stream, streamErr := next.NetworkServiceEndpointRegistryClient(ctx).Find(healCtx, &registry.NetworkServiceEndpointQuery{NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{Name: resp.GetName()}, Watch: true}, opts...)
 
 	if streamErr != nil {
 		cancel()
 		return nil, streamErr
 	}
 
-	c.Store(nse.GetName(), cancel)
+	c.Store(resp.GetName(), cancel)
 
 	go func() {
 		for {


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
It's better to use the response rather than the initial parameter in registry heal

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
