### PR TITLE
Remove IsTracingEnabled replace with opentelemetry.IsEnabled

### DIFF
--- a/pkg/networkservice/core/trace/common_test.go
+++ b/pkg/networkservice/core/trace/common_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/trace"
-	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
 func TestDiffMechanism(t *testing.T) {
@@ -113,7 +112,6 @@ func TestTraceOutput(t *testing.T) {
 		DisableTimestamp: true,
 	})
 	logrus.SetLevel(logrus.TraceLevel)
-	log.EnableTracing(true)
 
 	// Create a chain with modifying elements
 	ch := chain.NewNetworkServiceServer(
@@ -168,7 +166,6 @@ func TestErrorOutput(t *testing.T) {
 		DisableTimestamp: true,
 	})
 	logrus.SetLevel(logrus.TraceLevel)
-	log.EnableTracing(true)
 
 	// Create a chain with modifying elements
 	ch := chain.NewNetworkServiceServer(

--- a/pkg/networkservice/core/trace/context.go
+++ b/pkg/networkservice/core/trace/context.go
@@ -24,11 +24,12 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/spanlogger"
-	"github.com/sirupsen/logrus"
 )
 
 type contextKeyType string
@@ -57,12 +58,12 @@ func withLog(parent context.Context, operation, connectionID string) (c context.
 
 	if grpcTraceState := grpcutils.TraceFromContext(parent); (grpcTraceState == grpcutils.TraceOn) ||
 		(grpcTraceState == grpcutils.TraceUndefined && logrus.GetLevel() == logrus.TraceLevel) {
-			ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, map[string]interface{}{"type": loggedType, "id": connectionID})
-			ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, map[string]interface{}{"type": loggedType, "id": connectionID})
-			return withTrace(log.WithLog(ctx, sLogger, lLogger)), func() {
-				sFinish()
-				lFinish()
-			}
+		ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, map[string]interface{}{"type": loggedType, "id": connectionID})
+		ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, map[string]interface{}{"type": loggedType, "id": connectionID})
+		return withTrace(log.WithLog(ctx, sLogger, lLogger)), func() {
+			sFinish()
+			lFinish()
+		}
 	}
 	return log.WithLog(parent), func() {}
 }

--- a/pkg/networkservice/core/trace/context.go
+++ b/pkg/networkservice/core/trace/context.go
@@ -28,7 +28,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/spanlogger"
-	"github.com/networkservicemesh/sdk/pkg/tools/opentelemetry"
+	"github.com/sirupsen/logrus"
 )
 
 type contextKeyType string
@@ -56,7 +56,7 @@ func withLog(parent context.Context, operation, connectionID string) (c context.
 	parent = grpcutils.PassTraceToOutgoing(parent)
 
 	if grpcTraceState := grpcutils.TraceFromContext(parent); (grpcTraceState == grpcutils.TraceOn) ||
-		(grpcTraceState == grpcutils.TraceUndefined && opentelemetry.IsEnabled()) {
+		(grpcTraceState == grpcutils.TraceUndefined && logrus.GetLevel() == logrus.TraceLevel) {
 			ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, map[string]interface{}{"type": loggedType, "id": connectionID})
 			ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, map[string]interface{}{"type": loggedType, "id": connectionID})
 			return withTrace(log.WithLog(ctx, sLogger, lLogger)), func() {

--- a/pkg/registry/core/trace/context.go
+++ b/pkg/registry/core/trace/context.go
@@ -21,11 +21,12 @@ package trace
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/spanlogger"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -43,12 +44,12 @@ func withLog(parent context.Context, operation string) (c context.Context, f fun
 
 	if grpcTraceState := grpcutils.TraceFromContext(parent); (grpcTraceState == grpcutils.TraceOn) ||
 		(grpcTraceState == grpcutils.TraceUndefined && logrus.GetLevel() == logrus.TraceLevel) {
-			ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, map[string]interface{}{"type": loggedType})
-			ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, map[string]interface{}{"type": loggedType})
-			return log.WithLog(ctx, sLogger, lLogger), func() {
-				sFinish()
-				lFinish()
-			}
+		ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, map[string]interface{}{"type": loggedType})
+		ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, map[string]interface{}{"type": loggedType})
+		return log.WithLog(ctx, sLogger, lLogger), func() {
+			sFinish()
+			lFinish()
+		}
 	}
 	return log.WithLog(parent), func() {}
 }

