### PR TITLE
qfix: Dont exclude subnets from routes

### DIFF
--- a/pkg/networkservice/common/excludedprefixes/client.go
+++ b/pkg/networkservice/common/excludedprefixes/client.go
@@ -190,6 +190,10 @@ func (epc *excludedPrefixesClient) Close(ctx context.Context, conn *networkservi
 func getRoutePrefixes(routes []*networkservice.Route) []string {
 	var rv []string
 	for _, route := range routes {
+		var o, b = route.GetPrefixIPNet().Mask.Size()
+		if o != b {
+			continue
+		}
 		rv = append(rv, route.GetPrefix())
 	}
 

--- a/pkg/networkservice/common/excludedprefixes/client_test.go
+++ b/pkg/networkservice/common/excludedprefixes/client_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -519,7 +521,7 @@ func Test_ExcludePrefixClient_ShouldntExcludeRouteSubnets(t *testing.T) {
 	_, err := client.Request(context.Background(), req)
 	require.NoError(t, err)
 
-	//Refresh
+	// Refresh
 	client = chain.NewNetworkServiceClient(
 		client,
 		checkrequest.NewClient(t, func(t *testing.T, request *networkservice.NetworkServiceRequest) {
@@ -531,7 +533,6 @@ func Test_ExcludePrefixClient_ShouldntExcludeRouteSubnets(t *testing.T) {
 	_, err = client.Request(context.Background(), req)
 
 	require.NoError(t, err)
-
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
We shouldn't exclude whole subnets on refresh


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
