### PR TITLE
fix: Return backward compatibility

### DIFF
--- a/pkg/registry/common/authorize/ns_client.go
+++ b/pkg/registry/common/authorize/ns_client.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/registry/common/grpcmetadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/opa"
 	"github.com/networkservicemesh/sdk/pkg/tools/postpone"
 )
 
@@ -51,18 +50,8 @@ func NewNetworkServiceRegistryClient(opts ...Option) registry.NetworkServiceRegi
 		opt(o)
 	}
 
-	policies, err := opa.PoliciesByFileMask(o.policyPaths...)
-	if err != nil {
-		panic(errors.Wrap(err, "failed to read policies in NetworkServiceRegistry authorize client").Error())
-	}
-
-	var policyList policiesList
-	for _, p := range policies {
-		policyList = append(policyList, p)
-	}
-
 	return &authorizeNSClient{
-		policies:     policyList,
+		policies:     o.policies,
 		nsPathIdsMap: o.resourcePathIdsMap,
 	}
 }

--- a/pkg/registry/common/authorize/ns_server.go
+++ b/pkg/registry/common/authorize/ns_server.go
@@ -21,13 +21,11 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/common/grpcmetadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/opa"
 )
 
 type authorizeNSServer struct {
@@ -46,18 +44,8 @@ func NewNetworkServiceRegistryServer(opts ...Option) registry.NetworkServiceRegi
 		opt(o)
 	}
 
-	policies, err := opa.PoliciesByFileMask(o.policyPaths...)
-	if err != nil {
-		panic(errors.Wrap(err, "failed to read policies in NetworkServiceRegistry authorize client").Error())
-	}
-
-	var policyList policiesList
-	for _, p := range policies {
-		policyList = append(policyList, p)
-	}
-
 	return &authorizeNSServer{
-		policies:     policyList,
+		policies:     o.policies,
 		nsPathIdsMap: o.resourcePathIdsMap,
 	}
 }

--- a/pkg/registry/common/authorize/nse_client.go
+++ b/pkg/registry/common/authorize/nse_client.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/registry/common/grpcmetadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/opa"
 	"github.com/networkservicemesh/sdk/pkg/tools/postpone"
 )
 
@@ -51,18 +50,8 @@ func NewNetworkServiceEndpointRegistryClient(opts ...Option) registry.NetworkSer
 		opt(o)
 	}
 
-	policies, err := opa.PoliciesByFileMask(o.policyPaths...)
-	if err != nil {
-		panic(errors.Wrap(err, "failed to read policies in NetworkServiceRegistry authorize client").Error())
-	}
-
-	var policyList policiesList
-	for _, p := range policies {
-		policyList = append(policyList, p)
-	}
-
 	return &authorizeNSEClient{
-		policies:      policyList,
+		policies:      o.policies,
 		nsePathIdsMap: o.resourcePathIdsMap,
 	}
 }

--- a/pkg/registry/common/authorize/nse_server.go
+++ b/pkg/registry/common/authorize/nse_server.go
@@ -21,13 +21,11 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/common/grpcmetadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/opa"
 )
 
 type authorizeNSEServer struct {
@@ -46,18 +44,8 @@ func NewNetworkServiceEndpointRegistryServer(opts ...Option) registry.NetworkSer
 		opt(o)
 	}
 
-	policies, err := opa.PoliciesByFileMask(o.policyPaths...)
-	if err != nil {
-		panic(errors.Wrap(err, "failed to read policies in NetworkServiceRegistry authorize client").Error())
-	}
-
-	var policyList policiesList
-	for _, p := range policies {
-		policyList = append(policyList, p)
-	}
-
 	return &authorizeNSEServer{
-		policies:      policyList,
+		policies:      o.policies,
 		nsePathIdsMap: o.resourcePathIdsMap,
 	}
 }