--- a/pkg/registry/core/trace/context.go
+++ b/pkg/registry/core/trace/context.go
@@ -25,7 +25,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
 	"github.com/networkservicemesh/sdk/pkg/tools/log/spanlogger"
-	"github.com/networkservicemesh/sdk/pkg/tools/opentelemetry"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -42,7 +42,7 @@ func withLog(parent context.Context, operation string) (c context.Context, f fun
 	parent = grpcutils.PassTraceToOutgoing(parent)
 
 	if grpcTraceState := grpcutils.TraceFromContext(parent); (grpcTraceState == grpcutils.TraceOn) ||
-		(grpcTraceState == grpcutils.TraceUndefined && opentelemetry.IsEnabled()) {
+		(grpcTraceState == grpcutils.TraceUndefined && logrus.GetLevel() == logrus.TraceLevel) {
 			ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, map[string]interface{}{"type": loggedType})
 			ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, map[string]interface{}{"type": loggedType})
 			return log.WithLog(ctx, sLogger, lLogger), func() {

--- a/pkg/tools/log/logger.go
+++ b/pkg/tools/log/logger.go
@@ -19,19 +19,12 @@ package log
 
 import (
 	"context"
-	"sync/atomic"
-
-	"github.com/sirupsen/logrus"
 )
 
 type contextKeyType string
 
 const (
 	logKey contextKeyType = "Logger"
-)
-
-var (
-	isTracingEnabled int32 = 0
 )
 
 // Logger - unified interface for logging
@@ -77,18 +70,5 @@ func WithLog(ctx context.Context, log ...Logger) context.Context {
 	return context.WithValue(ctx, logKey, Combine(log...))
 }
 
-// IsTracingEnabled - checks if it is allowed to use traces
-func IsTracingEnabled() bool {
-	// TODO: Rework this within https://github.com/networkservicemesh/sdk/issues/1272
-	return atomic.LoadInt32(&isTracingEnabled) != 0 && logrus.GetLevel() == logrus.TraceLevel
-}
-
 // EnableTracing - enable/disable traces
-func EnableTracing(enable bool) {
-	if enable {
-		atomic.StoreInt32(&isTracingEnabled, 1)
-		return
-	}
-
-	atomic.StoreInt32(&isTracingEnabled, 0)
-}
+func EnableTracing(enable bool) {}

--- a/pkg/tools/log/logger.go
+++ b/pkg/tools/log/logger.go
@@ -69,6 +69,3 @@ func Join(ctx context.Context, log Logger) context.Context {
 func WithLog(ctx context.Context, log ...Logger) context.Context {
 	return context.WithValue(ctx, logKey, Combine(log...))
 }
-
-// EnableTracing - enable/disable traces
-func EnableTracing(enable bool) {}

--- a/pkg/tools/opentelemetry/README.md
+++ b/pkg/tools/opentelemetry/README.md
@@ -25,7 +25,6 @@ The example exposes the following backends:
 ## Using spans and metrics in tests
 After running docker-compose you can enable spans and metrics inside any test using the following code:
 ```Go
-log.EnableTracing(true)
 os.Setenv("TELEMETRY", "opentelemetry")
 spanExporter := opentelemetry.InitSpanExporter(ctx, "0.0.0.0:4317")
 metricExporter := opentelemetry.InitMetricExporter(ctx, "0.0.0.0:4317")

--- a/pkg/tools/opentelemetry/README.md
+++ b/pkg/tools/opentelemetry/README.md
@@ -25,7 +25,7 @@ The example exposes the following backends:
 ## Using spans and metrics in tests
 After running docker-compose you can enable spans and metrics inside any test using the following code:
 ```Go
-os.Setenv("TELEMETRY", "opentelemetry")
+os.Setenv("TELEMETRY", "true")
 spanExporter := opentelemetry.InitSpanExporter(ctx, "0.0.0.0:4317")
 metricExporter := opentelemetry.InitMetricExporter(ctx, "0.0.0.0:4317")
 o := opentelemetry.Init(ctx, spanExporter, metricExporter, "NSM")


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
EnableTracing was removed. Instead LogLevel is used to enable tracing if TraceLevel is set.

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/sdk/issues/1272

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
