### PR TITLE
Fix deprecated Github Action set-output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Get tag
         run: |
           branch=${{github.event.workflow_run.head_branch}}
-          echo '::set-output name=tag::'${branch#release/}
+          echo 'tag=${branch#release/}' >> $GITHUB_OUTPUT
         id: get-tag-step
 
   create-release:


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Replace deprecated Github Action


## Issue link
https://github.com/networkservicemesh/integration-k8s-packet/issues/312


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [x] CI
