### PR TITLE
[qfix] Add more logs to policies checking

### DIFF
--- a/pkg/networkservice/common/authorize/common.go
+++ b/pkg/networkservice/common/authorize/common.go
@@ -23,10 +23,14 @@ import (
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
 // Policy represents authorization policy for network service.
 type Policy interface {
+	// Name returns policy name
+	Name() string
 	// Check checks authorization
 	Check(ctx context.Context, input interface{}) error
 }
@@ -42,7 +46,8 @@ func (l *policiesList) check(ctx context.Context, p *networkservice.Path) error 
 			continue
 		}
 		if err := policy.Check(ctx, p); err != nil {
-			return errors.Wrap(err, "an error occurred during authorization policy check")
+			log.FromContext(ctx).Errorf("policy failed: %v", policy.Name())
+			return errors.Wrap(err, "networkservice: an error occurred during authorization policy check")
 		}
 	}
 	return nil

--- a/pkg/registry/common/authorize/common.go
+++ b/pkg/registry/common/authorize/common.go
@@ -39,6 +39,8 @@ type RegistryOpaInput struct {
 
 // Policy represents authorization policy for network service.
 type Policy interface {
+	// Name returns policy name
+	Name() string
 	// Check checks authorization
 	Check(ctx context.Context, input interface{}) error
 }
@@ -55,8 +57,8 @@ func (l *policiesList) check(ctx context.Context, input RegistryOpaInput) error 
 		}
 
 		if err := policy.Check(ctx, input); err != nil {
-			log.FromContext(ctx).Infof("policy failed %v", policy)
-			return errors.Wrap(err, "an error occurred during authorization policy check")
+			log.FromContext(ctx).Errorf("policy failed: %v", policy.Name())
+			return errors.Wrap(err, "registry: an error occurred during authorization policy check")
 		}
 
 		log.FromContext(ctx).Infof("policy passed")

--- a/pkg/tools/monitorconnection/authorize/common.go
+++ b/pkg/tools/monitorconnection/authorize/common.go
@@ -20,10 +20,14 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
 // Policy represents authorization policy for monitor connection.
 type Policy interface {
+	// Name returns policy name
+	Name() string
 	// Check checks authorization
 	Check(ctx context.Context, input interface{}) error
 }
@@ -39,7 +43,8 @@ func (l *policiesList) check(ctx context.Context, srv MonitorOpaInput) error {
 			continue
 		}
 		if err := policy.Check(ctx, srv); err != nil {
-			return errors.Wrap(err, "an error occurred during authorization policy check")
+			log.FromContext(ctx).Errorf("policy failed: %v", policy.Name())
+			return errors.Wrapf(err, "monitor: an error occurred during authorization policy check")
 		}
 	}
 	return nil

--- a/pkg/tools/monitorconnection/authorize/server_test.go
+++ b/pkg/tools/monitorconnection/authorize/server_test.go
@@ -78,7 +78,7 @@ func getContextWithTLSCert() (context.Context, error) {
 }
 
 func testPolicy() authorize.Policy {
-	return opa.WithPolicyFromSource(`
+	return opa.WithNamedPolicyFromSource("testPolicy", `
 		package test
 	
 		default allow = false

--- a/pkg/tools/opa/policies.go
+++ b/pkg/tools/opa/policies.go
@@ -70,6 +70,7 @@ func PolicyFromFile(p string) (*AuthorizationPolicy, error) {
 		}
 	}
 	return &AuthorizationPolicy{
+		name:         p,
 		policySource: string(b),
 		query:        "valid",
 		checker:      True("valid"),

--- a/pkg/tools/opa/policy.go
+++ b/pkg/tools/opa/policy.go
@@ -58,6 +58,17 @@ func True(query string) CheckAccessFunc {
 // WithPolicyFromSource creates custom policy based on rego source code
 func WithPolicyFromSource(source, query string, checkQuery CheckQueryFunc) *AuthorizationPolicy {
 	return &AuthorizationPolicy{
+		name:         "fromSource",
+		policySource: strings.TrimSpace(source),
+		query:        query,
+		checker:      checkQuery(query),
+	}
+}
+
+// WithNamedPolicyFromSource creates named custom policy based on rego source code
+func WithNamedPolicyFromSource(name, source, query string, checkQuery CheckQueryFunc) *AuthorizationPolicy {
+	return &AuthorizationPolicy{
+		name:         name,
 		policySource: strings.TrimSpace(source),
 		query:        query,
 		checker:      checkQuery(query),
@@ -67,6 +78,7 @@ func WithPolicyFromSource(source, query string, checkQuery CheckQueryFunc) *Auth
 // AuthorizationPolicy checks that passed tokens are valid
 type AuthorizationPolicy struct {
 	initErr        error
+	name           string
 	policyFilePath string
 	policySource   string
 	pkg            string
@@ -74,6 +86,11 @@ type AuthorizationPolicy struct {
 	evalQuery      *rego.PreparedEvalQuery
 	checker        CheckAccessFunc
 	once           sync.Once
+}
+
+// Name returns AuthorizationPolicy name
+func (d *AuthorizationPolicy) Name() string {
+	return d.name
 }
 
 // Check returns nil if passed tokens are valid


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Add more logs to policies checking.

Error output:
```
2023/04/18 14:28:47 [ERROR] policy failed: policy.rego
```


## Issue link
Incident: https://github.com/networkservicemesh/integration-k8s-kind/actions/runs/4665104418/jobs/8258077225
Logs (no information about failed policy):
```
...
Apr 11 08:21:05.750[31m [ERRO] [id:alpine-74dcb6dd55-kfx57-0] [type:networkService] [0m(8.3)          an error occurred during authorization policy check: rpc error: code = PermissionDenied desc = no sufficient privileges
Apr 11 08:21:05.750[31m [ERRO] [id:alpine-74dcb6dd55-kfx57-0] [type:networkService] [0m(7.1)         an error occurred during authorization policy check: rpc error: code = PermissionDenied desc = no sufficient privileges
...
```


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
