### PR TITLE
begin: update eventFactory context based on the initial one

### DIFF
--- a/pkg/networkservice/common/begin/client.go
+++ b/pkg/networkservice/common/begin/client.go
@@ -66,9 +66,9 @@ func (b *beginClient) Request(ctx context.Context, request *networkservice.Netwo
 			return
 		}
 
-		ctx = withEventFactory(ctx, eventFactoryClient)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryClient)
 		request.Connection = mergeConnection(eventFactoryClient.returnedConnection, request.GetConnection(), eventFactoryClient.request.GetConnection())
-		conn, err = next.Client(ctx).Request(ctx, request, opts...)
+		conn, err = next.Client(withEventFactoryCtx).Request(withEventFactoryCtx, request, opts...)
 		if err != nil {
 			if eventFactoryClient.state != established {
 				eventFactoryClient.state = closed
@@ -110,8 +110,8 @@ func (b *beginClient) Close(ctx context.Context, conn *networkservice.Connection
 		}
 		// Always close with the last valid Connection we got
 		conn = eventFactoryClient.request.Connection
-		ctx = withEventFactory(ctx, eventFactoryClient)
-		emp, err = next.Client(ctx).Close(ctx, conn, opts...)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryClient)
+		emp, err = next.Client(withEventFactoryCtx).Close(withEventFactoryCtx, conn, opts...)
 		// afterCloseFunc() is used to cleanup things like the entry in the Map for EventFactories
 		eventFactoryClient.afterCloseFunc()
 	})

--- a/pkg/networkservice/common/begin/server.go
+++ b/pkg/networkservice/common/begin/server.go
@@ -62,8 +62,8 @@ func (b *beginServer) Request(ctx context.Context, request *networkservice.Netwo
 			return
 		}
 
-		ctx = withEventFactory(ctx, eventFactoryServer)
-		conn, err = next.Server(ctx).Request(ctx, request)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
+		conn, err = next.Server(withEventFactoryCtx).Request(withEventFactoryCtx, request)
 		if err != nil {
 			if eventFactoryServer.state != established {
 				eventFactoryServer.state = closed
@@ -101,8 +101,8 @@ func (b *beginServer) Close(ctx context.Context, conn *networkservice.Connection
 		}
 		// Always close with the last valid EventFactory we got
 		conn = eventFactoryServer.request.Connection
-		ctx = withEventFactory(ctx, eventFactoryServer)
-		emp, err = next.Server(ctx).Close(ctx, conn)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
+		emp, err = next.Server(withEventFactoryCtx).Close(withEventFactoryCtx, conn)
 		eventFactoryServer.afterCloseFunc()
 	})
 	return &emptypb.Empty{}, err

--- a/pkg/registry/common/begin/ns_client.go
+++ b/pkg/registry/common/begin/ns_client.go
@@ -62,8 +62,8 @@ func (b *beginNSClient) Register(ctx context.Context, in *registry.NetworkServic
 			return
 		}
 
-		ctx = withEventFactory(ctx, eventFactoryClient)
-		resp, err = next.NetworkServiceRegistryClient(ctx).Register(ctx, in, opts...)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryClient)
+		resp, err = next.NetworkServiceRegistryClient(withEventFactoryCtx).Register(withEventFactoryCtx, in, opts...)
 		if err != nil {
 			if eventFactoryClient.state != established {
 				eventFactoryClient.state = closed
@@ -107,8 +107,8 @@ func (b *beginNSClient) Unregister(ctx context.Context, in *registry.NetworkServ
 			return
 		}
 		// Always close with the last valid Connection we got
-		ctx = withEventFactory(ctx, eventFactoryClient)
-		emp, err = next.NetworkServiceRegistryClient(ctx).Unregister(ctx, eventFactoryClient.registration, opts...)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryClient)
+		emp, err = next.NetworkServiceRegistryClient(withEventFactoryCtx).Unregister(withEventFactoryCtx, eventFactoryClient.registration, opts...)
 		// afterCloseFunc() is used to cleanup things like the entry in the Map for EventFactories
 		eventFactoryClient.afterCloseFunc()
 	})

