### PR TITLE
Fix timeout/expire chain elements

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -276,7 +276,7 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		opts.authorizeNSERegistryServer,
 		begin.NewNetworkServiceEndpointRegistryServer(),
 		registryclientinfo.NewNetworkServiceEndpointRegistryServer(),
-		expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
+		expire.NewNetworkServiceEndpointRegistryServer(ctx),
 		registryrecvfd.NewNetworkServiceEndpointRegistryServer(), // Allow to receive a passed files
 		registrysendfd.NewNetworkServiceEndpointRegistryServer(),
 		remoteOrLocalRegistry,

--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -272,9 +272,9 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 
 	var nseRegistry = chain.NewNetworkServiceEndpointRegistryServer(
 		grpcmetadata.NewNetworkServiceEndpointRegistryServer(),
-		begin.NewNetworkServiceEndpointRegistryServer(),
 		updatepath.NewNetworkServiceEndpointRegistryServer(tokenGenerator),
 		opts.authorizeNSERegistryServer,
+		begin.NewNetworkServiceEndpointRegistryServer(),
 		registryclientinfo.NewNetworkServiceEndpointRegistryServer(),
 		expire.NewNetworkServiceEndpointRegistryServer(ctx, time.Minute),
 		registryrecvfd.NewNetworkServiceEndpointRegistryServer(), // Allow to receive a passed files

--- a/pkg/networkservice/chains/nsmgr/single_test.go
+++ b/pkg/networkservice/chains/nsmgr/single_test.go
@@ -264,7 +264,6 @@ func Test_UsecasePoint2MultiPoint(t *testing.T) {
 		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, _ int) {
 			node.NewNSMgr(ctx, "nsmgr", nil, sandbox.GenerateTestToken, nsmgr.NewServer)
 		}).