--- a/pkg/registry/common/authorize/options.go
+++ b/pkg/registry/common/authorize/options.go
@@ -17,8 +17,9 @@
 package authorize
 
 import (
-	"github.com/networkservicemesh/sdk/pkg/tools/opa"
 	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/opa"
 )
 
 type options struct {

--- a/pkg/registry/common/authorize/options.go
+++ b/pkg/registry/common/authorize/options.go
@@ -16,8 +16,13 @@
 
 package authorize
 
+import (
+	"github.com/networkservicemesh/sdk/pkg/tools/opa"
+	"github.com/pkg/errors"
+)
+
 type options struct {
-	policyPaths        []string
+	policies           policiesList
 	resourcePathIdsMap *PathIdsMap
 }
 
@@ -27,7 +32,7 @@ type Option func(*options)
 // Any authorizes any call of request/close
 func Any() Option {
 	return func(o *options) {
-		o.policyPaths = nil
+		o.policies = nil
 	}
 }
 
@@ -35,7 +40,14 @@ func Any() Option {
 // policyPaths can be combination of both policy files and dirs with policies
 func WithPolicies(policyPaths ...string) Option {
 	return func(o *options) {
-		o.policyPaths = policyPaths
+		policies, err := opa.PoliciesByFileMask(policyPaths...)
+		if err != nil {
+			panic(errors.Wrap(err, "failed to read policies in NetworkServiceRegistry authorize client").Error())
+		}
+
+		for _, p := range policies {
+			o.policies = append(o.policies, Policy(p))
+		}
 	}
 }
 

--- a/pkg/registry/common/grpcmetadata/ns_client.go
+++ b/pkg/registry/common/grpcmetadata/ns_client.go
@@ -47,26 +47,24 @@ func (c *grpcMetadataNSClient) Register(ctx context.Context, ns *registry.Networ
 
 	var header metadata.MD
 	opts = append(opts, grpc.Header(&header))
+
 	resp, err := next.NetworkServiceRegistryClient(ctx).Register(ctx, ns, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	newpath, err := loadFromMetadata(header)
-	if err != nil {
-		return nil, err
-	}
+	newpath, err := fromMD(header)
 
-	path.Index = newpath.Index
-	path.PathSegments = newpath.PathSegments
+	if err == nil {
+		path.Index = newpath.Index
+		path.PathSegments = newpath.PathSegments
+	}
 
 	return resp, nil
 }
 
 func (c *grpcMetadataNSClient) Find(ctx context.Context, query *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
-	resp, err := next.NetworkServiceRegistryClient(ctx).Find(ctx, query, opts...)
-
-	return resp, err
+	return next.NetworkServiceRegistryClient(ctx).Find(ctx, query, opts...)
 }
 
 func (c *grpcMetadataNSClient) Unregister(ctx context.Context, ns *registry.NetworkService, opts ...grpc.CallOption) (*empty.Empty, error) {
@@ -77,10 +75,5 @@ func (c *grpcMetadataNSClient) Unregister(ctx context.Context, ns *registry.Netw
 		return nil, err
 	}
 
-	resp, err := next.NetworkServiceRegistryClient(ctx).Unregister(ctx, ns, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return next.NetworkServiceRegistryClient(ctx).Unregister(ctx, ns, opts...)
 }

--- a/pkg/registry/common/grpcmetadata/nse_client.go
+++ b/pkg/registry/common/grpcmetadata/nse_client.go
@@ -51,13 +51,12 @@ func (c *grpcMetadataNSEClient) Register(ctx context.Context, nse *registry.Netw
 		return nil, err
 	}
 
-	newpath, err := loadFromMetadata(header)
-	if err != nil {
-		return nil, err
-	}
+	newpath, err := fromMD(header)
 
-	path.Index = newpath.Index
-	path.PathSegments = newpath.PathSegments
+	if err == nil {
+		path.Index = newpath.Index
+		path.PathSegments = newpath.PathSegments
+	}
 
 	return resp, nil
 }
@@ -74,10 +73,5 @@ func (c *grpcMetadataNSEClient) Unregister(ctx context.Context, nse *registry.Ne
 		return nil, err
 	}
 
-	resp, err := next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
 }

--- a/pkg/registry/common/grpcmetadata/nse_test.go
+++ b/pkg/registry/common/grpcmetadata/nse_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/stretchr/testify/require"
@@ -125,4 +126,86 @@ func TestGRPCMetadataNetworkServiceEndpoint(t *testing.T) {
 
 	serverGRPCServer.Stop()
 	proxyGRPCServer.Stop()
+}
+
+func TestGRPCMetadataNetworkServiceEndpoint_BackwardCompatibility(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cacncel := context.WithTimeout(context.Background(), time.Second)
+	defer cacncel()
+
+	clientToken, _, _ := tokenGeneratorFunc(clientID)(nil)
+
+	serverLis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := next.NewNetworkServiceEndpointRegistryServer()
+
+	serverGRPCServer := grpc.NewServer()
+	defer func() {
+		serverGRPCServer.Stop()
+	}()
+	registry.RegisterNetworkServiceEndpointRegistryServer(serverGRPCServer, server)
+	go func() {
+		serveErr := serverGRPCServer.Serve(serverLis)
+		require.NoError(t, serveErr)
+	}()
+
+	proxyLis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	serverConn, err := grpc.Dial(serverLis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer func() {
+		closeErr := serverConn.Close()
+		require.NoError(t, closeErr)
+	}()
+
+	proxyServer := next.NewNetworkServiceEndpointRegistryServer(
+		injectpeertoken.NewNetworkServiceEndpointRegistryServer(clientToken),
+		grpcmetadata.NewNetworkServiceEndpointRegistryServer(),
+		updatepath.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(proxyID)),
+		checkcontext.NewNSEServer(t, func(t *testing.T, ctx context.Context) {
+			path := grpcmetadata.PathFromContext(ctx)
+			require.Equal(t, int(path.Index), 1)
+		}),
+		adapters.NetworkServiceEndpointClientToServer(next.NewNetworkServiceEndpointRegistryClient(
+			grpcmetadata.NewNetworkServiceEndpointRegistryClient(),
+			registry.NewNetworkServiceEndpointRegistryClient(serverConn),
+		)),
+	)
+
+	proxyGRPCServer := grpc.NewServer()
+	defer func() {
+		proxyGRPCServer.Stop()
+	}()
+	registry.RegisterNetworkServiceEndpointRegistryServer(proxyGRPCServer, proxyServer)
+	go func() {
+		serveErr := proxyGRPCServer.Serve(proxyLis)
+		require.NoError(t, serveErr)
+	}()
+
+	conn, err := grpc.Dial(proxyLis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer func() {
+		closeErr := conn.Close()
+		require.NoError(t, closeErr)
+	}()
+
+	client := next.NewNetworkServiceEndpointRegistryClient(
+		grpcmetadata.NewNetworkServiceEndpointRegistryClient(),
+		registry.NewNetworkServiceEndpointRegistryClient(conn))
+
+	path := grpcmetadata.Path{}
+	ctx = grpcmetadata.PathWithContext(ctx, &path)
+
+	ns := &registry.NetworkServiceEndpoint{Name: "ns"}
+	_, err = client.Register(ctx, ns)
+	require.NoError(t, err)
+
+	require.Equal(t, int(path.Index), 0)
+	require.Len(t, path.PathSegments, 2)
+
+	_, err = client.Unregister(ctx, ns)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
We can make a private path from grpcmetadata optional. 

If registry auth is enabled then OPA will fail registers/unregisters by default policies for any combinations of old/new components.
If registry auth is disabled then the private path could be invalid, but old NSM could work with any combination of old/new components.

## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/8187


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