--- a/pkg/registry/common/begin/ns_event_factory.go
+++ b/pkg/registry/common/begin/ns_event_factory.go
@@ -24,12 +24,14 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/extend"
 	"github.com/networkservicemesh/sdk/pkg/tools/postpone"
 )
 
 type eventNSFactoryClient struct {
 	state          connectionState
 	executor       serialize.Executor
+	initialCtxFunc func() (context.Context, context.CancelFunc)
 	ctxFunc        func() (context.Context, context.CancelFunc)
 	registration   *registry.NetworkService
 	response       *registry.NetworkService
@@ -40,8 +42,9 @@ type eventNSFactoryClient struct {
 
 func newEventNSFactoryClient(ctx context.Context, afterClose func(), opts ...grpc.CallOption) *eventNSFactoryClient {
 	f := &eventNSFactoryClient{
-		client: next.NetworkServiceRegistryClient(ctx),
-		opts:   opts,
+		client:         next.NetworkServiceRegistryClient(ctx),
+		initialCtxFunc: postpone.Context(ctx),
+		opts:           opts,
 	}
 	f.updateContext(ctx)
 
@@ -54,10 +57,10 @@ func newEventNSFactoryClient(ctx context.Context, afterClose func(), opts ...grp
 	return f
 }
 
-func (f *eventNSFactoryClient) updateContext(ctx context.Context) {
-	ctxFunc := postpone.ContextWithValues(ctx)
+func (f *eventNSFactoryClient) updateContext(valueCtx context.Context) {
 	f.ctxFunc = func() (context.Context, context.CancelFunc) {
-		eventCtx, cancel := ctxFunc()
+		eventCtx, cancel := f.initialCtxFunc()
+		eventCtx = extend.WithValuesFromContext(eventCtx, valueCtx)
 		return withEventFactory(eventCtx, f), cancel
 	}
 }
@@ -122,6 +125,7 @@ var _ EventFactory = &eventNSFactoryClient{}
 type eventNSFactoryServer struct {
 	state          connectionState
 	executor       serialize.Executor
+	initialCtxFunc func() (context.Context, context.CancelFunc)
 	ctxFunc        func() (context.Context, context.CancelFunc)
 	registration   *registry.NetworkService
 	response       *registry.NetworkService
@@ -131,7 +135,8 @@ type eventNSFactoryServer struct {
 
 func newNSEventFactoryServer(ctx context.Context, afterClose func()) *eventNSFactoryServer {
 	f := &eventNSFactoryServer{
-		server: next.NetworkServiceRegistryServer(ctx),
+		server:         next.NetworkServiceRegistryServer(ctx),
+		initialCtxFunc: postpone.Context(ctx),
 	}
 	f.updateContext(ctx)
 
@@ -142,10 +147,10 @@ func newNSEventFactoryServer(ctx context.Context, afterClose func()) *eventNSFac
 	return f
 }
 
-func (f *eventNSFactoryServer) updateContext(ctx context.Context) {
-	ctxFunc := postpone.ContextWithValues(ctx)
+func (f *eventNSFactoryServer) updateContext(valueCtx context.Context) {
 	f.ctxFunc = func() (context.Context, context.CancelFunc) {
-		eventCtx, cancel := ctxFunc()
+		eventCtx, cancel := f.initialCtxFunc()
+		eventCtx = extend.WithValuesFromContext(eventCtx, valueCtx)
 		return withEventFactory(eventCtx, f), cancel
 	}
 }

--- a/pkg/registry/common/begin/ns_server.go
+++ b/pkg/registry/common/begin/ns_server.go
@@ -61,8 +61,8 @@ func (b *beginNSServer) Register(ctx context.Context, in *registry.NetworkServic
 			return
 		}
 
-		ctx = withEventFactory(ctx, eventFactoryServer)
-		resp, err = next.NetworkServiceRegistryServer(ctx).Register(ctx, in)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
+		resp, err = next.NetworkServiceRegistryServer(withEventFactoryCtx).Register(withEventFactoryCtx, in)
 		if err != nil {
 			if eventFactoryServer.state != established {
 				eventFactoryServer.state = closed
@@ -102,8 +102,8 @@ func (b *beginNSServer) Unregister(ctx context.Context, in *registry.NetworkServ
 		if currentServerClient != eventFactoryServer {
 			return
 		}
-		ctx = withEventFactory(ctx, eventFactoryServer)
-		_, err = next.NetworkServiceRegistryServer(ctx).Unregister(ctx, eventFactoryServer.registration)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
+		_, err = next.NetworkServiceRegistryServer(withEventFactoryCtx).Unregister(withEventFactoryCtx, eventFactoryServer.registration)
 		eventFactoryServer.afterCloseFunc()
 	})
 	return &emptypb.Empty{}, err

--- a/pkg/registry/common/begin/nse_client.go
+++ b/pkg/registry/common/begin/nse_client.go
@@ -62,8 +62,8 @@ func (b *beginNSEClient) Register(ctx context.Context, in *registry.NetworkServi
 			return
 		}
 
-		ctx = withEventFactory(ctx, eventFactoryClient)
-		resp, err = next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, in, opts...)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryClient)
+		resp, err = next.NetworkServiceEndpointRegistryClient(withEventFactoryCtx).Register(withEventFactoryCtx, in, opts...)
 		if err != nil {
 			if eventFactoryClient.state != established {
 				eventFactoryClient.state = closed
@@ -107,8 +107,8 @@ func (b *beginNSEClient) Unregister(ctx context.Context, in *registry.NetworkSer
 			return
 		}
 		// Always close with the last valid Connection we got
-		ctx = withEventFactory(ctx, eventFactoryClient)
-		emp, err = next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, eventFactoryClient.registration, opts...)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryClient)
+		emp, err = next.NetworkServiceEndpointRegistryClient(withEventFactoryCtx).Unregister(withEventFactoryCtx, eventFactoryClient.registration, opts...)
 		// afterCloseFunc() is used to cleanup things like the entry in the Map for EventFactories
 		eventFactoryClient.afterCloseFunc()
 	})

--- a/pkg/registry/common/begin/nse_event_factory_client_test.go
+++ b/pkg/registry/common/begin/nse_event_factory_client_test.go
@@ -22,6 +22,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -29,14 +32,12 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/begin"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
-	"google.golang.org/grpc"
+	"github.com/networkservicemesh/sdk/pkg/tools/clock"
+	"github.com/networkservicemesh/sdk/pkg/tools/clockmock"
 )
 
 // This test reproduces the situation when refresh changes the eventFactory context
-func TestRefresh_Client(t *testing.T) {
+func TestContextValues_Client(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	checkCtxCl := &checkContextClient{t: t}
@@ -110,8 +111,8 @@ func TestRefreshDuringUnregister_Client(t *testing.T) {
 	nse := &registry.NetworkServiceEndpoint{
 		Name: "1",
 	}
-	conn, err := client.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, conn)
+	nse, err := client.Register(ctx, nse.Clone())
+	assert.NotNil(t, t, nse)
 	assert.NoError(t, err)
 
 	// Change context value before refresh
@@ -122,12 +123,48 @@ func TestRefreshDuringUnregister_Client(t *testing.T) {
 	eventFactoryCl.callUnregister()
 
 	// Call refresh (should be called at the same time as Unregister)
-	conn, err = client.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, conn)
+	nse, err = client.Register(ctx, nse.Clone())
+	assert.NotNil(t, t, nse)
 	assert.NoError(t, err)
 
 	// Call refresh from eventFactory. We are expecting updated value in the context
 	eventFactoryCl.callRefresh()
+}
+
+// This test checks if the timeout for the Register/Unregister called from the event factory is correct
+func TestContextTimeout_Client(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Add clockMock to the context
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
+
+	ctx, cancel = context.WithDeadline(ctx, clockMock.Now().Add(time.Second*3))
+	defer cancel()
+
+	eventFactoryCl := &eventFactoryClient{}
+	client := chain.NewNetworkServiceEndpointRegistryClient(
+		begin.NewNetworkServiceEndpointRegistryClient(),
+		eventFactoryCl,
+		&delayedNSEClient{t: t, clock: clockMock},
+	)
+
+	// Do Register
+	nse := &registry.NetworkServiceEndpoint{
+		Name: "1",
+	}
+	nse, err := client.Register(ctx, nse.Clone())
+	assert.NotNil(t, t, nse)
+	assert.NoError(t, err)
+
+	// Check eventFactory Refresh. We are expecting the same timeout as for register
+	eventFactoryCl.callRefresh()
+
+	// Check eventFactory Unregister. We are expecting the same timeout as for register
+	eventFactoryCl.callUnregister()
 }
 
 type eventFactoryClient struct {
@@ -194,5 +231,42 @@ func (f *failedNSEClient) Unregister(ctx context.Context, in *registry.NetworkSe
 	if in.Url == failedNSEURLClient {
 		return nil, errors.New("failed")
 	}
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, in, opts...)
+}
+
+type delayedNSEClient struct {
+	registry.NetworkServiceEndpointRegistryClient
+	t              *testing.T
+	clock          *clockmock.Mock
+	initialTimeout time.Duration
+}
+
+func (d *delayedNSEClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	deadline, _ := ctx.Deadline()
+	clockTime := clock.FromContext(ctx)
+	timeout := clockTime.Until(deadline)
+
+	// Check that context timeout is greater than 0
+	assert.Greater(d.t, timeout, time.Duration(0))
+
+	// For the first request
+	if d.initialTimeout == 0 {
+		d.initialTimeout = timeout
+	}
+	// All requests timeout must be equal the first
+	assert.Equal(d.t, d.initialTimeout, timeout)
+
+	// Add delay
+	d.clock.Add(timeout / 2)
+	return next.NetworkServiceEndpointRegistryClient(ctx).Register(ctx, in, opts...)
+}
+
+func (d *delayedNSEClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+	assert.Greater(d.t, d.initialTimeout, time.Duration(0))
+
+	deadline, _ := ctx.Deadline()
+	clockTime := clock.FromContext(ctx)
+
+	assert.Equal(d.t, d.initialTimeout, clockTime.Until(deadline))
 	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, in, opts...)
 }

--- a/pkg/registry/common/begin/nse_event_factory_server_test.go
+++ b/pkg/registry/common/begin/nse_event_factory_server_test.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -29,13 +31,12 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/begin"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/goleak"
+	"github.com/networkservicemesh/sdk/pkg/tools/clock"
+	"github.com/networkservicemesh/sdk/pkg/tools/clockmock"
 )
 
 // This test reproduces the situation when refresh changes the eventFactory context
-func TestRefresh_Server(t *testing.T) {
+func TestContextValues_Server(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	checkCtxServ := &checkContextServer{t: t}
@@ -109,8 +110,8 @@ func TestRefreshDuringUnregister_Server(t *testing.T) {
 	nse := &registry.NetworkServiceEndpoint{
 		Name: "1",
 	}
-	conn, err := server.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, conn)
+	nse, err := server.Register(ctx, nse.Clone())
+	assert.NotNil(t, t, nse)
 	assert.NoError(t, err)
 
 	// Change context value before refresh
@@ -121,12 +122,48 @@ func TestRefreshDuringUnregister_Server(t *testing.T) {
 	eventFactoryServ.callUnregister()
 
 	// Call refresh (should be called at the same time as Unregister)
-	conn, err = server.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, conn)
+	nse, err = server.Register(ctx, nse.Clone())
+	assert.NotNil(t, t, nse)
 	assert.NoError(t, err)
 
 	// Call refresh from eventFactory. We are expecting updated value in the context
 	eventFactoryServ.callRefresh()
+}
+
+// This test checks if the timeout for the Register/Unregister called from the event factory is correct
+func TestContextTimeout_Server(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Add clockMock to the context
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
+
+	ctx, cancel = context.WithDeadline(ctx, clockMock.Now().Add(time.Second*3))
+	defer cancel()
+
+	eventFactoryServ := &eventFactoryServer{}
+	server := chain.NewNetworkServiceEndpointRegistryServer(
+		begin.NewNetworkServiceEndpointRegistryServer(),
+		eventFactoryServ,
+		&delayedNSEServer{t: t, clock: clockMock},
+	)
+
+	// Do Register
+	nse := &registry.NetworkServiceEndpoint{
+		Name: "1",
+	}
+	nse, err := server.Register(ctx, nse.Clone())
+	assert.NotNil(t, t, nse)
+	assert.NoError(t, err)
+
+	// Check eventFactory Refresh. We are expecting the same timeout as for register
+	eventFactoryServ.callRefresh()
+
+	// Check eventFactory Unregister. We are expecting the same timeout as for register
+	eventFactoryServ.callUnregister()
 }
 
 type eventFactoryServer struct {
@@ -191,5 +228,42 @@ func (f *failedNSEServer) Unregister(ctx context.Context, in *registry.NetworkSe
 	if in.Url == failedNSEURLServer {
 		return nil, errors.New("failed")
 	}
+	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, in)
+}
+
+type delayedNSEServer struct {
+	registry.NetworkServiceEndpointRegistryServer
+	t              *testing.T
+	clock          *clockmock.Mock
+	initialTimeout time.Duration
+}
+
+func (d *delayedNSEServer) Register(ctx context.Context, in *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	deadline, _ := ctx.Deadline()
+	clockTime := clock.FromContext(ctx)
+	timeout := clockTime.Until(deadline)
+
+	// Check that context timeout is greater than 0
+	assert.Greater(d.t, timeout, time.Duration(0))
+
+	// For the first request
+	if d.initialTimeout == 0 {
+		d.initialTimeout = timeout
+	}
+	// All requests timeout must be equal the first
+	assert.Equal(d.t, d.initialTimeout, timeout)
+
+	// Add delay
+	d.clock.Add(timeout / 2)
+	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, in)
+}
+
+func (d *delayedNSEServer) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint) (*emptypb.Empty, error) {
+	assert.Greater(d.t, d.initialTimeout, time.Duration(0))
+
+	deadline, _ := ctx.Deadline()
+	clockTime := clock.FromContext(ctx)
+
+	assert.Equal(d.t, d.initialTimeout, clockTime.Until(deadline))
 	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, in)
 }

