### PR TITLE
[qfix] Return empty spiffeID if path is empty

### DIFF
--- a/pkg/registry/common/authorize/ns_client.go
+++ b/pkg/registry/common/authorize/ns_client.go
@@ -80,13 +80,9 @@ func (c *authorizeNSClient) Register(ctx context.Context, ns *registry.NetworkSe
 	}
 
 	path = grpcmetadata.PathFromContext(ctx)
-
-	spiffeID, err := getSpiffeIDFromPath(path)
-	if err != nil {
-		return nil, err
-	}
-
+	spiffeID := getSpiffeIDFromPath(ctx, path)
 	rawMap := getRawMap(c.nsPathIdsMap)
+
 	input := RegistryOpaInput{
 		ResourceID:         spiffeID.String(),
 		ResourceName:       resp.Name,
@@ -127,13 +123,9 @@ func (c *authorizeNSClient) Unregister(ctx context.Context, ns *registry.Network
 	}
 
 	path = grpcmetadata.PathFromContext(ctx)
-
-	spiffeID, err := getSpiffeIDFromPath(path)
-	if err != nil {
-		return nil, err
-	}
-
+	spiffeID := getSpiffeIDFromPath(ctx, path)
 	rawMap := getRawMap(c.nsPathIdsMap)
+
 	input := RegistryOpaInput{
 		ResourceID:         spiffeID.String(),
 		ResourceName:       ns.Name,

--- a/pkg/registry/common/authorize/ns_server.go
+++ b/pkg/registry/common/authorize/ns_server.go
@@ -56,11 +56,7 @@ func (s *authorizeNSServer) Register(ctx context.Context, ns *registry.NetworkSe
 	}
 
 	path := grpcmetadata.PathFromContext(ctx)
-
-	spiffeID, err := getSpiffeIDFromPath(path)
-	if err != nil {
-		return nil, err
-	}
+	spiffeID := getSpiffeIDFromPath(ctx, path)
 
 	index := path.Index
 	var leftSide = &grpcmetadata.Path{
@@ -94,11 +90,7 @@ func (s *authorizeNSServer) Unregister(ctx context.Context, ns *registry.Network
 	}
 
 	path := grpcmetadata.PathFromContext(ctx)
-
-	spiffeID, err := getSpiffeIDFromPath(path)
-	if err != nil {
-		return nil, err
-	}
+	spiffeID := getSpiffeIDFromPath(ctx, path)
 
 	index := path.Index
 	var leftSide = &grpcmetadata.Path{

--- a/pkg/registry/common/authorize/nse_client.go
+++ b/pkg/registry/common/authorize/nse_client.go
@@ -81,11 +81,7 @@ func (c *authorizeNSEClient) Register(ctx context.Context, nse *registry.Network
 	}
 
 	path = grpcmetadata.PathFromContext(ctx)
-
-	spiffeID, err := getSpiffeIDFromPath(path)
-	if err != nil {
-		return nil, err
-	}
+	spiffeID := getSpiffeIDFromPath(ctx, path)
 
 	rawMap := getRawMap(c.nsePathIdsMap)
 	input := RegistryOpaInput{
@@ -134,11 +130,7 @@ func (c *authorizeNSEClient) Unregister(ctx context.Context, nse *registry.Netwo
 	}
 
 	path = grpcmetadata.PathFromContext(ctx)
-
-	spiffeID, err := getSpiffeIDFromPath(path)
-	if err != nil {
-		return nil, err
-	}
+	spiffeID := getSpiffeIDFromPath(ctx, path)
 
 	rawMap := getRawMap(c.nsePathIdsMap)
 	input := RegistryOpaInput{

--- a/pkg/registry/common/authorize/nse_server.go
+++ b/pkg/registry/common/authorize/nse_server.go
@@ -56,11 +56,7 @@ func (s *authorizeNSEServer) Register(ctx context.Context, nse *registry.Network
 	}
 
 	path := grpcmetadata.PathFromContext(ctx)
-
-	spiffeID, err := getSpiffeIDFromPath(path)
-	if err != nil {
-		return nil, err
-	}
+	spiffeID := getSpiffeIDFromPath(ctx, path)
 
 	index := path.Index
 	var leftSide = &grpcmetadata.Path{
@@ -95,11 +91,7 @@ func (s *authorizeNSEServer) Unregister(ctx context.Context, nse *registry.Netwo
 	}
 
 	path := grpcmetadata.PathFromContext(ctx)
-
-	spiffeID, err := getSpiffeIDFromPath(path)
-	if err != nil {
-		return nil, err
-	}
+	spiffeID := getSpiffeIDFromPath(ctx, path)
 
 	index := path.Index
 	var leftSide = &grpcmetadata.Path{


### PR DESCRIPTION
Signed-off-by: Nikita Skrynnik <nikita.skrynnik@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
getSpiffeIDFromPath should return empty spiffeID from empty path. For backward compatibility.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
