### PR TITLE
Fix begin on refresh

### DIFF
--- a/pkg/networkservice/common/begin/client.go
+++ b/pkg/networkservice/common/begin/client.go
@@ -65,6 +65,7 @@ func (b *beginClient) Request(ctx context.Context, request *networkservice.Netwo
 			conn, err = b.Request(ctx, request, opts...)
 			return
 		}
+		eventFactoryClient.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryClient)
 		request.Connection = mergeConnection(eventFactoryClient.returnedConnection, request.GetConnection(), eventFactoryClient.request.GetConnection())

--- a/pkg/networkservice/common/begin/event_factory_server_test.go
+++ b/pkg/networkservice/common/begin/event_factory_server_test.go
@@ -32,6 +32,48 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 )
 
+// This test reproduces the situation when refresh changes the eventFactory context
+// nolint:dupl
+func TestRefresh_Server(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	syncChan := make(chan struct{})
+	checkCtxServ := &checkContextServer{t: t}
+	eventFactoryServ := &eventFactoryServer{ch: syncChan}
+	server := chain.NewNetworkServiceServer(
+		begin.NewServer(),
+		checkCtxServ,
+		eventFactoryServ,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Set any value to context
+	ctx = context.WithValue(ctx, contextKey{}, "value_1")
+	checkCtxServ.setExpectedValue("value_1")
+
+	// Do Request with this context
+	request := testRequest("1")
+	conn, err := server.Request(ctx, request.Clone())
+	assert.NotNil(t, t, conn)
+	assert.NoError(t, err)
+
+	// Change context value before refresh Request
+	ctx = context.WithValue(ctx, contextKey{}, "value_2")
+	checkCtxServ.setExpectedValue("value_2")
+	request.Connection = conn.Clone()
+
+	// Call refresh
+	conn, err = server.Request(ctx, request.Clone())
+	assert.NotNil(t, t, conn)
+	assert.NoError(t, err)
+
+	// Call refresh from eventFactory. We are expecting updated value in the context
+	eventFactoryServ.callRefresh()
+	<-syncChan
+}
+
 // This test reproduces the situation when Close and Request were called at the same time
 // nolint:dupl
 func TestRefreshDuringClose_Server(t *testing.T) {

--- a/pkg/networkservice/common/begin/server.go
+++ b/pkg/networkservice/common/begin/server.go
@@ -61,6 +61,8 @@ func (b *beginServer) Request(ctx context.Context, request *networkservice.Netwo
 			conn, err = b.Request(ctx, request)
 			return
 		}
+		eventFactoryServer.updateContext(ctx)
+
 		ctx = withEventFactory(ctx, eventFactoryServer)
 		conn, err = next.Server(ctx).Request(ctx, request)
 		if err != nil {

--- a/pkg/registry/common/begin/ns_client.go
+++ b/pkg/registry/common/begin/ns_client.go
@@ -61,6 +61,7 @@ func (b *beginNSClient) Register(ctx context.Context, in *registry.NetworkServic
 			resp, err = b.Register(ctx, in, opts...)
 			return
 		}
+		eventFactoryClient.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryClient)
 		resp, err = next.NetworkServiceRegistryClient(ctx).Register(ctx, in, opts...)

--- a/pkg/registry/common/begin/ns_event_factory.go
+++ b/pkg/registry/common/begin/ns_event_factory.go
@@ -43,11 +43,7 @@ func newEventNSFactoryClient(ctx context.Context, afterClose func(), opts ...grp
 		client: next.NetworkServiceRegistryClient(ctx),
 		opts:   opts,
 	}
-	ctxFunc := postpone.ContextWithValues(ctx)
-	f.ctxFunc = func() (context.Context, context.CancelFunc) {
-		eventCtx, cancel := ctxFunc()
-		return withEventFactory(eventCtx, f), cancel
-	}
+	f.updateContext(ctx)
 
 	f.afterCloseFunc = func() {
 		f.state = closed
@@ -56,6 +52,14 @@ func newEventNSFactoryClient(ctx context.Context, afterClose func(), opts ...grp
 		}
 	}
 	return f
+}
+
+func (f *eventNSFactoryClient) updateContext(ctx context.Context) {
+	ctxFunc := postpone.ContextWithValues(ctx)
+	f.ctxFunc = func() (context.Context, context.CancelFunc) {
+		eventCtx, cancel := ctxFunc()
+		return withEventFactory(eventCtx, f), cancel
+	}
 }
 
 func (f *eventNSFactoryClient) Register(opts ...Option) <-chan error {
@@ -129,17 +133,21 @@ func newNSEventFactoryServer(ctx context.Context, afterClose func()) *eventNSFac
 	f := &eventNSFactoryServer{
 		server: next.NetworkServiceRegistryServer(ctx),
 	}
-	ctxFunc := postpone.ContextWithValues(ctx)
-	f.ctxFunc = func() (context.Context, context.CancelFunc) {
-		eventCtx, cancel := ctxFunc()
-		return withEventFactory(eventCtx, f), cancel
-	}
+	f.updateContext(ctx)
 
 	f.afterCloseFunc = func() {
 		f.state = closed
 		afterClose()
 	}
 	return f
+}
+
+func (f *eventNSFactoryServer) updateContext(ctx context.Context) {
+	ctxFunc := postpone.ContextWithValues(ctx)
+	f.ctxFunc = func() (context.Context, context.CancelFunc) {
+		eventCtx, cancel := ctxFunc()
+		return withEventFactory(eventCtx, f), cancel
+	}
 }
 
 func (f *eventNSFactoryServer) Register(opts ...Option) <-chan error {

--- a/pkg/registry/common/begin/ns_server.go
+++ b/pkg/registry/common/begin/ns_server.go
@@ -60,6 +60,8 @@ func (b *beginNSServer) Register(ctx context.Context, in *registry.NetworkServic
 			resp, err = b.Register(ctx, in)
 			return
 		}
+		eventFactoryServer.updateContext(ctx)
+
 		ctx = withEventFactory(ctx, eventFactoryServer)
 		resp, err = next.NetworkServiceRegistryServer(ctx).Register(ctx, in)
 		if err != nil {

--- a/pkg/registry/common/begin/nse_client.go
+++ b/pkg/registry/common/begin/nse_client.go
@@ -61,6 +61,7 @@ func (b *beginNSEClient) Register(ctx context.Context, in *registry.NetworkServi
 			resp, err = b.Register(ctx, in, opts...)
 			return
 		}
+		eventFactoryClient.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryClient)
 		resp, err = next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, in, opts...)

--- a/pkg/registry/common/begin/nse_event_factory.go
+++ b/pkg/registry/common/begin/nse_event_factory.go
@@ -43,11 +43,7 @@ func newEventNSEFactoryClient(ctx context.Context, afterClose func(), opts ...gr
 		client: next.NetworkServiceEndpointRegistryClient(ctx),
 		opts:   opts,
 	}
-	ctxFunc := postpone.ContextWithValues(ctx)
-	f.ctxFunc = func() (context.Context, context.CancelFunc) {
-		eventCtx, cancel := ctxFunc()
-		return withEventFactory(eventCtx, f), cancel
-	}
+	f.updateContext(ctx)
 
 	f.afterCloseFunc = func() {
 		f.state = closed
@@ -56,6 +52,14 @@ func newEventNSEFactoryClient(ctx context.Context, afterClose func(), opts ...gr
 		}
 	}
 	return f
+}
+
+func (f *eventNSEFactoryClient) updateContext(ctx context.Context) {
+	ctxFunc := postpone.ContextWithValues(ctx)
+	f.ctxFunc = func() (context.Context, context.CancelFunc) {
+		eventCtx, cancel := ctxFunc()
+		return withEventFactory(eventCtx, f), cancel
+	}
 }
 
 func (f *eventNSEFactoryClient) Register(opts ...Option) <-chan error {
@@ -129,17 +133,21 @@ func newNSEEventFactoryServer(ctx context.Context, afterClose func()) *eventNSEF
 	f := &eventNSEFactoryServer{
 		server: next.NetworkServiceEndpointRegistryServer(ctx),
 	}
-	ctxFunc := postpone.ContextWithValues(ctx)
-	f.ctxFunc = func() (context.Context, context.CancelFunc) {
-		eventCtx, cancel := ctxFunc()
-		return withEventFactory(eventCtx, f), cancel
-	}
+	f.updateContext(ctx)
 
 	f.afterCloseFunc = func() {
 		f.state = closed
 		afterClose()
 	}
 	return f
+}
+
+func (f *eventNSEFactoryServer) updateContext(ctx context.Context) {
+	ctxFunc := postpone.ContextWithValues(ctx)
+	f.ctxFunc = func() (context.Context, context.CancelFunc) {
+		eventCtx, cancel := ctxFunc()
+		return withEventFactory(eventCtx, f), cancel
+	}
 }
 
 func (f *eventNSEFactoryServer) Register(opts ...Option) <-chan error {

--- a/pkg/registry/common/begin/nse_server.go
+++ b/pkg/registry/common/begin/nse_server.go
@@ -60,6 +60,8 @@ func (b *beginNSEServer) Register(ctx context.Context, in *registry.NetworkServi
 			resp, err = b.Register(ctx, in)
 			return
 		}
+		eventFactoryServer.updateContext(ctx)
+
 		ctx = withEventFactory(ctx, eventFactoryServer)
 		resp, err = next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, in)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description

Steps to reproduce:
1. Deploy any NSM remote case (for example kernel2vxlan2kernel)
2. Delete remote Nsmgr pod
3. Wait for a new Nsmgr
4. Delete NSE pod
See - `network service endpoint {NAME} not found: all forwarders have failed`

### Why is this happening?

After restarting the remote Nsmgr, it reconnects to the remote Forwarder with the same `connID`, but with a **_different context values_** (this is needed for `authorize` chain element). 
`begin` has a map that stores the eventFactory by `connID`. When the recreated Nsmgr reaches the Forwarder, we use the previous eventFactory with the **_old internal context_**.

After that, all calls from `eventFactory` will fail. For example, [nsmonitor](https://github.com/networkservicemesh/sdk-vpp/tree/main/pkg/networkservice/nsmonitor) will not work on forwarder. And it affects the healing.

## Issue link
https://github.com/networkservicemesh/sdk/issues/1357


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
