### PR TITLE
Return an error if there is no DNS address.

### DIFF
--- a/pkg/networkservice/common/monitor/monitor_connection_server.go
+++ b/pkg/networkservice/common/monitor/monitor_connection_server.go
@@ -105,21 +105,9 @@ func (m *monitorConnectionServer) Send(event *networkservice.ConnectionEvent) (_
 	return nil
 }
 
-func (m *monitorConnectionServer) GetConnections() map[string]*networkservice.Connection {
-	connections := make(map[string]*networkservice.Connection)
-
-	<-m.executor.AsyncExec(func() {
-		for k, v := range m.connections {
-			connections[k] = v
-		}
-	})
-	return connections
-}
-
 // EventConsumer - interface for monitor events sending
 type EventConsumer interface {
 	Send(event *networkservice.ConnectionEvent) (err error)
-	GetConnections() map[string]*networkservice.Connection
 }
 
 var _ EventConsumer = &monitorConnectionServer{}

--- a/pkg/networkservice/connectioncontext/dnscontext/vl3dns/server.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/vl3dns/server.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"text/template"
 
@@ -31,7 +30,6 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/pkg/errors"
 
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/monitor"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils"
@@ -42,11 +40,9 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/noloop"
 	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils/norecursion"
 	"github.com/networkservicemesh/sdk/pkg/tools/ippool"
