### PR TITLE
Always add initial client DNS config to request

### DIFF
--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -89,7 +89,9 @@ func (c *dnsContextClient) Request(ctx context.Context, request *networkservice.
 		c.initialClientDNSConfigs = request.Connection.Context.DnsContext.Configs
 	}
 
-	request.Connection.Context.DnsContext.Configs = append(c.initialClientDNSConfigs, c.resolvconfDNSConfig)
+	dnsConfigs := c.initialClientDNSConfigs
+	dnsConfigs = append(dnsConfigs, c.resolvconfDNSConfig)
+	request.Connection.Context.DnsContext.Configs = dnsConfigs
 
 	rv, err := next.Client(ctx).Request(ctx, request, opts...)
 	if err != nil {

--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -67,6 +67,9 @@ func NewClient(options ...DNSOption) networkservice.NetworkServiceClient {
 }
 
 func (c *dnsContextClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	if request.Connection == nil {
+		request.Connection = &networkservice.Connection{}
+	}
 	if request.Connection.GetContext() == nil {
 		request.Connection.Context = &networkservice.ConnectionContext{
 			DnsContext: &networkservice.DNSContext{},

--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -84,13 +84,8 @@ func (c *dnsContextClient) Request(ctx context.Context, request *networkservice.
 		request.Connection.Context.DnsContext = &networkservice.DNSContext{}
 	}
 
-	var initialClientDNSConfigs []*networkservice.DNSConfig
-	if v, ok := metadata.Map(ctx, true).Load(dnsContextClientRefreshKey); ok {
-		initialClientDNSConfigs = v.([]*networkservice.DNSConfig)
-	} else {
-		initialClientDNSConfigs = request.Connection.Context.DnsContext.Configs
-		metadata.Map(ctx, true).Store(dnsContextClientRefreshKey, initialClientDNSConfigs)
-	}
+	v, _ := metadata.Map(ctx, true).LoadOrStore(dnsContextClientRefreshKey, request.Connection.Context.DnsContext.Configs)
+	initialClientDNSConfigs = v.([]*networkservice.DNSConfig)
 
 	initialClientDNSConfigs = append(initialClientDNSConfigs, c.resolvconfDNSConfig)
 	request.Connection.Context.DnsContext.Configs = initialClientDNSConfigs

--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -85,7 +85,7 @@ func (c *dnsContextClient) Request(ctx context.Context, request *networkservice.
 	}
 
 	v, _ := metadata.Map(ctx, true).LoadOrStore(dnsContextClientRefreshKey, request.Connection.Context.DnsContext.Configs)
-	initialClientDNSConfigs = v.([]*networkservice.DNSConfig)
+	initialClientDNSConfigs := v.([]*networkservice.DNSConfig)
 
 	initialClientDNSConfigs = append(initialClientDNSConfigs, c.resolvconfDNSConfig)
 	request.Connection.Context.DnsContext.Configs = initialClientDNSConfigs

--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -101,7 +101,6 @@ func (c *dnsContextClient) Request(ctx context.Context, request *networkservice.
 	if rv.GetContext().GetDnsContext() != nil {
 		conifgs = rv.GetContext().GetDnsContext().GetConfigs()
 	}
-	log.FromContext(ctx).Infof("DNSCLIENT configs from NSE: %v", conifgs)
 	if len(conifgs) > 0 {
 		c.dnsConfigManager.Store(rv.GetId(), conifgs...)
 		c.updateCorefileQueue.AsyncExec(c.updateCorefile)

--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -84,11 +84,8 @@ func (c *dnsContextClient) Request(ctx context.Context, request *networkservice.
 		request.Connection.Context.DnsContext = &networkservice.DNSContext{}
 	}
 
-	v, _ := metadata.Map(ctx, true).LoadOrStore(dnsContextClientRefreshKey, request.Connection.Context.DnsContext.Configs)
-	initialClientDNSConfigs := v.([]*networkservice.DNSConfig)
-
-	initialClientDNSConfigs = append(initialClientDNSConfigs, c.resolvconfDNSConfig)
-	request.Connection.Context.DnsContext.Configs = initialClientDNSConfigs
+	initialClientDNSConfigs, _ := metadata.Map(ctx, true).LoadOrStore(dnsContextClientRefreshKey, request.Connection.Context.DnsContext.Configs)
+	request.Connection.Context.DnsContext.Configs = append(initialClientDNSConfigs.([]*networkservice.DNSConfig), c.resolvconfDNSConfig)
 
 	rv, err := next.Client(ctx).Request(ctx, request, opts...)
 	if err != nil {

--- a/pkg/networkservice/connectioncontext/dnscontext/client_test.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client_test.go
@@ -33,49 +33,8 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/dnscontext"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 )
-
-func Test_DNSContextClient_Restart(t *testing.T) {
-	t.Cleanup(func() { goleak.VerifyNone(t) })
-	corefilePath := filepath.Join(t.TempDir(), "corefile")
-	resolveConfigPath := filepath.Join(t.TempDir(), "resolv.conf")
-	err := ioutil.WriteFile(resolveConfigPath, []byte("nameserver 8.8.4.4\n"), os.ModePerm)
-	require.NoError(t, err)
-	const expectedEmptyCorefile = `. {
-	fanout . 8.8.4.4
-	log
-	reload
-	cache {
-		denial 0
-	}
-}`
-	for i := 0; i < 100; i++ {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		var c = chain.NewNetworkServiceClient(
-			dnscontext.NewClient(
-				dnscontext.WithCorefilePath(corefilePath),
-				dnscontext.WithResolveConfigPath(resolveConfigPath),
-				dnscontext.WithChainContext(ctx),
-			),
-		)
-		_, _ = c.Request(ctx, &networkservice.NetworkServiceRequest{})
-
-		cancel()
-	}
-
-	require.Never(t, func() bool {
-		for {
-			// #nosec
-			b, err := ioutil.ReadFile(corefilePath)
-			if err == nil {
-				time.Sleep(time.Millisecond * 50)
-				continue
-			}
-			return string(b) != expectedEmptyCorefile
-		}
-	}, time.Second/2, time.Millisecond*100)
-}
 
 func Test_DNSContextClient_Usecases(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
@@ -89,6 +48,7 @@ func Test_DNSContextClient_Usecases(t *testing.T) {
 	require.NoError(t, err)
 
 	client := chain.NewNetworkServiceClient(
+		metadata.NewClient(),
 		dnscontext.NewClient(
 			dnscontext.WithCorefilePath(corefilePath),
 			dnscontext.WithResolveConfigPath(resolveConfigPath),

--- a/pkg/networkservice/connectioncontext/dnscontext/client_test.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client_test.go
@@ -36,6 +36,49 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 )
 
+func Test_DNSContextClient_Restart(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+	corefilePath := filepath.Join(t.TempDir(), "corefile")
+	resolveConfigPath := filepath.Join(t.TempDir(), "resolv.conf")
+	err := ioutil.WriteFile(resolveConfigPath, []byte("nameserver 8.8.4.4\n"), os.ModePerm)
+	require.NoError(t, err)
+	const expectedEmptyCorefile = `. {
+	fanout . 8.8.4.4
+	log
+	reload
+	cache {
+		denial 0
+	}
+}`
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var c = chain.NewNetworkServiceClient(
+			metadata.NewClient(),
+			dnscontext.NewClient(
+				dnscontext.WithCorefilePath(corefilePath),
+				dnscontext.WithResolveConfigPath(resolveConfigPath),
+				dnscontext.WithChainContext(ctx),
+			),
+		)
+		_, _ = c.Request(ctx, &networkservice.NetworkServiceRequest{})
+
+		cancel()
+	}
+
+	require.Never(t, func() bool {
+		for {
+			// #nosec
+			b, err := ioutil.ReadFile(corefilePath)
+			if err == nil {
+				time.Sleep(time.Millisecond * 50)
+				continue
+			}
+			return string(b) != expectedEmptyCorefile
+		}
+	}, time.Second/2, time.Millisecond*100)
+}
+
 func Test_DNSContextClient_Usecases(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
Signed-off-by: Nikita Skrynnik <nikita.skrynnik@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->

Endpoint appends its DNS configs to configs which are already in the connection on first request from a client. Client saves these DNS configs. On Refresh client sends request with saved configs to the endpoint and the endpoint appends its configs again. It leads to duplication of the endpoint's dns configs on refreshes.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
