### PR TITLE
Fix metrics concurrency

### DIFF
--- a/pkg/networkservice/common/metrics/metadata.go
+++ b/pkg/networkservice/common/metrics/metadata.go
@@ -25,7 +25,7 @@ import (
 )
 
 type keyType struct{}
-type metricsMap map[string]metric.Int64Histogram
+type metricsMap = map[string]metric.Int64Histogram
 
 func loadOrStore(ctx context.Context, metrics metricsMap) (value metricsMap, ok bool) {
 	rawValue, ok := metadata.Map(ctx, false).LoadOrStore(keyType{}, metrics)

--- a/pkg/networkservice/common/metrics/metadata.go
+++ b/pkg/networkservice/common/metrics/metadata.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+)
+
+type keyType struct{}
+type metricsMap map[string]metric.Int64Histogram
+
+func loadOrStore(ctx context.Context, metrics metricsMap) (value metricsMap, ok bool) {
+	rawValue, ok := metadata.Map(ctx, false).LoadOrStore(keyType{}, metrics)
+	return rawValue.(metricsMap), ok
+}

--- a/pkg/networkservice/common/metrics/server_test.go
+++ b/pkg/networkservice/common/metrics/server_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"context"
+
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"go.uber.org/goleak"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/begin"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/metrics"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/updatepath"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+)
+
+func TestMetrics_Concurrency(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	server := chain.NewNetworkServiceServer(
+		begin.NewServer(),
+		metadata.NewServer(),
+		updatepath.NewServer("testServer"),
+		&metricsGeneratorServer{},
+		metrics.NewServer(),
+	)
+	for i := 0; i < 100; i++ {
+		go func(i int) {
+			req := &networkservice.NetworkServiceRequest{
+				Connection: &networkservice.Connection{Id: "nsc-" + strconv.Itoa(i)},
+			}
+			_, err := server.Request(context.Background(), req)
+			require.NoError(t, err)
+		}(i)
+	}
+}
+
+type metricsGeneratorServer struct{}
+
+func (s *metricsGeneratorServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	segment := request.GetConnection().GetPath().GetPathSegments()[0]
+	if segment.Metrics == nil {
+		segment.Metrics = make(map[string]string)
+	}
+	// Generate any random metric value
+	// nolint:gosec
+	segment.Metrics["testMetric"] = strconv.Itoa(rand.Intn(100))
+	return next.Server(ctx).Request(ctx, request)
+}
+
+func (s *metricsGeneratorServer) Close(ctx context.Context, connection *networkservice.Connection) (*empty.Empty, error) {
+	return next.Server(ctx).Close(ctx, connection)
+}


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description

The metrics map should be unique for each connection and shouldn't cause concurrency issues.
In this PR the map has been moved from the chain element to the metadata.

## Issue link
Closes: https://github.com/networkservicemesh/sdk/issues/1311


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
