### PR TITLE
Add default expiration option for registry

### DIFF
--- a/pkg/networkservice/chains/nsmgr/single_test.go
+++ b/pkg/networkservice/chains/nsmgr/single_test.go
@@ -519,6 +519,7 @@ func Test_FailedRegistryAuthorization(t *testing.T) {
 	registrySupplier := func(
 		ctx context.Context,
 		tokenGenerator token.GeneratorFunc,
+		expiryDuration time.Duration,
 		proxyRegistryURL *url.URL,
 		options ...grpc.DialOption) registry.Registry {
 		registryName := sandbox.UniqueName("registry-memory")
@@ -527,6 +528,7 @@ func Test_FailedRegistryAuthorization(t *testing.T) {
 			ctx,
 			tokenGeneratorFunc("spiffe://test.com/"+registryName),
 			memory.WithProxyRegistryURL(proxyRegistryURL),
+			memory.WithDefaultExpiration(expiryDuration),
 			memory.WithDialOptions(options...),
 			memory.WithAuthorizeNSRegistryServer(
 				authorizeregistry.NewNetworkServiceRegistryServer(authorizeregistry.WithPolicies("etc/nsm/opa/registry/client_allowed.rego"))),
@@ -688,12 +690,14 @@ func Test_Expire(t *testing.T) {
 	registrySupplier := func(
 		ctx context.Context,
 		tokenGenerator token.GeneratorFunc,
+		expiryDuration time.Duration,
 		proxyRegistryURL *url.URL,
 		options ...grpc.DialOption) registry.Registry {
 		return memory.NewServer(
 			ctx,
 			tokenGenerator,
 			memory.WithProxyRegistryURL(proxyRegistryURL),
+			memory.WithDefaultExpiration(expiryDuration),
 			memory.WithDialOptions(options...),
 			memory.WithAuthorizeNSRegistryServer(
 				authorizeregistry.NewNetworkServiceRegistryServer(authorizeregistry.WithPolicies("etc/nsm/opa/common/tokens_expired.rego"))),

--- a/pkg/registry/common/expire/options.go
+++ b/pkg/registry/common/expire/options.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expire
+
+import "time"
+
+type options struct {
+	defaultExpiration time.Duration
+}
+
+// Option is option to configure expire chain element
+type Option func(*options)
+
+// WithDefaultExpiration sets the default expiration for endpoints
+func WithDefaultExpiration(d time.Duration) Option {
+	return func(o *options) {
+		o.defaultExpiration = d
+	}
+}

--- a/pkg/tools/sandbox/types.go
+++ b/pkg/tools/sandbox/types.go
@@ -19,6 +19,7 @@ package sandbox
 import (
 	"context"
 	"net/url"
+	"time"
 
 	registryapi "github.com/networkservicemesh/api/pkg/api/registry"
 	"google.golang.org/grpc"
@@ -40,7 +41,7 @@ type SupplyNSMgrProxyFunc func(ctx context.Context, regURL, proxyURL *url.URL, t
 type SupplyNSMgrFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, options ...nsmgr.Option) nsmgr.Nsmgr
 
 // SupplyRegistryFunc supplies Registry
-type SupplyRegistryFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry
+type SupplyRegistryFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, defaultExpiration time.Duration, proxyRegistryURL *url.URL, options ...grpc.DialOption) registry.Registry
 
 // SupplyRegistryProxyFunc supplies registry proxy
 type SupplyRegistryProxyFunc func(ctx context.Context, tokenGenerator token.GeneratorFunc, dnsResolver dnsresolve.Resolver, options ...proxydns.Option) registry.Registry


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
`WithDefaultExpiration` sets default expiration time for endpoint if it was not set before


## Issue link
https://github.com/networkservicemesh/sdk/issues/1398


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