--- a/pkg/registry/common/begin/nse_event_factory_server_test.go
+++ b/pkg/registry/common/begin/nse_event_factory_server_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -60,8 +60,8 @@ func TestContextValues_Server(t *testing.T) {
 		Name: "1",
 	}
 	nse, err := server.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, nse)
-	assert.NoError(t, err)
+	require.NotNil(t, t, nse)
+	require.NoError(t, err)
 
 	// Change context value before refresh
 	ctx = context.WithValue(ctx, contextKey{}, "value_2")
@@ -70,7 +70,7 @@ func TestContextValues_Server(t *testing.T) {
 	nse.Url = failedNSEURLServer
 	checkCtxServ.setExpectedValue("value_2")
 	_, err = server.Register(ctx, nse.Clone())
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Call refresh from eventFactory. We are expecting the previous value in the context
 	checkCtxServ.setExpectedValue("value_1")
@@ -80,8 +80,8 @@ func TestContextValues_Server(t *testing.T) {
 	nse.Url = ""
 	checkCtxServ.setExpectedValue("value_2")
 	nse, err = server.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, nse)
-	assert.NoError(t, err)
+	require.NotNil(t, t, nse)
+	require.NoError(t, err)
 
 	// Call refresh from eventFactory. We are expecting updated value in the context
 	eventFactoryServ.callRefresh()
@@ -111,8 +111,8 @@ func TestRefreshDuringUnregister_Server(t *testing.T) {
 		Name: "1",
 	}
 	nse, err := server.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, nse)
