### PR TITLE
Opentelemetry fixes

### DIFF
--- a/pkg/networkservice/core/trace/client.go
+++ b/pkg/networkservice/core/trace/client.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020 Cisco Systems, Inc.
+// Copyright (c) 2020-2023 Cisco Systems, Inc.
 //
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2023 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -46,8 +46,8 @@ func NewNetworkServiceClient(traced networkservice.NetworkServiceClient) network
 
 func (t *beginTraceClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
 	// Create a new logger
-	operation := typeutils.GetFuncName(t.traced, "Request")
-	ctx, finish := withLog(ctx, operation, request.GetConnection().GetId())
+	operation := typeutils.GetFuncName(t.traced, methodNameRequest)
+	ctx, finish := withLog(ctx, operation, methodNameRequest, request.GetConnection().GetId())
 	defer finish()
 
 	logRequest(ctx, request, "request")
@@ -62,8 +62,8 @@ func (t *beginTraceClient) Request(ctx context.Context, request *networkservice.
 
 func (t *beginTraceClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
 	// Create a new logger
-	operation := typeutils.GetFuncName(t.traced, "Close")
-	ctx, finish := withLog(ctx, operation, conn.GetId())
+	operation := typeutils.GetFuncName(t.traced, methodNameClose)
+	ctx, finish := withLog(ctx, operation, methodNameClose, conn.GetId())
 	defer finish()
 
 	logRequest(ctx, conn, "close")

--- a/pkg/networkservice/core/trace/common.go
+++ b/pkg/networkservice/core/trace/common.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020 Cisco Systems, Inc.
+// Copyright (c) 2020-2023 Cisco Systems, Inc.
 //
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2023 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -31,6 +31,11 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+const (
+	methodNameRequest = "Request"
+	methodNameClose   = "Close"
 )
 
 func logRequest(ctx context.Context, request proto.Message, prefixes ...string) {

--- a/pkg/networkservice/core/trace/server.go
+++ b/pkg/networkservice/core/trace/server.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020 Cisco Systems, Inc.
+// Copyright (c) 2020-2023 Cisco Systems, Inc.
 //
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2023 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -45,8 +45,8 @@ func NewNetworkServiceServer(traced networkservice.NetworkServiceServer) network
 
 func (t *beginTraceServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	// Create a new logger
-	operation := typeutils.GetFuncName(t.traced, "Request")
-	ctx, finish := withLog(ctx, operation, request.GetConnection().GetId())
+	operation := typeutils.GetFuncName(t.traced, methodNameRequest)
+	ctx, finish := withLog(ctx, operation, methodNameRequest, request.GetConnection().GetId())
 	defer finish()
 
 	logRequest(ctx, request, "request")
@@ -61,8 +61,8 @@ func (t *beginTraceServer) Request(ctx context.Context, request *networkservice.
 
 func (t *beginTraceServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
 	// Create a new logger
-	operation := typeutils.GetFuncName(t.traced, "Close")
-	ctx, finish := withLog(ctx, operation, conn.GetId())
+	operation := typeutils.GetFuncName(t.traced, methodNameClose)
+	ctx, finish := withLog(ctx, operation, methodNameClose, conn.GetId())
 	defer finish()
 
 	logRequest(ctx, conn, "close")

--- a/pkg/registry/core/trace/common.go
+++ b/pkg/registry/core/trace/common.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +26,14 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+const (
+	methodNameRegister   = "Register"
+	methodNameUnregister = "Unregister"
+	methodNameFind       = "Find"
+	methodNameSend       = "Send"
+	methodNameRecv       = "Recv"
 )
 
 type stackTracer interface {

--- a/pkg/registry/core/trace/context.go
+++ b/pkg/registry/core/trace/context.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020-2022 Cisco Systems, Inc.
+// Copyright (c) 2020-2023 Cisco Systems, Inc.
 //
-// Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2023 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -32,7 +32,7 @@ const (
 )
 
 // withLog - provides corresponding logger in context
-func withLog(parent context.Context, operation string) (c context.Context, f func()) {
+func withLog(parent context.Context, operation, methodName string) (c context.Context, f func()) {
 	if parent == nil {
 		panic("cannot create context from nil parent")
 	}
@@ -42,8 +42,10 @@ func withLog(parent context.Context, operation string) (c context.Context, f fun
 
 	if grpcTraceState := grpcutils.TraceFromContext(parent); (grpcTraceState == grpcutils.TraceOn) ||
 		(grpcTraceState == grpcutils.TraceUndefined && log.IsTracingEnabled()) {
-		ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, map[string]interface{}{"type": loggedType})
-		ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, map[string]interface{}{"type": loggedType})
+		fields := []*log.Field{log.NewField("type", loggedType)}
+
+		ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, methodName, fields)
+		ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, fields)
 		return log.WithLog(ctx, sLogger, lLogger), func() {
 			sFinish()
 			lFinish()

--- a/pkg/registry/core/trace/ns_registry.go
+++ b/pkg/registry/core/trace/ns_registry.go
@@ -44,8 +44,8 @@ type traceNetworkServiceRegistryFindClient struct {
 }
 
 func (t *traceNetworkServiceRegistryFindClient) Recv() (*registry.NetworkServiceResponse, error) {
-	operation := typeutils.GetFuncName(t.NetworkServiceRegistry_FindClient, "Recv")
-	ctx, finish := withLog(t.Context(), operation)
+	operation := typeutils.GetFuncName(t.NetworkServiceRegistry_FindClient, methodNameRecv)
+	ctx, finish := withLog(t.Context(), operation, methodNameRecv)
 	defer finish()
 
 	s := streamcontext.NetworkServiceRegistryFindClient(ctx, t.NetworkServiceRegistry_FindClient)
@@ -65,8 +65,8 @@ func (t *traceNetworkServiceRegistryFindClient) Recv() (*registry.NetworkService
 }
 
 func (t *traceNetworkServiceRegistryClient) Register(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*registry.NetworkService, error) {
-	operation := typeutils.GetFuncName(t.traced, "Register")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameRegister)
+	ctx, finish := withLog(ctx, operation, methodNameRegister)
 	defer finish()
 
 	logObjectTrace(ctx, "register", in)
@@ -79,8 +79,8 @@ func (t *traceNetworkServiceRegistryClient) Register(ctx context.Context, in *re
 	return rv, nil
 }
 func (t *traceNetworkServiceRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
-	operation := typeutils.GetFuncName(t.traced, "Find")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameFind)
+	ctx, finish := withLog(ctx, operation, methodNameFind)
 	defer finish()
 
 	logObjectTrace(ctx, "find", in)
@@ -96,8 +96,8 @@ func (t *traceNetworkServiceRegistryClient) Find(ctx context.Context, in *regist
 }
 
 func (t *traceNetworkServiceRegistryClient) Unregister(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*empty.Empty, error) {
-	operation := typeutils.GetFuncName(t.traced, "Unregister")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameUnregister)
+	ctx, finish := withLog(ctx, operation, methodNameUnregister)
 	defer finish()
 
 	logObjectTrace(ctx, "unregister", in)
@@ -121,8 +121,8 @@ type traceNetworkServiceRegistryServer struct {
 }
 
 func (t *traceNetworkServiceRegistryServer) Register(ctx context.Context, in *registry.NetworkService) (*registry.NetworkService, error) {
-	operation := typeutils.GetFuncName(t.traced, "Register")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameRegister)
+	ctx, finish := withLog(ctx, operation, methodNameRegister)
 	defer finish()
 
 	logObjectTrace(ctx, "register", in)
@@ -136,8 +136,8 @@ func (t *traceNetworkServiceRegistryServer) Register(ctx context.Context, in *re
 }
 
 func (t *traceNetworkServiceRegistryServer) Find(in *registry.NetworkServiceQuery, s registry.NetworkServiceRegistry_FindServer) error {
-	operation := typeutils.GetFuncName(t.traced, "Find")
-	ctx, finish := withLog(s.Context(), operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameFind)
+	ctx, finish := withLog(s.Context(), operation, methodNameFind)
 	defer finish()
 
 	s = &traceNetworkServiceRegistryFindServer{
@@ -154,8 +154,8 @@ func (t *traceNetworkServiceRegistryServer) Find(in *registry.NetworkServiceQuer
 }
 
 func (t *traceNetworkServiceRegistryServer) Unregister(ctx context.Context, in *registry.NetworkService) (*empty.Empty, error) {
-	operation := typeutils.GetFuncName(t.traced, "Unregister")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameUnregister)
+	ctx, finish := withLog(ctx, operation, methodNameUnregister)
 	defer finish()
 
 	logObjectTrace(ctx, "unregister", in)
@@ -179,8 +179,8 @@ type traceNetworkServiceRegistryFindServer struct {
 }
 
 func (t *traceNetworkServiceRegistryFindServer) Send(nsResp *registry.NetworkServiceResponse) error {
-	operation := typeutils.GetFuncName(t.NetworkServiceRegistry_FindServer, "Send")
-	ctx, finish := withLog(t.Context(), operation)
+	operation := typeutils.GetFuncName(t.NetworkServiceRegistry_FindServer, methodNameSend)
+	ctx, finish := withLog(t.Context(), operation, methodNameSend)
 	defer finish()
 
 	logObjectTrace(ctx, "network service", nsResp.NetworkService)

--- a/pkg/registry/core/trace/nse_registry.go
+++ b/pkg/registry/core/trace/nse_registry.go
@@ -43,9 +43,8 @@ type traceNetworkServiceEndpointRegistryFindClient struct {
 }
 
 func (t *traceNetworkServiceEndpointRegistryFindClient) Recv() (*registry.NetworkServiceEndpointResponse, error) {
-	operation := typeutils.GetFuncName(t.NetworkServiceEndpointRegistry_FindClient, "Recv")
-
-	ctx, finish := withLog(t.Context(), operation)
+	operation := typeutils.GetFuncName(t.NetworkServiceEndpointRegistry_FindClient, methodNameRecv)
+	ctx, finish := withLog(t.Context(), operation, methodNameRecv)
 	defer finish()
 
 	s := streamcontext.NetworkServiceEndpointRegistryFindClient(ctx, t.NetworkServiceEndpointRegistry_FindClient)
@@ -65,8 +64,8 @@ func (t *traceNetworkServiceEndpointRegistryFindClient) Recv() (*registry.Networ
 }
 
 func (t *traceNetworkServiceEndpointRegistryClient) Register(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
-	operation := typeutils.GetFuncName(t.traced, "Register")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameRegister)
+	ctx, finish := withLog(ctx, operation, methodNameRegister)
 	defer finish()
 
 	logObjectTrace(ctx, "register", in)
@@ -78,8 +77,8 @@ func (t *traceNetworkServiceEndpointRegistryClient) Register(ctx context.Context
 	return rv, nil
 }
 func (t *traceNetworkServiceEndpointRegistryClient) Find(ctx context.Context, in *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
-	operation := typeutils.GetFuncName(t.traced, "Find")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameFind)
+	ctx, finish := withLog(ctx, operation, methodNameFind)
 	defer finish()
 
 	logObjectTrace(ctx, "find", in)
@@ -95,8 +94,8 @@ func (t *traceNetworkServiceEndpointRegistryClient) Find(ctx context.Context, in
 }
 
 func (t *traceNetworkServiceEndpointRegistryClient) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
-	operation := typeutils.GetFuncName(t.traced, "Unregister")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameUnregister)
+	ctx, finish := withLog(ctx, operation, methodNameUnregister)
 	defer finish()
 
 	logObjectTrace(ctx, "unregister", in)
@@ -120,8 +119,8 @@ type traceNetworkServiceEndpointRegistryServer struct {
 }
 
 func (t *traceNetworkServiceEndpointRegistryServer) Register(ctx context.Context, in *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	operation := typeutils.GetFuncName(t.traced, "Register")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameRegister)
+	ctx, finish := withLog(ctx, operation, methodNameRegister)
 	defer finish()
 
 	logObjectTrace(ctx, "register", in)
@@ -135,8 +134,8 @@ func (t *traceNetworkServiceEndpointRegistryServer) Register(ctx context.Context
 }
 
 func (t *traceNetworkServiceEndpointRegistryServer) Find(in *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
-	operation := typeutils.GetFuncName(t.traced, "Find")
-	ctx, finish := withLog(s.Context(), operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameFind)
+	ctx, finish := withLog(s.Context(), operation, methodNameFind)
 	defer finish()
 
 	s = &traceNetworkServiceEndpointRegistryFindServer{
@@ -155,8 +154,8 @@ func (t *traceNetworkServiceEndpointRegistryServer) Find(in *registry.NetworkSer
 }
 
 func (t *traceNetworkServiceEndpointRegistryServer) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
-	operation := typeutils.GetFuncName(t.traced, "Unregister")
-	ctx, finish := withLog(ctx, operation)
+	operation := typeutils.GetFuncName(t.traced, methodNameUnregister)
+	ctx, finish := withLog(ctx, operation, methodNameUnregister)
 	defer finish()
 
 	logObjectTrace(ctx, "unregister", in)
@@ -180,8 +179,8 @@ type traceNetworkServiceEndpointRegistryFindServer struct {
 }
 
 func (t *traceNetworkServiceEndpointRegistryFindServer) Send(nseResp *registry.NetworkServiceEndpointResponse) error {
-	operation := typeutils.GetFuncName(t.NetworkServiceEndpointRegistry_FindServer, "Send")
-	ctx, finish := withLog(t.Context(), operation)
+	operation := typeutils.GetFuncName(t.NetworkServiceEndpointRegistry_FindServer, methodNameSend)
+	ctx, finish := withLog(t.Context(), operation, methodNameSend)
 	defer finish()
 
 	logObjectTrace(ctx, "network service endpoint", nseResp.NetworkServiceEndpoint)

--- a/pkg/tools/dnsutils/trace/context.go
+++ b/pkg/tools/dnsutils/trace/context.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Cisco Systems, Inc.
+// Copyright (c) 2020-2023 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -39,14 +39,16 @@ type traceInfo struct {
 	ResponseMsg *dns.Msg
 }
 
-func withLog(parent context.Context, operation, messageID string) (c context.Context, f func()) {
+func withLog(parent context.Context, operation, methodName, messageID string) (c context.Context, f func()) {
 	if parent == nil {
 		panic("cannot create context from nil parent")
 	}
 
 	if log.IsTracingEnabled() {
-		ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, map[string]interface{}{"type": loggedType, "id": messageID})
-		ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, map[string]interface{}{"type": loggedType, "id": messageID})
+		fields := []*log.Field{log.NewField("type", loggedType), log.NewField("id", messageID)}
+
+		ctx, sLogger, span, sFinish := spanlogger.FromContext(parent, operation, methodName, fields)
+		ctx, lLogger, lFinish := logruslogger.FromSpan(ctx, span, operation, fields)
 		return withTrace(log.WithLog(ctx, sLogger, lLogger)), func() {
 			sFinish()
 			lFinish()

--- a/pkg/tools/dnsutils/trace/handler.go
+++ b/pkg/tools/dnsutils/trace/handler.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco Systems, Inc.
+// Copyright (c) 2022-2023 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -42,8 +42,9 @@ func NewDNSHandler(traced dnsutils.Handler) dnsutils.Handler {
 }
 
 func (t *beginTraceHandler) ServeDNS(ctx context.Context, rw dns.ResponseWriter, m *dns.Msg) {
-	operation := typeutils.GetFuncName(t.traced, "ServeDNS")
-	ctx, finish := withLog(ctx, operation, strconv.Itoa(int(m.Id)))
+	methodName := "ServeDNS"
+	operation := typeutils.GetFuncName(t.traced, methodName)
+	ctx, finish := withLog(ctx, operation, methodName, strconv.Itoa(int(m.Id)))
 	defer finish()
 
 	logRequest(ctx, m, "message")

--- a/pkg/tools/log/common.go
+++ b/pkg/tools/log/common.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+// Field structure that is used for additional information in the logs
+type Field struct {
+	k string
+	v interface{}
+}
+
+// NewField creates Field
+func NewField(k string, v interface{}) *Field {
+	return &Field{k, v}
+}
+
+// Key returns key
+func (f *Field) Key() string {
+	return f.k
+}
+
+// Val returns value
+func (f *Field) Val() interface{} {
+	return f.v
+}

--- a/pkg/tools/log/spanlogger/spanlogger.go
+++ b/pkg/tools/log/spanlogger/spanlogger.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -128,10 +130,10 @@ func (s *spanLogger) logf(level, format string, v ...interface{}) {
 }
 
 // FromContext - creates a new spanLogger from context and operation
-func FromContext(ctx context.Context, operation string, fields map[string]interface{}) (context.Context, log.Logger, Span, func()) {
+func FromContext(ctx context.Context, operation, methodName string, fields []*log.Field) (context.Context, log.Logger, Span, func()) {
 	var span Span
 	if opentelemetry.IsEnabled() {
-		ctx, span = newOTELSpan(ctx, operation, fields)
+		ctx, span = newOpentelemetrySpan(ctx, operation, methodName, fields)
 	}
 	newLog := &spanLogger{
 		span: span,

--- a/pkg/tools/opentelemetry/opentelemetry.go
+++ b/pkg/tools/opentelemetry/opentelemetry.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric"
 	"go.opentelemetry.io/otel/metric/global"
+	"go.opentelemetry.io/otel/propagation"
 	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
 	processor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
@@ -109,6 +112,7 @@ func Init(ctx context.Context, spanExporter sdktrace.SpanExporter, metricExporte
 		sdktrace.WithSpanProcessor(bsp),
 	)
 
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
 	otel.SetTracerProvider(tracerProvider)
 	o.tracerProvider = tracerProvider
 


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Fixes:
1. Added `opentelemetry` `TextMapPropagator` to link spans of different applications
2. Added human-readable root span title
3. Refreshes are displayed in separate spans

Jaeger output example (from the client):
![jaeger](https://user-images.githubusercontent.com/17748275/234525239-73f05e51-13b0-4ea6-a10a-0375b4d376e6.png)

## Issue link
https://github.com/networkservicemesh/sdk/issues/1441


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
