### PR TITLE
fix: remove go-routine that restore resolv.conf file to prevent resolv.conf…

### DIFF
--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -129,11 +129,6 @@ func (c *dnsContextClient) initialize() {
 
 	c.storeOriginalResolvConf()
 
-	go func() {
-		defer c.restoreResolvConf()
-		<-c.chainContext.Done()
-	}()
-
 	c.dnsConfigManager.Store("", &networkservice.DNSConfig{
 		SearchDomains: r.Value(dnscontext.AnyDomain),
 		DnsServerIps:  r.Value(dnscontext.NameserverProperty),

--- a/pkg/networkservice/connectioncontext/dnscontext/client_test.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client_test.go
@@ -66,15 +66,15 @@ func Test_DNSContextClient_Restart(t *testing.T) {
 
 	require.Never(t, func() bool {
 		for {
+			// #nosec
 			b, err := ioutil.ReadFile(corefilePath)
 			if err == nil {
 				time.Sleep(time.Millisecond * 50)
+				continue
 			}
 			return string(b) != expectedEmptyCorefile
 		}
-
 	}, time.Second/2, time.Millisecond*100)
-
 }
 
 func Test_DNSContextClient_Usecases(t *testing.T) {

--- a/pkg/networkservice/connectioncontext/dnscontext/client_test.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func Test_DNSContextClient_Restart(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
 	corefilePath := filepath.Join(t.TempDir(), "corefile")
 	resolveConfigPath := filepath.Join(t.TempDir(), "resolv.conf")
 	err := ioutil.WriteFile(resolveConfigPath, []byte("nameserver 8.8.4.4\n"), os.ModePerm)
@@ -48,8 +49,8 @@ func Test_DNSContextClient_Restart(t *testing.T) {
 		denial 0
 	}
 }`
-	for i := 0; i < 1; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var c = chain.NewNetworkServiceClient(
 			dnscontext.NewClient(
@@ -60,10 +61,20 @@ func Test_DNSContextClient_Restart(t *testing.T) {
 		)
 		_, _ = c.Request(ctx, &networkservice.NetworkServiceRequest{})
 
-		requireFileChanged(ctx, t, corefilePath, expectedEmptyCorefile)
-
 		cancel()
 	}
+
+	require.Never(t, func() bool {
+		for {
+			b, err := ioutil.ReadFile(corefilePath)
+			if err == nil {
+				time.Sleep(time.Millisecond * 50)
+			}
+			return string(b) != expectedEmptyCorefile
+		}
+
+	}, time.Second/2, time.Millisecond*100)
+
 }
 
 func Test_DNSContextClient_Usecases(t *testing.T) {


### PR DESCRIPTION
… file data lose

Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description

I saw when cmd-nsc-init did incorrect restore file that makes data inconsistent.

Seems like on CPU bound POD (cmd-nsc-init is CPU bounded)  the goroutine could be stopped before work done.



## Logs
```
/etc # cat resolv.conf
nameserver 127.0.0.1/etc # 
/etc # cat resolv.conf.restore 
/etc # cat resolv.conf.restore 
/etc # cat resolv.conf
/etc # cat resolv.conf.restore 
/etc # cat coredns/Corefile 
. {
        fanout . 172.16.1.2
        log
        reload
        cache {
                denial 0
        }
}. {
        fanout . 172.16.1.2
        log
        reload
        cache {
                denial 0
        }
}/etc # exit
```

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
