### PR TITLE
Add priorityMechanisms chain element

### DIFF
--- a/pkg/networkservice/common/prioritymechanisms/client.go
+++ b/pkg/networkservice/common/prioritymechanisms/client.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package prioritymechanisms prioritize mechanisms according to the list
+package prioritymechanisms
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+)
+
+type priorityMechanismsClient struct {
+	priorities map[string]int
+}
+
+// NewClient - returns a new client chain element that prioritize mechanisms according to the list
+func NewClient(priorities []string) networkservice.NetworkServiceClient {
+	c := &priorityMechanismsClient{
+		priorities: map[string]int{},
+	}
+	for i, p := range priorities {
+		c.priorities[strings.ToUpper(p)] = i
+	}
+
+	return c
+}
+
+func (p *priorityMechanismsClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	request.MechanismPreferences = prioritizeMechanismsByType(request.GetMechanismPreferences(), p.priorities)
+	return next.Client(ctx).Request(ctx, request, opts...)
+}
+
+func (p *priorityMechanismsClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.Client(ctx).Close(ctx, conn, opts...)
+}
+
+func prioritizeMechanismsByType(mechanisms []*networkservice.Mechanism, priorities map[string]int) []*networkservice.Mechanism {
+	var head, tail []*networkservice.Mechanism
+	for _, mechanism := range mechanisms {
+		if _, ok := priorities[mechanism.GetType()]; ok {
+			head = append(head, mechanism)
+		} else {
+			tail = append(tail, mechanism)
+		}
+	}
+	sort.Slice(head, func(i, j int) bool {
+		return priorities[head[i].GetType()] < priorities[head[j].GetType()]
+	})
+
+	return append(head, tail...)
+}

--- a/pkg/networkservice/common/prioritymechanisms/client_test.go
+++ b/pkg/networkservice/common/prioritymechanisms/client_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prioritymechanisms_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/memif"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/srv6"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/vxlan"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/wireguard"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/prioritymechanisms"
+)
+
+func TestPriorityMechanismsClient_Request(t *testing.T) {
+	request := func() *networkservice.NetworkServiceRequest {
+		return &networkservice.NetworkServiceRequest{
+			MechanismPreferences: []*networkservice.Mechanism{
+				{
+					Cls:  cls.REMOTE,
+					Type: srv6.MECHANISM,
+				},
+				{
+					Cls:  cls.REMOTE,
+					Type: vxlan.MECHANISM,
+				},
+				{
+					Cls:  cls.REMOTE,
+					Type: wireguard.MECHANISM,
+				},
+				{
+					Cls:  cls.LOCAL,
+					Type: kernel.MECHANISM,
+				},
+				{
+					Cls:  cls.LOCAL,
+					Type: memif.MECHANISM,
+				},
+			},
+		}
+	}
+	samples := []struct {
+		Name           string
+		Priorities     []string
+		ExpectedResult []string
+	}{
+		{
+			Name:           "No priority",
+			ExpectedResult: []string{srv6.MECHANISM, vxlan.MECHANISM, wireguard.MECHANISM, kernel.MECHANISM, memif.MECHANISM},
+		},
+		{
+			Name:           "One priority",
+			Priorities:     []string{vxlan.MECHANISM},
+			ExpectedResult: []string{vxlan.MECHANISM, srv6.MECHANISM, wireguard.MECHANISM, kernel.MECHANISM, memif.MECHANISM},
+		},
+		{
+			Name:           "Multi priorities",
+			Priorities:     []string{kernel.MECHANISM, wireguard.MECHANISM, srv6.MECHANISM},
+			ExpectedResult: []string{kernel.MECHANISM, wireguard.MECHANISM, srv6.MECHANISM, vxlan.MECHANISM, memif.MECHANISM},
+		},
+		{
+			Name:           "Not supported mechanism in priority list",
+			Priorities:     []string{"NOT_SUPPORTED", vxlan.MECHANISM},
+			ExpectedResult: []string{vxlan.MECHANISM, srv6.MECHANISM, wireguard.MECHANISM, kernel.MECHANISM, memif.MECHANISM},
+		},
+	}
+
+	for _, sample := range samples {
+		c := prioritymechanisms.NewClient(sample.Priorities)
+		req := request()
+		_, err := c.Request(context.Background(), req)
+		require.NoError(t, err)
+		require.NotEmpty(t, req.MechanismPreferences)
+
+		require.Equal(t, len(sample.ExpectedResult), len(req.MechanismPreferences))
+		for i := range req.MechanismPreferences {
+			require.Equal(t, sample.ExpectedResult[i], req.MechanismPreferences[i].Type)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
This PR adds `priorityMechanisms` chain element.
The input is a list of mechanisms by priority. On the Request, the chain element sorts the mechanism preferences according to these priorities.

This element will be used on the forwarder.

## Issue link
https://github.com/networkservicemesh/sdk-vpp/issues/638


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
