### PR TITLE
Handle empty dns answer

### DIFF
--- a/pkg/tools/dnsutils/cache/handler.go
+++ b/pkg/tools/dnsutils/cache/handler.go
@@ -85,6 +85,9 @@ func (h *dnsCacheHandler) updateTTL() {
 }
 
 func validateMsg(m *dns.Msg) bool {
+	if len(m.Answer) == 0 {
+		return false
+	}
 	for _, answer := range m.Answer {
 		if answer.Header().Ttl <= 0 {
 			return false

--- a/pkg/tools/dnsutils/fanout/handler.go
+++ b/pkg/tools/dnsutils/fanout/handler.go
@@ -102,7 +102,7 @@ func (h *fanoutHandler) waitResponse(ctx context.Context, respCh <-chan *dns.Msg
 				}
 				continue
 			}
-			if resp.Rcode == dns.RcodeSuccess {
+			if resp.Rcode == dns.RcodeSuccess && len(resp.Answer) != 0 {
 				return resp
 			}
 			if respCount == 0 {


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
If we run `dig` or `nslookup` with `norec` flag, these commands may return a positive result (`NOERROR`) but without `Answer` section. We must handle this situation.

## Issue link
Closes: https://github.com/networkservicemesh/integration-k8s-packet/issues/294


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
