### PR TITLE
Don't trace gRPC "Canceled" errors

### DIFF
--- a/pkg/registry/core/trace/ns_registry.go
+++ b/pkg/registry/core/trace/ns_registry.go
@@ -19,6 +19,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/streamcontext"
@@ -26,6 +27,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 )
@@ -47,10 +50,10 @@ func (t *traceNetworkServiceRegistryFindClient) Recv() (*registry.NetworkService
 	rv, err := s.Recv()
 
 	if err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil, err
 		}
-		if err == context.Canceled {
+		if status.Code(err) == codes.Canceled {
 			return nil, err
 		}
 		return nil, logError(ctx, err, operation)

--- a/pkg/registry/core/trace/nse_registry.go
+++ b/pkg/registry/core/trace/nse_registry.go
@@ -18,6 +18,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/streamcontext"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 )
@@ -47,10 +50,10 @@ func (t *traceNetworkServiceEndpointRegistryFindClient) Recv() (*registry.Networ
 	rv, err := s.Recv()
 
 	if err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil, err
 		}
-		if err == context.Canceled {
+		if status.Code(err) == codes.Canceled {
 			return nil, err
 		}
 		return nil, logError(ctx, err, operation)


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
We were getting a *lot* of log chaff at TRACE level during normal operation because gRPC returns a "context canceled" error periodically but it's not really an error for us because we immediately loop around again.

This commit uses the gRPC status.Code() method to identify these non-errors. It also uses errors.Is() instead of == to compare error objects. This handles wrapped errors.

https://pkg.go.dev/google.golang.org/grpc/status#Code

https://github.com/golang/go/wiki/ErrorValueFAQ#how-should-i-change-my-error-handling-code-to-work-with-the-new-features

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/sdk/issues/1068

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

Deploy cmd-nse-icmp-responder, see periodic "context cancelled" errors, deploy build with patched SDK, verify that errors aren't present.

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI

Only relevant when running at TRACE log level.
