### PR TITLE
begin: update context after a successful request

### DIFF
--- a/pkg/networkservice/common/begin/client.go
+++ b/pkg/networkservice/common/begin/client.go
@@ -65,7 +65,6 @@ func (b *beginClient) Request(ctx context.Context, request *networkservice.Netwo
 			conn, err = b.Request(ctx, request, opts...)
 			return
 		}
-		eventFactoryClient.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryClient)
 		request.Connection = mergeConnection(eventFactoryClient.returnedConnection, request.GetConnection(), eventFactoryClient.request.GetConnection())
@@ -83,6 +82,7 @@ func (b *beginClient) Request(ctx context.Context, request *networkservice.Netwo
 		eventFactoryClient.state = established
 
 		eventFactoryClient.returnedConnection = conn.Clone()
+		eventFactoryClient.updateContext(ctx)
 	})
 	return conn, err
 }

--- a/pkg/networkservice/common/begin/event_factory_server_test.go
+++ b/pkg/networkservice/common/begin/event_factory_server_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -37,13 +39,13 @@ import (
 func TestRefresh_Server(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	syncChan := make(chan struct{})
 	checkCtxServ := &checkContextServer{t: t}
-	eventFactoryServ := &eventFactoryServer{ch: syncChan}
+	eventFactoryServ := &eventFactoryServer{}
 	server := chain.NewNetworkServiceServer(
 		begin.NewServer(),
 		checkCtxServ,
 		eventFactoryServ,
+		&failedNSEServer{},
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -61,17 +63,27 @@ func TestRefresh_Server(t *testing.T) {
 
 	// Change context value before refresh Request
 	ctx = context.WithValue(ctx, contextKey{}, "value_2")
-	checkCtxServ.setExpectedValue("value_2")
-	request.Connection = conn.Clone()
 
-	// Call refresh
+	// Call refresh that will fail
+	request.Connection = conn.Clone()
+	request.Connection.NetworkServiceEndpointName = failedNSENameServer
+	checkCtxServ.setExpectedValue("value_2")
+	_, err = server.Request(ctx, request.Clone())
+	assert.Error(t, err)
+
+	// Call refresh from eventFactory. We are expecting the previous value in the context
+	checkCtxServ.setExpectedValue("value_1")
+	eventFactoryServ.callRefresh()
+
+	// Call refresh that will successful
+	request.Connection.NetworkServiceEndpointName = ""
+	checkCtxServ.setExpectedValue("value_2")
 	conn, err = server.Request(ctx, request.Clone())
 	assert.NotNil(t, t, conn)
 	assert.NoError(t, err)
 
 	// Call refresh from eventFactory. We are expecting updated value in the context
 	eventFactoryServ.callRefresh()
-	<-syncChan
 }
 
 // This test reproduces the situation when Close and Request were called at the same time
@@ -79,9 +91,8 @@ func TestRefresh_Server(t *testing.T) {
 func TestRefreshDuringClose_Server(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	syncChan := make(chan struct{})
 	checkCtxServ := &checkContextServer{t: t}
-	eventFactoryServ := &eventFactoryServer{ch: syncChan}
+	eventFactoryServ := &eventFactoryServer{}
 	server := chain.NewNetworkServiceServer(
 		begin.NewServer(),
 		checkCtxServ,
@@ -108,7 +119,6 @@ func TestRefreshDuringClose_Server(t *testing.T) {
 
 	// Call Close from eventFactory
 	eventFactoryServ.callClose()
-	<-syncChan
 
 	// Call refresh  (should be called at the same time as Close)
 	conn, err = server.Request(ctx, request.Clone())
@@ -117,12 +127,10 @@ func TestRefreshDuringClose_Server(t *testing.T) {
 
 	// Call refresh from eventFactory. We are expecting updated value in the context
 	eventFactoryServ.callRefresh()
-	<-syncChan
 }
 
 type eventFactoryServer struct {
 	ctx context.Context
-	ch  chan<- struct{}
 }
 
 func (e *eventFactoryServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
@@ -138,18 +146,12 @@ func (e *eventFactoryServer) Close(ctx context.Context, conn *networkservice.Con
 
 func (e *eventFactoryServer) callClose() {
 	eventFactory := begin.FromContext(e.ctx)
-	go func() {
-		e.ch <- struct{}{}
-		eventFactory.Close()
-	}()
+	eventFactory.Close()
 }
 
 func (e *eventFactoryServer) callRefresh() {
 	eventFactory := begin.FromContext(e.ctx)
-	go func() {
-		e.ch <- struct{}{}
-		eventFactory.Request()
-	}()
+	<-eventFactory.Request()
 }
 
 type checkContextServer struct {
@@ -168,4 +170,22 @@ func (c *checkContextServer) Close(ctx context.Context, conn *networkservice.Con
 
 func (c *checkContextServer) setExpectedValue(value string) {
 	c.expectedValue = value
+}
+
+const failedNSENameServer = "failedNSE"
+
+type failedNSEServer struct{}
+
+func (f *failedNSEServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	if request.GetConnection().NetworkServiceEndpointName == failedNSENameServer {
+		return nil, errors.New("failed")
+	}
+	return next.Server(ctx).Request(ctx, request)
+}
+
+func (f *failedNSEServer) Close(ctx context.Context, conn *networkservice.Connection) (*emptypb.Empty, error) {
+	if conn.NetworkServiceEndpointName == failedNSENameServer {
+		return nil, errors.New("failed")
+	}
+	return next.Server(ctx).Close(ctx, conn)
 }

--- a/pkg/networkservice/common/begin/server.go
+++ b/pkg/networkservice/common/begin/server.go
@@ -61,7 +61,6 @@ func (b *beginServer) Request(ctx context.Context, request *networkservice.Netwo
 			conn, err = b.Request(ctx, request)
 			return
 		}
-		eventFactoryServer.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryServer)
 		conn, err = next.Server(ctx).Request(ctx, request)
@@ -77,6 +76,7 @@ func (b *beginServer) Request(ctx context.Context, request *networkservice.Netwo
 		eventFactoryServer.state = established
 
 		eventFactoryServer.returnedConnection = conn.Clone()
+		eventFactoryServer.updateContext(ctx)
 	})
 	return conn, err
 }

--- a/pkg/registry/common/begin/ns_client.go
+++ b/pkg/registry/common/begin/ns_client.go
@@ -61,7 +61,6 @@ func (b *beginNSClient) Register(ctx context.Context, in *registry.NetworkServic
 			resp, err = b.Register(ctx, in, opts...)
 			return
 		}
-		eventFactoryClient.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryClient)
 		resp, err = next.NetworkServiceRegistryClient(ctx).Register(ctx, in, opts...)
@@ -76,6 +75,7 @@ func (b *beginNSClient) Register(ctx context.Context, in *registry.NetworkServic
 		eventFactoryClient.state = established
 		eventFactoryClient.registration = mergeNS(in, resp.Clone())
 		eventFactoryClient.response = resp.Clone()
+		eventFactoryClient.updateContext(ctx)
 	})
 	return resp, err
 }

--- a/pkg/registry/common/begin/ns_server.go
+++ b/pkg/registry/common/begin/ns_server.go
@@ -60,7 +60,6 @@ func (b *beginNSServer) Register(ctx context.Context, in *registry.NetworkServic
 			resp, err = b.Register(ctx, in)
 			return
 		}
-		eventFactoryServer.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryServer)
 		resp, err = next.NetworkServiceRegistryServer(ctx).Register(ctx, in)
@@ -74,6 +73,7 @@ func (b *beginNSServer) Register(ctx context.Context, in *registry.NetworkServic
 		eventFactoryServer.registration = mergeNS(in, resp)
 		eventFactoryServer.state = established
 		eventFactoryServer.response = resp
+		eventFactoryServer.updateContext(ctx)
 	})
 	return resp, err
 }

--- a/pkg/registry/common/begin/nse_client.go
+++ b/pkg/registry/common/begin/nse_client.go
@@ -61,7 +61,6 @@ func (b *beginNSEClient) Register(ctx context.Context, in *registry.NetworkServi
 			resp, err = b.Register(ctx, in, opts...)
 			return
 		}
-		eventFactoryClient.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryClient)
 		resp, err = next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, in, opts...)
