### PR TITLE
Add interdomain funcs to vl3-dns template

### DIFF
--- a/pkg/networkservice/connectioncontext/dnscontext/vl3dns/options.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/vl3dns/options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils"
+	"github.com/networkservicemesh/sdk/pkg/tools/interdomain"
 )
 
 // Option configures vl3DNSServer
@@ -50,7 +51,13 @@ func WithDomainSchemes(domainSchemes ...string) Option {
 	return func(vd *vl3DNSServer) {
 		vd.domainSchemeTemplates = nil
 		for i, domainScheme := range domainSchemes {
-			vd.domainSchemeTemplates = append(vd.domainSchemeTemplates, template.Must(template.New(fmt.Sprintf("dnsScheme%d", i)).Parse(domainScheme)))
+			vd.domainSchemeTemplates = append(vd.domainSchemeTemplates,
+				template.Must(template.New(fmt.Sprintf("dnsScheme%d", i)).
+					Funcs(template.FuncMap{
+						"target": interdomain.Target,
+						"domain": interdomain.Domain,
+					}).
+					Parse(domainScheme)))
 		}
 	}
 }

--- a/pkg/networkservice/connectioncontext/dnscontext/vl3dns/server.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/vl3dns/server.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"sync/atomic"
 	"text/template"
@@ -196,7 +197,7 @@ func (n *vl3DNSServer) buildSrcDNSRecords(c *networkservice.Connection) ([]strin
 		if err := templ.Execute(recordBuilder, c); err != nil {
 			return nil, errors.Wrap(err, "error occurred executing the template or writing its output")
 		}
-		result = append(result, recordBuilder.String())
+		result = append(result, removeDupDots(recordBuilder.String()))
 	}
 	return result, nil
 }
@@ -228,4 +229,10 @@ func getSrcIPs(c *networkservice.Connection) []net.IP {
 		ips = append(ips, srcIPNet.IP)
 	}
 	return ips
+}
+
+var regexDot = regexp.MustCompile(`\.+`)
+
+func removeDupDots(str string) string {
+	return regexDot.ReplaceAllString(str, ".")
 }


### PR DESCRIPTION
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Interdomain template functions have been added to `vl3dns`. 
Now we can use a DNS template like this:
`{{ index .Labels \“podName\” }}.{{ target .NetworkService }}.{{ domain .NetworkService }}.`

## Issue link
https://github.com/networkservicemesh/sdk/issues/1414


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
