### PR TITLE
Fix empty map panic in networkservice authorize.Close

### DIFF
--- a/pkg/networkservice/common/authorize/server.go
+++ b/pkg/networkservice/common/authorize/server.go
@@ -100,10 +100,13 @@ func (a *authorizeServer) Close(ctx context.Context, conn *networkservice.Connec
 			}
 		}
 		idsEmpty := true
-		ids.Range(func(_ string, _ struct{}) bool {
-			idsEmpty = false
-			return true
-		})
+		if ok {
+			ids.Range(func(_ string, _ struct{}) bool {
+				idsEmpty = false
+				return true
+			})
+		}
+
 		if idsEmpty {
 			a.spiffeIDConnectionMap.Delete(spiffeID)
 		} else {

--- a/pkg/networkservice/common/authorize/server.go
+++ b/pkg/networkservice/common/authorize/server.go
@@ -94,16 +94,15 @@ func (a *authorizeServer) Close(ctx context.Context, conn *networkservice.Connec
 	if spiffeID, err := spire.SpiffeIDFromContext(ctx); err == nil {
 		connID := conn.GetPath().GetPathSegments()[index-1].GetId()
 		ids, ok := a.spiffeIDConnectionMap.Load(spiffeID)
+		idsEmpty := true
 		if ok {
 			if _, loaded := ids.Load(connID); loaded {
 				ids.Delete(connID)
 			}
-		}
-		idsEmpty := true
-		if ok {
+
 			ids.Range(func(_ string, _ struct{}) bool {
 				idsEmpty = false
-				return true
+				return false
 			})
 		}
 

--- a/pkg/networkservice/common/authorize/server.go
+++ b/pkg/networkservice/common/authorize/server.go
@@ -95,7 +95,7 @@ func (a *authorizeServer) Close(ctx context.Context, conn *networkservice.Connec
 		connID := conn.GetPath().GetPathSegments()[index-1].GetId()
 		ids, ok := a.spiffeIDConnectionMap.Load(spiffeID)
 		if ok {
-			if _, ok := ids.Load(connID); ok {
+			if _, loaded := ids.Load(connID); loaded {
 				ids.Delete(connID)
 			}
 		}

--- a/pkg/networkservice/common/authorize/server_test.go
+++ b/pkg/networkservice/common/authorize/server_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/networkservice/common/authorize/server_test.go
+++ b/pkg/networkservice/common/authorize/server_test.go
@@ -18,7 +18,15 @@ package authorize_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"math/big"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/opa"
 
@@ -26,11 +34,41 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 )
+
+func generateCert(u *url.URL) []byte {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(1653),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		URIs:         []*url.URL{u},
+	}
+
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	pub := &priv.PublicKey
+
+	certBytes, _ := x509.CreateCertificate(rand.Reader, ca, ca, pub, priv)
+	return certBytes
+}
+
+func withPeer(ctx context.Context, certBytes []byte) (context.Context, error) {
+	x509cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	authInfo := &credentials.TLSInfo{
+		State: tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{x509cert},
+		},
+	}
+	return peer.NewContext(ctx, &peer.Peer{AuthInfo: authInfo}), nil
+}
 
 func testPolicy() authorize.Policy {
 	return opa.WithPolicyFromSource(`
@@ -128,4 +166,28 @@ func TestAuthzEndpoint(t *testing.T) {
 			checkResult(err)
 		})
 	}
+}
+
+func TestAuthorize_EmptySpiffeIDConnectionMapOnClose(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	conn := &networkservice.Connection{
+		Id: "conn",
+		Path: &networkservice.Path{
+			Index: 1,
+			PathSegments: []*networkservice.PathSegment{
+				{Id: "id-1"},
+				{Id: "id-2"},
+			},
+		},
+	}
+
+	server := authorize.NewServer(authorize.Any())
+	certBytes := generateCert(&url.URL{Scheme: "spiffe", Host: "test.com", Path: "test"})
+
+	ctx, err := withPeer(context.Background(), certBytes)
+	require.NoError(t, err)
+
+	_, err = server.Close(ctx, conn)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Signed-off-by: Nikita Skrynnik <nikita.skrynnik@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/deployments-k8s/issues/7792

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