@@ -76,6 +75,7 @@ func (b *beginNSEClient) Register(ctx context.Context, in *registry.NetworkServi
 		eventFactoryClient.state = established
 		eventFactoryClient.registration = mergeNSE(in, resp.Clone())
 		eventFactoryClient.response = resp.Clone()
+		eventFactoryClient.updateContext(ctx)
 	})
 	return resp, err
 }

--- a/pkg/registry/common/begin/nse_event_factory_client_test.go
+++ b/pkg/registry/common/begin/nse_event_factory_client_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
@@ -37,13 +39,13 @@ import (
 func TestRefresh_Client(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	syncChan := make(chan struct{})
 	checkCtxCl := &checkContextClient{t: t}
-	eventFactoryCl := &eventFactoryClient{ch: syncChan}
+	eventFactoryCl := &eventFactoryClient{}
 	client := chain.NewNetworkServiceEndpointRegistryClient(
 		begin.NewNetworkServiceEndpointRegistryClient(),
 		checkCtxCl,
 		eventFactoryCl,
+		&failedNSEClient{},
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -57,31 +59,40 @@ func TestRefresh_Client(t *testing.T) {
 	nse := &registry.NetworkServiceEndpoint{
 		Name: "1",
 	}
-	conn, err := client.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, conn)
+	nse, err := client.Register(ctx, nse.Clone())
+	assert.NotNil(t, t, nse)
 	assert.NoError(t, err)
 
 	// Change context value before refresh
 	ctx = context.WithValue(ctx, contextKey{}, "value_2")
-	checkCtxCl.setExpectedValue("value_2")
 
-	// Call refresh
-	conn, err = client.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, conn)
+	// Call refresh that will fail
+	nse.Url = failedNSEURLClient
+	checkCtxCl.setExpectedValue("value_2")
+	_, err = client.Register(ctx, nse.Clone())
+	assert.Error(t, err)
+
+	// Call refresh from eventFactory. We are expecting the previous value in the context
+	checkCtxCl.setExpectedValue("value_1")
+	eventFactoryCl.callRefresh()
+
+	// Call refresh that will successful
+	nse.Url = ""
+	checkCtxCl.setExpectedValue("value_2")
+	nse, err = client.Register(ctx, nse.Clone())
+	assert.NotNil(t, t, nse)
 	assert.NoError(t, err)
 
 	// Call refresh from eventFactory. We are expecting updated value in the context
 	eventFactoryCl.callRefresh()
-	<-syncChan
 }
 
 // This test reproduces the situation when Unregister and Register were called at the same time
 func TestRefreshDuringUnregister_Client(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	syncChan := make(chan struct{})
 	checkCtxCl := &checkContextClient{t: t}
-	eventFactoryCl := &eventFactoryClient{ch: syncChan}
+	eventFactoryCl := &eventFactoryClient{}
 	client := chain.NewNetworkServiceEndpointRegistryClient(
 		begin.NewNetworkServiceEndpointRegistryClient(),
 		checkCtxCl,
@@ -109,7 +120,6 @@ func TestRefreshDuringUnregister_Client(t *testing.T) {
 
 	// Call Unregister from eventFactory
 	eventFactoryCl.callUnregister()
-	<-syncChan
 
 	// Call refresh (should be called at the same time as Unregister)
 	conn, err = client.Register(ctx, nse.Clone())
@@ -118,13 +128,11 @@ func TestRefreshDuringUnregister_Client(t *testing.T) {
 
 	// Call refresh from eventFactory. We are expecting updated value in the context
 	eventFactoryCl.callRefresh()
-	<-syncChan
 }
 
 type eventFactoryClient struct {
 	registry.NetworkServiceEndpointRegistryClient
 	ctx context.Context
-	ch  chan<- struct{}
 }
 
 func (e *eventFactoryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
@@ -140,18 +148,12 @@ func (e *eventFactoryClient) Unregister(ctx context.Context, in *registry.Networ
 
 func (e *eventFactoryClient) callUnregister() {
 	eventFactory := begin.FromContext(e.ctx)
-	go func() {
-		e.ch <- struct{}{}
-		eventFactory.Unregister()
-	}()
+	eventFactory.Unregister()
 }
 
 func (e *eventFactoryClient) callRefresh() {
 	eventFactory := begin.FromContext(e.ctx)
-	go func() {
-		e.ch <- struct{}{}
-		eventFactory.Register()
-	}()
+	<-eventFactory.Register()
 }
 
 type contextKey struct{}
@@ -173,4 +175,24 @@ func (c *checkContextClient) Unregister(ctx context.Context, in *registry.Networ
 
 func (c *checkContextClient) setExpectedValue(value string) {
 	c.expectedValue = value
+}
+
+const failedNSEURLClient = "failedNSE"
+
+type failedNSEClient struct {
+	registry.NetworkServiceEndpointRegistryClient
+}
+
+func (f *failedNSEClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	if in.Url == failedNSEURLClient {
+		return nil, errors.New("failed")
+	}
+	return next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, in, opts...)
+}
+
+func (f *failedNSEClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+	if in.Url == failedNSEURLClient {
+		return nil, errors.New("failed")
+	}
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, in, opts...)
 }

--- a/pkg/registry/common/begin/nse_server.go
+++ b/pkg/registry/common/begin/nse_server.go
@@ -60,7 +60,6 @@ func (b *beginNSEServer) Register(ctx context.Context, in *registry.NetworkServi
 			resp, err = b.Register(ctx, in)
 			return
 		}
-		eventFactoryServer.updateContext(ctx)
 
 		ctx = withEventFactory(ctx, eventFactoryServer)
 		resp, err = next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, in)
@@ -74,6 +73,7 @@ func (b *beginNSEServer) Register(ctx context.Context, in *registry.NetworkServi
 		eventFactoryServer.registration = mergeNSE(in, resp)
 		eventFactoryServer.state = established
 		eventFactoryServer.response = resp
+		eventFactoryServer.updateContext(ctx)
 	})
 	return resp, err
 }


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
We should update the eventFactory context **only after** successful refresh.

**The reason**: we update eventFactory request only if we don't have an error - https://github.com/networkservicemesh/sdk/blob/main/pkg/networkservice/common/begin/server.go#L75-L77
 
Thus, if we update the context before the request and it fails, we will have the wrong state (new context but previous request)

## Issue link
https://github.com/networkservicemesh/sdk/issues/1357


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