-	assert.NoError(t, err)
+	require.NotNil(t, t, nse)
+	require.NoError(t, err)
 
 	// Change context value before refresh
 	ctx = context.WithValue(ctx, contextKey{}, "value_2")
@@ -123,8 +123,8 @@ func TestRefreshDuringUnregister_Server(t *testing.T) {
 
 	// Call refresh (should be called at the same time as Unregister)
 	nse, err = server.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, nse)
-	assert.NoError(t, err)
+	require.NotNil(t, t, nse)
+	require.NoError(t, err)
 
 	// Call refresh from eventFactory. We are expecting updated value in the context
 	eventFactoryServ.callRefresh()
@@ -156,8 +156,8 @@ func TestContextTimeout_Server(t *testing.T) {
 		Name: "1",
 	}
 	nse, err := server.Register(ctx, nse.Clone())
-	assert.NotNil(t, t, nse)
-	assert.NoError(t, err)
+	require.NotNil(t, t, nse)
+	require.NoError(t, err)
 
 	// Check eventFactory Refresh. We are expecting the same timeout as for register
 	eventFactoryServ.callRefresh()
@@ -199,7 +199,7 @@ type checkContextServer struct {
 }
 
 func (c *checkContextServer) Register(ctx context.Context, in *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	assert.Equal(c.t, c.expectedValue, ctx.Value(contextKey{}))
+	require.Equal(c.t, c.expectedValue, ctx.Value(contextKey{}))
 	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, in)
 }
 