-		SetRegistryExpiryDuration(time.Second).
 		Build()
 
 	domain.Nodes[0].NewForwarder(ctx, &registryapi.NetworkServiceEndpoint{
@@ -386,7 +385,6 @@ func Test_RemoteUsecase_Point2MultiPoint(t *testing.T) {
 		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, _ int) {
 			node.NewNSMgr(ctx, "nsmgr", nil, sandbox.GenerateTestToken, nsmgr.NewServer)
 		}).
-		SetRegistryExpiryDuration(time.Second).
 		Build()
 
 	for i := 0; i < nodeCount; i++ {
@@ -521,7 +519,6 @@ func Test_FailedRegistryAuthorization(t *testing.T) {
 	registrySupplier := func(
 		ctx context.Context,
 		tokenGenerator token.GeneratorFunc,
-		expiryDuration time.Duration,
 		proxyRegistryURL *url.URL,
 		options ...grpc.DialOption) registry.Registry {
 		registryName := sandbox.UniqueName("registry-memory")
@@ -529,7 +526,6 @@ func Test_FailedRegistryAuthorization(t *testing.T) {
 		return memory.NewServer(
 			ctx,
 			tokenGeneratorFunc("spiffe://test.com/"+registryName),
-			memory.WithExpireDuration(expiryDuration),
 			memory.WithProxyRegistryURL(proxyRegistryURL),
 			memory.WithDialOptions(options...),
 			memory.WithAuthorizeNSRegistryServer(
@@ -692,13 +688,11 @@ func Test_Expire(t *testing.T) {
 	registrySupplier := func(
 		ctx context.Context,
 		tokenGenerator token.GeneratorFunc,
-		expiryDuration time.Duration,
 		proxyRegistryURL *url.URL,
 		options ...grpc.DialOption) registry.Registry {
 		return memory.NewServer(
 			ctx,
 			tokenGenerator,
-			memory.WithExpireDuration(expiryDuration),
 			memory.WithProxyRegistryURL(proxyRegistryURL),
 			memory.WithDialOptions(options...),
 			memory.WithAuthorizeNSRegistryServer(

--- a/pkg/networkservice/chains/nsmgr/single_test.go
+++ b/pkg/networkservice/chains/nsmgr/single_test.go
@@ -27,25 +27,32 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
-	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
-	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/cls"
+	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/excludedprefixes"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/ipam/point2pointipam"
+	countutils "github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injecterror"
 	"github.com/networkservicemesh/sdk/pkg/registry"
+	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/registry/chains/memory"
-	"github.com/networkservicemesh/sdk/pkg/registry/common/authorize"
+	authorizeregistry "github.com/networkservicemesh/sdk/pkg/registry/common/authorize"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
+	injecterrorregistry "github.com/networkservicemesh/sdk/pkg/registry/utils/inject/injecterror"
 	"github.com/networkservicemesh/sdk/pkg/tools/clientinfo"
+	"github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
@@ -500,13 +507,13 @@ func Test_FailedRegistryAuthorization(t *testing.T) {
 	nsmgrSuppier := func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgr.Option) nsmgr.Nsmgr {
 		options = append(options,
 			nsmgr.WithAuthorizeNSERegistryServer(
-				authorize.NewNetworkServiceEndpointRegistryServer(authorize.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
+				authorizeregistry.NewNetworkServiceEndpointRegistryServer(authorizeregistry.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
 			nsmgr.WithAuthorizeNSRegistryServer(
-				authorize.NewNetworkServiceRegistryServer(authorize.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
+				authorizeregistry.NewNetworkServiceRegistryServer(authorizeregistry.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
 			nsmgr.WithAuthorizeNSERegistryClient(
-				authorize.NewNetworkServiceEndpointRegistryClient(authorize.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
+				authorizeregistry.NewNetworkServiceEndpointRegistryClient(authorizeregistry.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
 			nsmgr.WithAuthorizeNSRegistryClient(
-				authorize.NewNetworkServiceRegistryClient(authorize.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
+				authorizeregistry.NewNetworkServiceRegistryClient(authorizeregistry.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
 		)
 		return nsmgr.NewServer(ctx, tokenGenerator, options...)
 	}
@@ -526,7 +533,7 @@ func Test_FailedRegistryAuthorization(t *testing.T) {
 			memory.WithProxyRegistryURL(proxyRegistryURL),
 			memory.WithDialOptions(options...),
 			memory.WithAuthorizeNSRegistryServer(
-				authorize.NewNetworkServiceRegistryServer(authorize.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
+				authorizeregistry.NewNetworkServiceRegistryServer(authorizeregistry.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
 		)
 	}
 	domain := sandbox.NewBuilder(ctx, t).
@@ -553,7 +560,7 @@ func Test_FailedRegistryAuthorization(t *testing.T) {
 
 	nsRegistryClient1 := domain.NewNSRegistryClient(ctx, tokenGeneratorFunc("spiffe://test.com/ns-1"),
 		registryclient.WithAuthorizeNSRegistryClient(
-			authorize.NewNetworkServiceRegistryClient(authorize.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))))
+			authorizeregistry.NewNetworkServiceRegistryClient(authorizeregistry.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))))
 
 	ns1 := defaultRegistryService("ns-1")
 	_, err := nsRegistryClient1.Register(ctx, ns1)
@@ -561,9 +568,186 @@ func Test_FailedRegistryAuthorization(t *testing.T) {
 
 	nsRegistryClient2 := domain.NewNSRegistryClient(ctx, tokenGeneratorFunc("spiffe://test.com/ns-2"),
 		registryclient.WithAuthorizeNSRegistryClient(
-			authorize.NewNetworkServiceRegistryClient(authorize.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))))
+			authorizeregistry.NewNetworkServiceRegistryClient(authorizeregistry.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))))
 
 	ns2 := defaultRegistryService("ns-1")
 	_, err = nsRegistryClient2.Register(ctx, ns2)
 	require.Error(t, err)
+}
+
+func createAuthorizedEndpoint(ctx context.Context, t *testing.T, ns string, nsmgrURL *url.URL, counter networkservice.NetworkServiceServer) {
+	nseReg := defaultRegistryEndpoint(ns)
+
+	nse := endpoint.NewServer(ctx, sandbox.GenerateTestToken,
+		endpoint.WithName("final-endpoint"),
+		endpoint.WithAuthorizeServer(authorize.NewServer(authorize.WithPolicies("etc/nsm/opa/common/tokens_expired.rego"))),
+		endpoint.WithAdditionalFunctionality(counter),
+	)
+
+	nseServer := grpc.NewServer()
+	nse.Register(nseServer)
+	nseURL := &url.URL{Scheme: "tcp", Host: "127.0.0.1:0"}
+	errCh := grpcutils.ListenAndServe(ctx, nseURL, nseServer)
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(
+		ctx,
+		registryclient.WithClientURL(nsmgrURL),
+		registryclient.WithDialOptions(sandbox.DialOptions(sandbox.WithTokenGenerator(sandbox.GenerateTestToken))...),
+		registryclient.WithNSEAdditionalFunctionality(sendfd.NewNetworkServiceEndpointRegistryClient()),
+	)
+
+	nseReg.Url = nseURL.String()
+	_, err := nseRegistryClient.Register(ctx, nseReg.Clone())
+	require.NoError(t, err)
+}
+
+// This test checks timeout on sandbox
+// We run nsmgr and NSE with networkservice authorize chain element (tokens_expired.rego)
+func Test_Timeout(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	// timeout chain element will call Close() after (tokenTimeout - requestTimeout)
+	// to be sure that token is not expired
+	tokenTimeout := time.Second * 2
+	requestTimeout := time.Second + time.Millisecond*500
+
+	chainCtx, chainCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer chainCtxCancel()
+
+	// Set tokens_expired policy
+	nsmgrSuppier := func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgr.Option) nsmgr.Nsmgr {
+		options = append(options,
+			nsmgr.WithAuthorizeServer(authorize.NewServer(authorize.WithPolicies("etc/nsm/opa/common/tokens_expired.rego"))),
+		)
+		return nsmgr.NewServer(ctx, tokenGenerator, options...)
+	}
+
+	domain := sandbox.NewBuilder(chainCtx, t).
+		SetNodesCount(1).
+		SetNSMgrSupplier(nsmgrSuppier).
+		Build()
+
+	nsRegistryClient := domain.NewNSRegistryClient(chainCtx, sandbox.GenerateTestToken)
+	ns := defaultRegistryService("ns")
+
+	nsReg, err := nsRegistryClient.Register(chainCtx, ns)
+	require.NoError(t, err)
+
+	counter := new(countutils.Server)
+
+	createAuthorizedEndpoint(chainCtx, t, ns.Name, domain.Nodes[0].NSMgr.URL, counter)
+
+	// Set an expiring token.
+	// Add injecterror to allow only the first Request. All subsequent ones will fall.
+	// This emulates the death of the client.
+	nsc := domain.Nodes[0].NewClient(chainCtx,
+		sandbox.GenerateExpiringToken(tokenTimeout),
+		client.WithAdditionalFunctionality(
+			injecterror.NewClient(injecterror.WithRequestErrorTimes(1, -1)),
+		),
+	)
+
+	request := defaultRequest(nsReg.Name)
+	requestCtx, requestCtxCancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer requestCtxCancel()
+
+	conn, err := nsc.Request(requestCtx, request)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	// Closes equal to 0 for now
+	require.Equal(t, 1, counter.Requests())
+	require.Equal(t, 0, counter.Closes())
+
+	// Waiting for the timeout
+	require.Eventually(t, func() bool { return counter.Closes() == 1 }, tokenTimeout, time.Millisecond*100)
+}
+
+// This test checks registry expire on sandbox
+// We run nsmgr and registry with registry authorize chain element (tokens_expired.rego)
+func Test_Expire(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	// expire chain element will call Unregister() after (tokenTimeout - registerTimeout)
+	// to be sure that token is not expired
+	tokenTimeout := time.Second * 2
+	registerTimeout := time.Second + time.Millisecond*500
+
+	chainCtx, chainCtxCancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer chainCtxCancel()
+
+	// Set tokens_expired policy for nsmgr and registry
+	nsmgrSuppier := func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgr.Option) nsmgr.Nsmgr {
+		options = append(options,
+			nsmgr.WithAuthorizeNSERegistryServer(
+				authorizeregistry.NewNetworkServiceEndpointRegistryServer(authorizeregistry.WithPolicies("etc/nsm/opa/common/tokens_expired.rego"))),
+		)
+		return nsmgr.NewServer(ctx, tokenGenerator, options...)
+	}
+
+	registrySupplier := func(
+		ctx context.Context,
+		tokenGenerator token.GeneratorFunc,
+		expiryDuration time.Duration,
+		proxyRegistryURL *url.URL,
+		options ...grpc.DialOption) registry.Registry {
+		return memory.NewServer(
+			ctx,
+			tokenGenerator,
+			memory.WithExpireDuration(expiryDuration),
+			memory.WithProxyRegistryURL(proxyRegistryURL),
+			memory.WithDialOptions(options...),
+			memory.WithAuthorizeNSRegistryServer(
+				authorizeregistry.NewNetworkServiceRegistryServer(authorizeregistry.WithPolicies("etc/nsm/opa/common/tokens_expired.rego"))),
+		)
+	}
+
+	domain := sandbox.NewBuilder(chainCtx, t).
+		SetNodesCount(1).
+		SetNSMgrSupplier(nsmgrSuppier).
+		SetRegistrySupplier(registrySupplier).
+		Build()
+
+	nsRegistryClient := domain.NewNSRegistryClient(chainCtx, sandbox.GenerateTestToken)
+	ns := defaultRegistryService("ns")
+
+	nsReg, err := nsRegistryClient.Register(chainCtx, ns)
+	require.NoError(t, err)
+
+	// Set an expiring token.
+	// Add injecterrorregistry to allow only the first Register. All subsequent ones will fall.
+	// This emulates the death of the NSE.
+	nseRegistryClient := registryclient.NewNetworkServiceEndpointRegistryClient(chainCtx,
+		registryclient.WithClientURL(domain.Nodes[0].NSMgr.URL),
+		registryclient.WithDialOptions(sandbox.DialOptions(sandbox.WithTokenGenerator(sandbox.GenerateExpiringToken(tokenTimeout)))...),
+		registryclient.WithNSEAdditionalFunctionality(
+			injecterrorregistry.NewNetworkServiceEndpointRegistryClient(
+				injecterrorregistry.WithRegisterErrorTimes(1, -1),
+				injecterrorregistry.WithFindErrorTimes())),
+	)
+
+	registerCtx, registerCtxCancel := context.WithTimeout(context.Background(), registerTimeout)
+	defer registerCtxCancel()
+	_, err = nseRegistryClient.Register(registerCtx, &registryapi.NetworkServiceEndpoint{
+		Name:                "final-endpoint",
+		Url:                 "nseURL",
+		NetworkServiceNames: []string{nsReg.Name},
+	})
+	require.NoError(t, err)
+
+	// Wait for the endpoint expiration
+	time.Sleep(tokenTimeout)
+	stream, err := nseRegistryClient.Find(chainCtx, &registryapi.NetworkServiceEndpointQuery{
+		NetworkServiceEndpoint: &registryapi.NetworkServiceEndpoint{
+			Name: "final-endpoint",
+		},
+	})
+	require.NoError(t, err)
+
+	// Eventually expire will call Unregister
+	require.Len(t, registryapi.ReadNetworkServiceEndpointList(stream), 0)
 }

--- a/pkg/networkservice/chains/nsmgrproxy/server.go
+++ b/pkg/networkservice/chains/nsmgrproxy/server.go
@@ -292,9 +292,9 @@ func NewServer(ctx context.Context, regURL, proxyURL *url.URL, tokenGenerator to
 
 	var nseServerChain = chain.NewNetworkServiceEndpointRegistryServer(
 		grpcmetadata.NewNetworkServiceEndpointRegistryServer(),
-		begin.NewNetworkServiceEndpointRegistryServer(),
 		updatepath.NewNetworkServiceEndpointRegistryServer(tokenGenerator),
 		opts.authorizeNSERegistryServer,
+		begin.NewNetworkServiceEndpointRegistryServer(),
 		clienturl.NewNetworkServiceEndpointRegistryServer(proxyURL),
 		interdomainBypassNSEServer,
 		registryswapip.NewNetworkServiceEndpointRegistryServer(opts.openMapIPChannel(ctx)),

--- a/pkg/registry/chains/memory/server.go
+++ b/pkg/registry/chains/memory/server.go
@@ -136,9 +136,9 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 
 	nseChain := chain.NewNetworkServiceEndpointRegistryServer(
 		grpcmetadata.NewNetworkServiceEndpointRegistryServer(),
-		begin.NewNetworkServiceEndpointRegistryServer(),
 		updatepath.NewNetworkServiceEndpointRegistryServer(tokenGenerator),
 		opts.authorizeNSERegistryServer,
+		begin.NewNetworkServiceEndpointRegistryServer(),
 		switchcase.NewNetworkServiceEndpointRegistryServer(switchcase.NSEServerCase{
 			Condition: func(c context.Context, nse *registry.NetworkServiceEndpoint) bool {
 				if interdomain.Is(nse.GetName()) {

--- a/pkg/registry/chains/proxydns/server.go
+++ b/pkg/registry/chains/proxydns/server.go
@@ -110,9 +110,9 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, dnsResol
 
 	nseChain := chain.NewNetworkServiceEndpointRegistryServer(
 		grpcmetadata.NewNetworkServiceEndpointRegistryServer(),
-		begin.NewNetworkServiceEndpointRegistryServer(),
 		updatepath.NewNetworkServiceEndpointRegistryServer(tokenGenerator),
 		opts.authorizeNSERegistryServer,
+		begin.NewNetworkServiceEndpointRegistryServer(),
 		dnsresolve.NewNetworkServiceEndpointRegistryServer(dnsresolve.WithResolver(dnsResolver)),
 		connect.NewNetworkServiceEndpointRegistryServer(
 			chain.NewNetworkServiceEndpointRegistryClient(

--- a/pkg/registry/common/begin/ns_client.go
+++ b/pkg/registry/common/begin/ns_client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	"github.com/networkservicemesh/sdk/pkg/registry/common/grpcmetadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
@@ -75,7 +76,7 @@ func (b *beginNSClient) Register(ctx context.Context, in *registry.NetworkServic
 		eventFactoryClient.state = established
 		eventFactoryClient.registration = mergeNS(in, resp.Clone())
 		eventFactoryClient.response = resp.Clone()
-		eventFactoryClient.updateContext(ctx)
+		eventFactoryClient.updateContext(grpcmetadata.PathWithContext(ctx, grpcmetadata.PathFromContext(ctx).Clone()))
 	})
 	return resp, err
 }

--- a/pkg/registry/common/begin/ns_server.go
+++ b/pkg/registry/common/begin/ns_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/networkservicemesh/sdk/pkg/registry/common/grpcmetadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
@@ -73,7 +74,7 @@ func (b *beginNSServer) Register(ctx context.Context, in *registry.NetworkServic
 		eventFactoryServer.registration = mergeNS(in, resp)
 		eventFactoryServer.state = established
 		eventFactoryServer.response = resp
-		eventFactoryServer.updateContext(ctx)
+		eventFactoryServer.updateContext(grpcmetadata.PathWithContext(ctx, grpcmetadata.PathFromContext(ctx).Clone()))
 	})
 	return resp, err
 }

--- a/pkg/registry/common/begin/nse_client.go
+++ b/pkg/registry/common/begin/nse_client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	"github.com/networkservicemesh/sdk/pkg/registry/common/grpcmetadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
@@ -75,7 +76,7 @@ func (b *beginNSEClient) Register(ctx context.Context, in *registry.NetworkServi
 		eventFactoryClient.state = established
 		eventFactoryClient.registration = mergeNSE(in, resp.Clone())
 		eventFactoryClient.response = resp.Clone()
-		eventFactoryClient.updateContext(ctx)
+		eventFactoryClient.updateContext(grpcmetadata.PathWithContext(ctx, grpcmetadata.PathFromContext(ctx).Clone()))
 	})
 	return resp, err
 }

--- a/pkg/registry/common/begin/nse_server.go
+++ b/pkg/registry/common/begin/nse_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/networkservicemesh/sdk/pkg/registry/common/grpcmetadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
@@ -73,7 +74,7 @@ func (b *beginNSEServer) Register(ctx context.Context, in *registry.NetworkServi
 		eventFactoryServer.registration = mergeNSE(in, resp)
 		eventFactoryServer.state = established
 		eventFactoryServer.response = resp
-		eventFactoryServer.updateContext(ctx)
+		eventFactoryServer.updateContext(grpcmetadata.PathWithContext(ctx, grpcmetadata.PathFromContext(ctx).Clone()))
 	})
 	return resp, err
 }

--- a/pkg/registry/common/grpcmetadata/ns_client.go
+++ b/pkg/registry/common/grpcmetadata/ns_client.go
@@ -75,5 +75,18 @@ func (c *grpcMetadataNSClient) Unregister(ctx context.Context, ns *registry.Netw
 		return nil, err
 	}
 
-	return next.NetworkServiceRegistryClient(ctx).Unregister(ctx, ns, opts...)
+	var header metadata.MD
+	opts = append(opts, grpc.Header(&header))
+
+	resp, err := next.NetworkServiceRegistryClient(ctx).Unregister(ctx, ns, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	newpath, err := fromMD(header)
+	if err == nil {
+		path.Index = newpath.Index
+		path.PathSegments = newpath.PathSegments
+	}
+	return resp, nil
 }

--- a/pkg/registry/common/grpcmetadata/nse_client.go
+++ b/pkg/registry/common/grpcmetadata/nse_client.go
@@ -73,5 +73,18 @@ func (c *grpcMetadataNSEClient) Unregister(ctx context.Context, nse *registry.Ne
 		return nil, err
 	}
 
-	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
+	var header metadata.MD
+	opts = append(opts, grpc.Header(&header))
+
+	resp, err := next.NetworkServiceEndpointRegistryClient(ctx).Unregister(ctx, nse, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	newpath, err := fromMD(header)
+	if err == nil {
+		path.Index = newpath.Index
+		path.PathSegments = newpath.PathSegments
+	}
+	return resp, nil
 }

--- a/pkg/registry/common/updatepath/ns_server_test.go
+++ b/pkg/registry/common/updatepath/ns_server_test.go
@@ -53,7 +53,7 @@ var nsSamples = []*nsSample{
 			}
 
 			server := next.NewNetworkServiceRegistryServer(
-				injectpeertoken.NewNetworkServiceRegistryServer(clientToken),
+				injectpeertoken.NewNetworkServiceRegistryServer(tokenGeneratorFunc(clientID)),
 				updatepath.NewNetworkServiceRegistryServer(tokenGeneratorFunc(serverID)),
 			)
 
@@ -107,9 +107,9 @@ var nsSamples = []*nsSample{
 			}
 
 			server := next.NewNetworkServiceRegistryServer(
-				injectpeertoken.NewNetworkServiceRegistryServer(clientToken),
+				injectpeertoken.NewNetworkServiceRegistryServer(tokenGeneratorFunc(clientID)),
 				updatepath.NewNetworkServiceRegistryServer(tokenGeneratorFunc(proxyID)),
-				injectpeertoken.NewNetworkServiceRegistryServer(proxyToken),
+				injectpeertoken.NewNetworkServiceRegistryServer(tokenGeneratorFunc(proxyID)),
 				updatepath.NewNetworkServiceRegistryServer(tokenGeneratorFunc(serverID)),
 			)
 
@@ -155,9 +155,9 @@ var nsSamples = []*nsSample{
 			}
 
 			server := next.NewNetworkServiceRegistryServer(
-				injectpeertoken.NewNetworkServiceRegistryServer(clientToken),
+				injectpeertoken.NewNetworkServiceRegistryServer(tokenGeneratorFunc(clientID)),
 				updatepath.NewNetworkServiceRegistryServer(tokenGeneratorFunc(proxyID)),
-				injectpeertoken.NewNetworkServiceRegistryServer(proxyToken),
+				injectpeertoken.NewNetworkServiceRegistryServer(tokenGeneratorFunc(proxyID)),
 				updatepath.NewNetworkServiceRegistryServer(tokenGeneratorFunc(serverID)),
 			)
 

--- a/pkg/registry/common/updatepath/nse_server.go
+++ b/pkg/registry/common/updatepath/nse_server.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
@@ -45,11 +46,11 @@ func (s *updatePathNSEServer) Register(ctx context.Context, nse *registry.Networ
 	path := grpcmetadata.PathFromContext(ctx)
 
 	// Update path
-	peerTok, _, tokenErr := token.FromContext(ctx)
+	peerTok, peerExpirationTime, tokenErr := token.FromContext(ctx)
 	if tokenErr != nil {
 		log.FromContext(ctx).Warnf("an error during getting peer token from the context: %+v", tokenErr)
 	}
-	tok, _, tokenErr := generateToken(ctx, s.tokenGenerator)
+	tok, expirationTime, tokenErr := generateToken(ctx, s.tokenGenerator)
 	if tokenErr != nil {
 		return nil, errors.Wrap(tokenErr, "an error during generating token")
 	}
@@ -69,6 +70,13 @@ func (s *updatePathNSEServer) Register(ctx context.Context, nse *registry.Networ
 	}
 	nse.PathIds = updatePathIds(nse.PathIds, int(path.Index-1), peerID.String())
 	nse.PathIds = updatePathIds(nse.PathIds, int(path.Index), id.String())
+
+	if nse.GetExpirationTime() == nil || peerExpirationTime.Before(nse.GetExpirationTime().AsTime().Local()) {
+		nse.ExpirationTime = timestamppb.New(peerExpirationTime)
+	}
+	if expirationTime.Before(nse.GetExpirationTime().AsTime().Local()) {
+		nse.ExpirationTime = timestamppb.New(expirationTime)
+	}
 
 	nse, err = next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
 	if err != nil {

--- a/pkg/registry/common/updatepath/nse_server_test.go
+++ b/pkg/registry/common/updatepath/nse_server_test.go
@@ -53,7 +53,7 @@ var nseSamples = []*nseSample{
 			}
 
 			server := next.NewNetworkServiceEndpointRegistryServer(
-				injectpeertoken.NewNetworkServiceEndpointRegistryServer(clientToken),
+				injectpeertoken.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(clientID)),
 				updatepath.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(serverID)),
 			)
 
@@ -107,9 +107,9 @@ var nseSamples = []*nseSample{
 			}
 
 			server := next.NewNetworkServiceEndpointRegistryServer(
-				injectpeertoken.NewNetworkServiceEndpointRegistryServer(clientToken),
+				injectpeertoken.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(clientID)),
 				updatepath.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(proxyID)),
-				injectpeertoken.NewNetworkServiceEndpointRegistryServer(proxyToken),
+				injectpeertoken.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(proxyID)),
 				updatepath.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(serverID)),
 			)
 
@@ -155,9 +155,9 @@ var nseSamples = []*nseSample{
 			}
 
 			server := next.NewNetworkServiceEndpointRegistryServer(
-				injectpeertoken.NewNetworkServiceEndpointRegistryServer(clientToken),
+				injectpeertoken.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(clientID)),
 				updatepath.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(proxyID)),
-				injectpeertoken.NewNetworkServiceEndpointRegistryServer(proxyToken),
+				injectpeertoken.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(proxyID)),
 				updatepath.NewNetworkServiceEndpointRegistryServer(tokenGeneratorFunc(serverID)),
 			)
 

--- a/pkg/registry/utils/inject/injectpeertoken/nse_server.go
+++ b/pkg/registry/utils/inject/injectpeertoken/nse_server.go
@@ -24,21 +24,23 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
 type injectSpiffeIDNSEServer struct {
-	peerToken string
+	tokenGenerator token.GeneratorFunc
 }
 
-// NewNetworkServiceEndpointRegistryServer returns a server chain element putting spiffeID to context on Register and Unregister
-func NewNetworkServiceEndpointRegistryServer(peerToken string) registry.NetworkServiceEndpointRegistryServer {
+// NewNetworkServiceEndpointRegistryServer returns a server chain element putting peer token to context on Register and Unregister
+func NewNetworkServiceEndpointRegistryServer(tokenGenerator token.GeneratorFunc) registry.NetworkServiceEndpointRegistryServer {
 	return &injectSpiffeIDNSEServer{
-		peerToken: peerToken,
+		tokenGenerator: tokenGenerator,
 	}
 }
 
 func (s *injectSpiffeIDNSEServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	ctx = withPeerToken(ctx, s.peerToken)
+	peerToken, _, _ := s.tokenGenerator(nil)
+	ctx = withPeerToken(ctx, peerToken)
 	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
 }
 
@@ -47,6 +49,7 @@ func (s *injectSpiffeIDNSEServer) Find(query *registry.NetworkServiceEndpointQue
 }
 
 func (s *injectSpiffeIDNSEServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
-	ctx = withPeerToken(ctx, s.peerToken)
+	peerToken, _, _ := s.tokenGenerator(nil)
+	ctx = withPeerToken(ctx, peerToken)
 	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
 }

--- a/pkg/tools/opa/policies/common/tokens_expired.rego
+++ b/pkg/tools/opa/policies/common/tokens_expired.rego
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Cisco and/or its affiliates.
+# Copyright (c) 2020-2022 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -19,11 +19,11 @@ package nsm
 default valid = false
 
 valid {
-	count({x | input.path_segments[x]; token_expired(input.path_segments[x].token)}) == count(input.path_segments)
+	count({x | input.path_segments[x]; token_alive(input.path_segments[x].token)}) == count(input.path_segments)
 }
 
-token_expired(token) {
-	print(token)
+# alive means not expired
+token_alive(token) {
 	[_, payload, _] := io.jwt.decode(token)
 	now < payload.exp
 }

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -19,7 +19,6 @@ package sandbox
 import (
 	"context"
 	"net/url"
-	"time"
 
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 	"google.golang.org/grpc"
@@ -41,7 +40,7 @@ type SupplyNSMgrProxyFunc func(ctx context.Context, regURL, proxyURL *url.URL, t
 type SupplyNSMgrFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgr.Option) nsmgr.Nsmgr
 
 // SupplyRegistryFunc supplies Registry
-type SupplyRegistryFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, expiryDuration time.Duration, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry
+type SupplyRegistryFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry
 
 // SupplyRegistryProxyFunc supplies registry proxy
 type SupplyRegistryProxyFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, dnsResolver dnsresolve.Resolver, options ...proxydns.Option) registry.Registry


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Main changes:
1. **networkservice timeout**: at the time of the call `Close()` on `timeout`, the token may already be expired. Therefore, we need to call `Close()` in advance - `(tokenTimeout - requestTimeout)`
2. **registry expire**:  since we now have tokens in the registry, we must follow the same logic as in the **networkservice** (see above). Expiration time selection has been extended. Now it is  - `min(peertoken.ExpirationTime, token.ExpirationTime, nse.ExpirationTIme) - registerTimeout`.
3. **grpcmetadata.NewNetworkServiceEndpointRegistryClient** - `grpc.Header` was added to `Unregister()` to process an updated `path` on the way back (like here - https://github.com/networkservicemesh/sdk/blob/main/pkg/registry/common/grpcmetadata/nse_client.go#L47-L48)
4. **registry authorize and updatepath** were placed before `begin`, because in case of an event that triggers an `eventFactory`, we don't need to re-authorize.
5. **registry begin** - when updating the context, we need to keep a copy of `path`, since we access it by reference (we should not be able to accidentally change it after `begin`)

## Issue link
https://github.com/networkservicemesh/sdk/issues/1398

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
