### PR TITLE
Fix searches dns chain element

### DIFF
--- a/pkg/tools/dnsutils/searches/handler_test.go
+++ b/pkg/tools/dnsutils/searches/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -80,7 +80,7 @@ func TestDomainSearches(t *testing.T) {
 	handler.ServeDNS(ctx, rw, m)
 
 	resp := rw.Response.Copy()
-	require.Equal(t, check.Count, 4)
+	require.Equal(t, check.Count, 2)
 	require.Equal(t, resp.MsgHdr.Rcode, dns.RcodeSuccess)
 	require.NotNil(t, resp.Answer)
 	require.Equal(t, resp.Answer[0].(*dns.A).A.String(), "1.1.1.1")

--- a/pkg/tools/dnsutils/searches/response_writer.go
+++ b/pkg/tools/dnsutils/searches/response_writer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -22,12 +22,10 @@ import (
 
 type responseWriter struct {
 	dns.ResponseWriter
-	Responses []*dns.Msg
-	Index     int
+	Response *dns.Msg
 }
 
 func (r *responseWriter) WriteMsg(m *dns.Msg) error {
-	r.Responses[r.Index] = m
-	r.Index++
+	r.Response = m
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
From `man resolv.conf` :

> **search** Search list for host-name lookup.
> ...
> Resolver queries ... will be attempted  using  each  component  of  the search  path  **in  turn** until a match is found

It will be much more efficient if we check the success of the dns request one by one, rather than all at once.

## Issue link

https://github.com/networkservicemesh/sdk/issues/1414

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
