### PR TITLE
ipool: handle IPv4 and IPv6 differently

### DIFF
--- a/pkg/tools/ippool/ippool_test.go
+++ b/pkg/tools/ippool/ippool_test.go
@@ -251,6 +251,12 @@ func TestIPPoolTool_PullP2PAddrs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, srcIPNet.String(), "192.0.1.0/32")
 	require.Equal(t, dstIPNet.String(), "192.0.1.2/32")
+
+	excludedPool = NewWithNetString("::/0")
+	srcIPNet, dstIPNet, err = ipPool.PullP2PAddrs(excludedPool)
+	require.NoError(t, err)
+	require.Equal(t, srcIPNet.String(), "192.0.0.5/32")
+	require.Equal(t, dstIPNet.String(), "192.0.0.6/32")
 }
 
 func TestIPPoolTool_IPv6Add(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
1. It is not fully correct to use `len(ipNet.IP)`, because `len(ipNet.IP) != len(ipNet.IP.To4())` sometimes for IPv4
2. We have to check if the excluded IP belongs to the `ipPool` family

## Issue link
Fixes: https://github.com/networkservicemesh/sdk/issues/1297


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
