### PR TITLE
Fixes for vl3_dns

### DIFF
--- a/pkg/networkservice/connectioncontext/dnscontext/server.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils"
 )
 
 // GetDNSConfigsFunc gets dns configs
@@ -47,7 +48,7 @@ func (d *dnsContextServer) Request(ctx context.Context, request *networkservice.
 	}
 
 	for _, config := range d.configs {
-		if !contains(request.GetConnection().GetContext().GetDnsContext().Configs, config) {
+		if !dnsutils.ContainsDNSConfig(request.GetConnection().GetContext().GetDnsContext().Configs, config) {
 			request.GetConnection().GetContext().GetDnsContext().Configs = append(request.GetConnection().GetContext().GetDnsContext().Configs, config)
 		}
 	}
@@ -56,35 +57,4 @@ func (d *dnsContextServer) Request(ctx context.Context, request *networkservice.
 
 func (d *dnsContextServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
 	return next.Server(ctx).Close(ctx, conn)
-}
-
-func contains(array []*networkservice.DNSConfig, value *networkservice.DNSConfig) bool {
-	for i := range array {
-		if equal(array[i].DnsServerIps, value.DnsServerIps) && equal(array[i].SearchDomains, value.SearchDomains) {
-			return true
-		}
-	}
-	return false
-}
-
-func equal(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	diff := make(map[string]int, len(a))
-	for _, v := range a {
-		diff[v]++
-	}
-
-	for _, v := range b {
-		if _, ok := diff[v]; !ok {
-			return false
-		}
-		diff[v]--
-		if diff[v] == 0 {
-			delete(diff, v)
-		}
-	}
-	return len(diff) == 0
 }

--- a/pkg/tools/dnsutils/dnsutils.go
+++ b/pkg/tools/dnsutils/dnsutils.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/miekg/dns"
 
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
@@ -55,4 +57,36 @@ func ListenAndServe(ctx context.Context, handler Handler, listenOn string) {
 			}
 		}()
 	}
+}
+
+// ContainsDNSConfig returns true if array contains a specific dns config
+func ContainsDNSConfig(array []*networkservice.DNSConfig, value *networkservice.DNSConfig) bool {
+	for i := range array {
+		if equal(array[i].DnsServerIps, value.DnsServerIps) && equal(array[i].SearchDomains, value.SearchDomains) {
+			return true
+		}
+	}
+	return false
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	diff := make(map[string]int, len(a))
+	for _, v := range a {
+		diff[v]++
+	}
+
+	for _, v := range b {
+		if _, ok := diff[v]; !ok {
+			return false
+		}
+		diff[v]--
+		if diff[v] == 0 {
+			delete(diff, v)
+		}
+	}
+	return len(diff) == 0
 }


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
1. The main fix is `GetSrcIPRoutes` -> `GetSrcRoutes`
2. Prevented dnsContext duplication
3. Other changes because of linter `cyclomatic complexity`


## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/6774


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