@@ -244,14 +244,14 @@ func (d *delayedNSEServer) Register(ctx context.Context, in *registry.NetworkSer
 	timeout := clockTime.Until(deadline)
 
 	// Check that context timeout is greater than 0
-	assert.Greater(d.t, timeout, time.Duration(0))
+	require.Greater(d.t, timeout, time.Duration(0))
 
 	// For the first request
 	if d.initialTimeout == 0 {
 		d.initialTimeout = timeout
 	}
 	// All requests timeout must be equal the first
-	assert.Equal(d.t, d.initialTimeout, timeout)
+	require.Equal(d.t, d.initialTimeout, timeout)
 
 	// Add delay
 	d.clock.Add(timeout / 2)
@@ -259,11 +259,11 @@ func (d *delayedNSEServer) Register(ctx context.Context, in *registry.NetworkSer
 }
 
 func (d *delayedNSEServer) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint) (*emptypb.Empty, error) {
-	assert.Greater(d.t, d.initialTimeout, time.Duration(0))
+	require.Greater(d.t, d.initialTimeout, time.Duration(0))
 
 	deadline, _ := ctx.Deadline()
 	clockTime := clock.FromContext(ctx)
 
-	assert.Equal(d.t, d.initialTimeout, clockTime.Until(deadline))
+	require.Equal(d.t, d.initialTimeout, clockTime.Until(deadline))
 	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, in)
 }

