### PR TITLE
remote-vlan-nse fix; Singlepoint IPAM should not allocate broadcast address

### DIFF
--- a/pkg/networkservice/ipam/singlepointipam/README.md
+++ b/pkg/networkservice/ipam/singlepointipam/README.md
@@ -1,0 +1,7 @@
+# Single point IPAM
+
+This chain element is used to provide IPAM functionality for the nse-remote-vlan.
+
+Per request allocates a single IP address in the given subnet and provides static routes. Request can set some exclude IP prefixes for the allocated IP.
+
+The first IP address from the specified IP range and the broadcast IPv4 address will be witheld.

--- a/pkg/networkservice/ipam/singlepointipam/server.go
+++ b/pkg/networkservice/ipam/singlepointipam/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/cidr"
 	"github.com/networkservicemesh/sdk/pkg/tools/ippool"
 )
 
@@ -78,6 +79,13 @@ func (sipam *singlePIpam) init() {
 		mask := fmt.Sprintf("/%d", ones)
 		sipam.masks = append(sipam.masks, mask)
 		ipPool := ippool.NewWithNet(prefix)
+		if prefix.IP.To4() != nil {
+			// Remove the broadcast address from the pool
+			_, sipam.initErr = ipPool.PullIP(cidr.BroadcastAddress(prefix))
+			if sipam.initErr != nil {
+				return
+			}
+		}
 		sipam.ipPools = append(sipam.ipPools, ipPool)
 	}
 }


### PR DESCRIPTION
Single-point IPAM should not allocate broadcast address

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Remote vlan nse is used to provide cluster breakout. The assigned IP to the front-end NSC can not be broadcast address.

## Issue link
<!--- Please link to the issue here. -->
#1430 

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
