### PR TITLE
PoC: add a possible to replace nse.URL of nsmgrproxy

### DIFF
--- a/pkg/networkservice/chains/nsmgrproxy/server.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server.go
@@ -70,7 +70,8 @@ type nsmgrProxyServer struct {
 
 type serverOptions struct {
 	name                             string
-	mapipFilePath                    string
+	tunnelMapFilePath                string
+	urlMapFilePath                   string
 	listenOn                         *url.URL
 	authorizeServer                  networkservice.NetworkServiceServer
 	authorizeMonitorConnectionServer networkservice.MonitorConnectionServer
@@ -80,9 +81,9 @@ type serverOptions struct {
 	dialTimeout                      time.Duration
 }
 
-func (s *serverOptions) openMapIPChannel(ctx context.Context) <-chan map[string]string {
+func (s *serverOptions) openMapIPChannel(ctx context.Context, p string) <-chan map[string]string {
 	var r = make(chan map[string]string)
-	var fCh = fs.WatchFile(ctx, s.mapipFilePath)
+	var fCh = fs.WatchFile(ctx, p)
 	go func() {
 		defer close(r)
 		for data := range fCh {
@@ -91,6 +92,7 @@ func (s *serverOptions) openMapIPChannel(ctx context.Context) <-chan map[string]
 				log.FromContext(ctx).Errorf("An error during umarshal ipmap: %v", err.Error())
 				continue
 			}
+			log.FromContext(ctx).Infof("map ip channel received update: %+v", m)
 			select {
 			case <-ctx.Done():
 				return
@@ -162,7 +164,14 @@ func WithListenOn(u *url.URL) Option {
 // WithMapIPFilePath sets the custom path for the file that contains internal to external IPs information in YAML format
 func WithMapIPFilePath(p string) Option {
 	return func(o *serverOptions) {
-		o.mapipFilePath = p
+		o.tunnelMapFilePath = p
+	}
+}
+
+// WithMapURLFilePath sets the path that contains the replacement for the hostname part of nse.URL in interdomain registry communication
+func WithMapURLFilePath(p string) Option {
+	return func(o *serverOptions) {
+		o.urlMapFilePath = p
 	}
 }
 
@@ -190,7 +199,7 @@ func NewServer(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator to
 		authorizeNSRegistryServer:        registryauthorize.NewNetworkServiceRegistryServer(registryauthorize.Any()),
 		authorizeNSERegistryServer:       registryauthorize.NewNetworkServiceEndpointRegistryServer(registryauthorize.Any()),
 		listenOn:                         &url.URL{Scheme: "unix", Host: "listen.on"},
-		mapipFilePath:                    "map-ip.yaml",
+		tunnelMapFilePath:                "map-ip.yaml",
 	}
 	for _, opt := range options {
 		opt(opts)
@@ -226,7 +235,7 @@ func NewServer(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator to
 		endpoint.WithAdditionalFunctionality(
 			interdomainbypass.NewServer(&interdomainBypassNSEServer, opts.listenOn),
 			discover.NewServer(nsClient, nseClient),
-			swapip.NewServer(opts.openMapIPChannel(ctx)),
+			swapip.NewServer(opts.openMapIPChannel(ctx, opts.tunnelMapFilePath)),
 			clusterinfo.NewServer(),
 			connect.NewServer(
 				client.NewClient(
@@ -236,7 +245,7 @@ func NewServer(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator to
 					client.WithDialTimeout(opts.dialTimeout),
 					client.WithoutRefresh(),
 					client.WithAdditionalFunctionality(
-						swapip.NewClient(opts.openMapIPChannel(ctx)),
+						swapip.NewClient(opts.openMapIPChannel(ctx, opts.tunnelMapFilePath)),
 					),
 				),
 			),
@@ -260,12 +269,17 @@ func NewServer(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator to
 		nsServerChain,
 	)
 
+	var registryMapIP = opts.urlMapFilePath
+	if registryMapIP == "" {
+		registryMapIP = opts.tunnelMapFilePath
+	}
+
 	var nseServerChain = chain.NewNetworkServiceEndpointRegistryServer(
 		begin.NewNetworkServiceEndpointRegistryServer(),
 		opts.authorizeNSERegistryServer,
 		clienturl.NewNetworkServiceEndpointRegistryServer(proxyURL),
 		interdomainBypassNSEServer,
-		registryswapip.NewNetworkServiceEndpointRegistryServer(opts.openMapIPChannel(ctx)),
+		registryswapip.NewNetworkServiceEndpointRegistryServer(opts.openMapIPChannel(ctx, registryMapIP)),
 		registryclusterinfo.NewNetworkServiceEndpointRegistryServer(),
 		registryconnect.NewNetworkServiceEndpointRegistryServer(
 			chain.NewNetworkServiceEndpointRegistryClient(


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description

This PR demonstrates how a could be handled a situation when we want to replace nse.URL to something else(load balancer ip, or any other needed ip)

## How Has This Been Tested?

- [X] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [X] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
