### PR TITLE
fix: nscs cant properly restore resolv.conf file on packet+kind setup

### DIFF
--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/edwarnicke/serialize"
@@ -48,7 +49,7 @@ type dnsContextClient struct {
 
 // NewClient creates a new DNS client chain component. Setups all DNS traffic to the localhost. Monitors DNS configs from connections.
 func NewClient(options ...DNSOption) networkservice.NetworkServiceClient {
-	c := &dnsContextClient{
+	var c = &dnsContextClient{
 		chainContext:        context.Background(),
 		defaultNameServerIP: "127.0.0.1",
 		resolveConfigPath:   "/etc/resolv.conf",
@@ -57,7 +58,9 @@ func NewClient(options ...DNSOption) networkservice.NetworkServiceClient {
 	for _, o := range options {
 		o.apply(c)
 	}
-	c.storedResolvConfigPath = c.resolveConfigPath + ".restore"
+
+	var _, name = path.Split(c.resolveConfigPath)
+	c.storedResolvConfigPath = path.Join(path.Dir(c.coreFilePath), name+".restore")
 	c.initialize()
 	return c
 }


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
this patch simply moves the restore file to the shared dir that is totally safe for different clusters


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
