### PR TITLE
Data path healing should be disabled

### DIFF
--- a/pkg/networkservice/ipam/singlepointipam/server.go
+++ b/pkg/networkservice/ipam/singlepointipam/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Nordix and its affiliates.
+// Copyright (c) 2020-2022 Nordix and its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -113,7 +113,6 @@ func (sipam *singlePIpam) Request(ctx context.Context, request *networkservice.N
 	}
 
 	addAddr(&ipContext.SrcIpAddrs, connInfo.srcAddr)
-	addAddr(&ipContext.DstIpAddrs, connInfo.dstAddr)
 
 	conn, err = next.Server(ctx).Request(ctx, request)
 	if err != nil {


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Do not set dst in IP context  in case of singlepoint IPAM


## Issue link
networkservicemesh/cmd-nsc#447


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [X] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
