### PR TITLE
Increase DNS timeout

### DIFF
--- a/pkg/tools/dnsutils/dnsutils.go
+++ b/pkg/tools/dnsutils/dnsutils.go
@@ -37,7 +37,7 @@ func ListenAndServe(ctx context.Context, handler Handler, listenOn string) {
 
 	for _, network := range networks {
 		var server = &dns.Server{Addr: listenOn, Net: network, Handler: dns.HandlerFunc(func(w dns.ResponseWriter, m *dns.Msg) {
-			var timeoutCtx, cancel = context.WithTimeout(context.Background(), time.Second)
+			var timeoutCtx, cancel = context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
 
 			handler.ServeDNS(timeoutCtx, w, m)


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Main changes:
1. Increase default dns timeout to 5 sec. It is linux default value - https://man7.org/linux/man-pages/man5/resolv.conf.5.html
2. `memory` dns has to write something into the writer (even if the entry is not found)


## Issue link
https://github.com/networkservicemesh/integration-k8s-packet/issues/295


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
