### PR TITLE
[PoC]: fix discover forwarder

### DIFF
--- a/pkg/networkservice/common/discoverforwarder/metadata.go
+++ b/pkg/networkservice/common/discoverforwarder/metadata.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,16 +24,21 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 )
 
-type selectedForworderKey struct{}
+type selectedForwarderKey struct{}
 
-func loadForwarderName(ctx context.Context) string {
-	v, ok := metadata.Map(ctx, false).Load(selectedForworderKey{})
-	if !ok {
-		return ""
-	}
-	return v.(string)
+type selectedForwarderVal struct {
+	name   string
+	active bool
 }
 
-func storeForwarderName(ctx context.Context, v string) {
-	metadata.Map(ctx, false).Store(selectedForworderKey{}, v)
+func loadForwarder(ctx context.Context) *selectedForwarderVal {
+	v, ok := metadata.Map(ctx, false).Load(selectedForwarderKey{})
+	if !ok {
+		return nil
+	}
+	return v.(*selectedForwarderVal)
+}
+
+func storeForwarder(ctx context.Context, v *selectedForwarderVal) {
+	metadata.Map(ctx, false).Store(selectedForwarderKey{}, v)
 }


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
If the forwarder is unavailable, we don't need to store its name.
But what do we need to do if the request returned an error?

Cases:
**1. Forwarder is no longer available.**
We need to clear the map with the forwarder name and find a new one on the re-request.
This solves the problem when several elements die - https://github.com/networkservicemesh/sdk/pull/1204

**2. NSE is no longer available.**
We can't just clear the map in this case. Because if `Close` is called next, we won't find anything in this map. But, the forwarder is fully reachable and contains interfaces.
Therefore, in case of a Request error, we set the flag "**_active_**", that will allow us to select a new forwarder in case of a re-request. And correctly Close the connection if necessary.


## Issue link
https://github.com/networkservicemesh/sdk/issues/1434


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
