### PR TITLE
Settable global logger

### DIFF
--- a/pkg/tools/log/defaultlogger.go
+++ b/pkg/tools/log/defaultlogger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -30,6 +30,12 @@ type defaultLogger struct {
 // Default - provides a default logger
 func Default() Logger {
 	return &defaultLogger{}
+}
+
+// IsDefault - true if the logger is a default logger
+func IsDefault(logger Logger) bool {
+	_, ok := logger.(*defaultLogger)
+	return ok
 }
 
 func (l *defaultLogger) Info(v ...interface{}) {

--- a/pkg/tools/log/logger.go
+++ b/pkg/tools/log/logger.go
@@ -31,7 +31,8 @@ const (
 )
 
 var (
-	isTracingEnabled int32 = 0
+	isTracingEnabled int32  = 0
+	globalLogger     Logger = Default()
 )
 
 // Logger - unified interface for logging
@@ -54,13 +55,24 @@ type Logger interface {
 	WithField(key, value interface{}) Logger
 }
 
+// L returns the global Logger
+func L() Logger {
+	return globalLogger
+}
+
+// SetGlobalLogger Set the global Logger. This should be called early
+// in main() only.
+func SetGlobalLogger(logger Logger) {
+	globalLogger = logger
+}
+
 // FromContext - returns logger from context
 func FromContext(ctx context.Context) Logger {
 	rv, ok := ctx.Value(logKey).(Logger)
 	if ok {
 		return rv
 	}
-	return Default()
+	return L()
 }
 
 // Join - concatenates new logger with existing loggers


### PR DESCRIPTION
## Description

It should be possible to set an own customizwd Logger to be used by NSM. Now the logger is hard-coded in some places, most notable the `logruslogger.FromSpan()` used for trace logging. The intention for this PR is to fix the most urgent needs in a backward compatible way with as little changes as possible.

This PR adds a global logger reachable with `log.L()` (same as [zap](https://github.com/uber-go/zap)) and settable with `log.SetGlobalLogger(l Logger)`.

`logruslogger.FromSpan()` has been altered to become generic by using the `log.Logger` interface rather than a variation of `logruslogger`. It uses the global logger as base (calls `log.L()`) and thus allows users to specify the logger used for trace. ~For backward compatibility the global Logger is set to a `logruslogger` on init.~ If no logger is specified (logger is log.Default()) a backward compatible logger (logrus) is used.

The global logger should be set early in `main()`. Example;
```go
	if config.LogLevel == "TRACE" {
		nsmlog.EnableTracing(true)
		// Work-around for hard-coded logrus dependency in NSM
		logrus.SetLevel(logrus.TraceLevel)
	}
	logger.Info("NSM trace", "enabled", nsmlog.IsTracingEnabled())
	nsmlogger := log.NSMLogger(logger)
	nsmlog.SetGlobalLogger(nsmlogger)
	ctx = nsmlog.WithLog(ctx, nsmlogger)
```

#### Tasks that should be done but are not backward compatible

* Move `FromSpan()` from package `logruslogger` to `log` (since it's not logrus specific any more)
* Rename `FromSpan()` -> `NewTraceLogger()`

I will not add these things since it affects code all over the place I guess. Also `FromSpan()` is a horrible hack IMHO and should be re-written.

## Issue link

https://github.com/networkservicemesh/sdk/issues/1272

## How Has This Been Tested?

- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

I have used this PR in our NSM application with trace and it works fine. The example above is from real code. I have also used a `logruslogger/logruslogger_test.go` unit test to exercise the code in a convenient way. I have not included it since it doesn't really make any automatic tests, it just emits logs in various ways to be eyeballed by the developer.


## Types of changes

- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