--- a/pkg/registry/common/begin/nse_server.go
+++ b/pkg/registry/common/begin/nse_server.go
@@ -61,8 +61,8 @@ func (b *beginNSEServer) Register(ctx context.Context, in *registry.NetworkServi
 			return
 		}
 
-		ctx = withEventFactory(ctx, eventFactoryServer)
-		resp, err = next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, in)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
+		resp, err = next.NetworkServiceEndpointRegistryServer(withEventFactoryCtx).Register(withEventFactoryCtx, in)
 		if err != nil {
 			if eventFactoryServer.state != established {
 				eventFactoryServer.state = closed
@@ -102,8 +102,8 @@ func (b *beginNSEServer) Unregister(ctx context.Context, in *registry.NetworkSer
 		if currentServerClient != eventFactoryServer {
 			return
 		}
-		ctx = withEventFactory(ctx, eventFactoryServer)
-		_, err = next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, eventFactoryServer.registration)
+		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
+		_, err = next.NetworkServiceEndpointRegistryServer(withEventFactoryCtx).Unregister(withEventFactoryCtx, eventFactoryServer.registration)
 		eventFactoryServer.afterCloseFunc()
 	})
 	return &emptypb.Empty{}, err


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
In the current implementation, we update the `eventFactory` context [after a successful request](https://github.com/networkservicemesh/sdk/blob/main/pkg/networkservice/common/begin/client.go#L85).
This is not quite right, because in addition to updating the context values, we also update **_the request timeout_**. It is calculated on the wayback.
For example, the request came with a timeout of 15s and took 5s. For the event factory, we calculate 10s, but we need 15s.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