-	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
 type vl3DNSServer struct {
-	chainCtx              context.Context
 	dnsServerRecords      genericsync.Map[string, []net.IP]
 	dnsConfigs            *genericsync.Map[string, []*networkservice.DNSConfig]
 	domainSchemeTemplates []*template.Template
@@ -55,8 +51,6 @@ type vl3DNSServer struct {
 	listenAndServeDNS     func(ctx context.Context, handler dnsutils.Handler, listenOn string)
 	dnsServerIP           atomic.Value
 	dnsServerIPCh         <-chan net.IP
-	monitorEventConsumer  monitor.EventConsumer
-	once                  sync.Once
 }
 
 type clientDNSNameKey struct{}
@@ -68,7 +62,6 @@ type clientDNSNameKey struct{}
 // opts configure vl3dns networkservice instance with specific behavior.
 func NewServer(chainCtx context.Context, dnsServerIPCh <-chan net.IP, opts ...Option) networkservice.NetworkServiceServer {
 	var result = &vl3DNSServer{
-		chainCtx:          chainCtx,
 		dnsPort:           53,
 		listenAndServeDNS: dnsutils.ListenAndServe,
 		dnsConfigs:        new(genericsync.Map[string, []*networkservice.DNSConfig]),
@@ -91,27 +84,37 @@ func NewServer(chainCtx context.Context, dnsServerIPCh <-chan net.IP, opts ...Op
 
 	result.listenAndServeDNS(chainCtx, result.dnsServer, fmt.Sprintf(":%v", result.dnsPort))
 
-	if len(dnsServerIPCh) > 0 {
-		result.dnsServerIP.Store(<-dnsServerIPCh)
-	}
+	go func() {
+		for {
+			select {
+			case <-chainCtx.Done():
+				return
+			case addr, ok := <-dnsServerIPCh:
+				if !ok {
+					return
+				}
+				result.dnsServerIP.Store(addr)
+			}
+		}
+	}()
+
 	return result
 }
 
 func (n *vl3DNSServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	n.once.Do(func() {
-		// We assume here that the monitorEventConsumer is the same for all connections.
-		// We need the context of any request to pull it out.
-		go n.checkServerAddressUpdates(ctx)
-	})
-
 	if request.GetConnection().GetContext().GetDnsContext() == nil {
 		request.Connection.Context.DnsContext = new(networkservice.DNSContext)
 	}
 
 	var clientsConfigs = request.GetConnection().GetContext().GetDnsContext().GetConfigs()
 
-	dnsServerIPStr, added := n.addDNSContext(request.GetConnection())
-	var recordNames, err = n.buildSrcDNSRecords(request.GetConnection())
+	dnsServerIPStr, err := n.addDNSContext(request.GetConnection())
+	if err != nil {
+		return nil, err
+	}
+
+	var recordNames []string
+	recordNames, err = n.buildSrcDNSRecords(request.GetConnection())
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +144,7 @@ func (n *vl3DNSServer) Request(ctx context.Context, request *networkservice.Netw
 			var lastPrefix = srcRoutes[len(srcRoutes)-1].Prefix
 			for _, config := range clientsConfigs {
 				for _, serverIP := range config.DnsServerIps {
-					if added && dnsServerIPStr == serverIP {
+					if dnsServerIPStr == serverIP {
 						continue
 					}
 					if withinPrefix(serverIP, lastPrefix) {
@@ -168,7 +171,7 @@ func (n *vl3DNSServer) Close(ctx context.Context, conn *networkservice.Connectio
 	return next.Server(ctx).Close(ctx, conn)
 }
 
-func (n *vl3DNSServer) addDNSContext(c *networkservice.Connection) (added string, ok bool) {
+func (n *vl3DNSServer) addDNSContext(c *networkservice.Connection) (added string, err error) {
 	if ip := n.dnsServerIP.Load(); ip != nil {
 		dnsServerIP := ip.(net.IP)
 		var dnsContext = c.GetContext().GetDnsContext()
@@ -178,9 +181,12 @@ func (n *vl3DNSServer) addDNSContext(c *networkservice.Connection) (added string
 		if !dnsutils.ContainsDNSConfig(dnsContext.Configs, configToAdd) {
 			dnsContext.Configs = append(dnsContext.Configs, configToAdd)
 		}
-		return dnsServerIP.String(), true
+		return dnsServerIP.String(), nil
+	} else if c.GetPath().GetPathSegments()[0].Name == c.GetCurrentPathSegment().Name {
+		// If it calls itself - this is not an error, but a request to allocate a dns address
+		return "", nil
 	}
-	return "", false
+	return "", errors.New("DNS address is initializing")
 }
 
 func (n *vl3DNSServer) buildSrcDNSRecords(c *networkservice.Connection) ([]string, error) {
@@ -193,40 +199,6 @@ func (n *vl3DNSServer) buildSrcDNSRecords(c *networkservice.Connection) ([]strin
 		result = append(result, recordBuilder.String())
 	}
 	return result, nil
-}
-
-func (n *vl3DNSServer) checkServerAddressUpdates(ctx context.Context) {
-	n.monitorEventConsumer, _ = monitor.LoadEventConsumer(ctx, metadata.IsClient(n))
-	for {
-		select {
-		case <-n.chainCtx.Done():
-			return
-		case addr, ok := <-n.dnsServerIPCh:
-			if !ok {
-				return
-			}
-
-			n.updateServerAddress(addr)
-		}
-	}
-}
-
-func (n *vl3DNSServer) updateServerAddress(address net.IP) {
-	n.dnsServerIP.Store(address)
-
-	if n.monitorEventConsumer != nil {
-		conns := n.monitorEventConsumer.GetConnections()
-		for _, c := range conns {
-			c.State = networkservice.State_REFRESH_REQUESTED
-		}
-		_ = n.monitorEventConsumer.Send(&networkservice.ConnectionEvent{
-			Type:        networkservice.ConnectionEventType_UPDATE,
-			Connections: conns,
-		})
-	} else {
-		log.FromContext(n.chainCtx).WithField("vl3DNSServer", "updateServerAddress").
-			Debug("eventConsumer is not presented")
-	}
 }
 
 func compareStringSlices(a, b []string) bool {

--- a/pkg/tools/dnsutils/dnsutils.go
+++ b/pkg/tools/dnsutils/dnsutils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -37,7 +37,7 @@ func ListenAndServe(ctx context.Context, handler Handler, listenOn string) {
 
 	for _, network := range networks {
 		var server = &dns.Server{Addr: listenOn, Net: network, Handler: dns.HandlerFunc(func(w dns.ResponseWriter, m *dns.Msg) {
-			var timeoutCtx, cancel = context.WithTimeout(context.Background(), time.Second*5)
+			var timeoutCtx, cancel = context.WithTimeout(ctx, time.Second*5)
 			defer cancel()
 
 			handler.ServeDNS(timeoutCtx, w, m)


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
This PR partially reverts this - https://github.com/networkservicemesh/sdk/pull/1416
The previous approach using `monitor` and sending `REFRESH_REQUESTED` event is not suitable, since there is some time (even if very little) between the `Request` and `MonitorConnections`. Because of this, we get into a situation where both the `Request` and the event may not update the DNS context.

In this PR we return an error until the address is assigned. **_But_** we must allow Request to itself, because that Request is what selects the addresses.

## Issue link
https://github.com/networkservicemesh/integration-k8s-kind/issues/750


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
