### PR TITLE
Fix InitialRegistrationTime in case of reregistration

### DIFF
--- a/pkg/registry/chains/client/ns_client.go
+++ b/pkg/registry/chains/client/ns_client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/null"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/retry"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/chain"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/metadata"
 )
 
 // NewNetworkServiceRegistryClient creates a new NewNetworkServiceRegistryClient that can be used for NS registration.
@@ -48,6 +49,7 @@ func NewNetworkServiceRegistryClient(ctx context.Context, opts ...Option) regist
 		append(
 			[]registry.NetworkServiceRegistryClient{
 				begin.NewNetworkServiceRegistryClient(),
+				metadata.NewNetworkServiceClient(),
 				retry.NewNetworkServiceRegistryClient(ctx),
 				clientOpts.authorizeNSRegistryClient,
 				heal.NewNetworkServiceRegistryClient(ctx),

--- a/pkg/registry/chains/client/ns_client.go
+++ b/pkg/registry/chains/client/ns_client.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/registry/chains/client/nse_client.go
+++ b/pkg/registry/chains/client/nse_client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/refresh"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/retry"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/chain"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/metadata"
 )
 
 // NewNetworkServiceEndpointRegistryClient creates a new NewNetworkServiceEndpointRegistryClient that can be used for NSE registration.
@@ -49,6 +50,7 @@ func NewNetworkServiceEndpointRegistryClient(ctx context.Context, opts ...Option
 		append(
 			[]registry.NetworkServiceEndpointRegistryClient{
 				begin.NewNetworkServiceEndpointRegistryClient(),
+				metadata.NewNetworkServiceEndpointClient(),
 				retry.NewNetworkServiceEndpointRegistryClient(ctx),
 				heal.NewNetworkServiceEndpointRegistryClient(ctx),
 				refresh.NewNetworkServiceEndpointRegistryClient(ctx),

--- a/pkg/registry/chains/client/nse_client.go
+++ b/pkg/registry/chains/client/nse_client.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/registry/chains/memory/server.go
+++ b/pkg/registry/chains/memory/server.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/registry/chains/memory/server.go
+++ b/pkg/registry/chains/memory/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/setregistrationtime"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/registry/switchcase"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/metadata"
 	"github.com/networkservicemesh/sdk/pkg/tools/interdomain"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
@@ -139,6 +140,7 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		updatepath.NewNetworkServiceEndpointRegistryServer(tokenGenerator),
 		opts.authorizeNSERegistryServer,
 		begin.NewNetworkServiceEndpointRegistryServer(),
+		metadata.NewNetworkServiceEndpointServer(),
 		switchcase.NewNetworkServiceEndpointRegistryServer(switchcase.NSEServerCase{
 			Condition: func(c context.Context, nse *registry.NetworkServiceEndpoint) bool {
 				if interdomain.Is(nse.GetName()) {
@@ -181,6 +183,7 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		grpcmetadata.NewNetworkServiceRegistryServer(),
 		updatepath.NewNetworkServiceRegistryServer(tokenGenerator),
 		opts.authorizeNSRegistryServer,
+		metadata.NewNetworkServiceServer(),
 		setpayload.NewNetworkServiceRegistryServer(),
 		switchcase.NewNetworkServiceRegistryServer(
 			switchcase.NSServerCase{

--- a/pkg/registry/common/setregistrationtime/metadata.go
+++ b/pkg/registry/common/setregistrationtime/metadata.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setregistrationtime
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/metadata"
+)
+
+type key struct{}
+
+// store sets the initialRegistrationTime stored in per NSE metadata.
+func store(ctx context.Context, initialRegistrationTime protoreflect.ProtoMessage) {
+	metadata.Map(ctx, false).Store(key{}, proto.Clone(initialRegistrationTime))
+}
+
+// load returns the initialRegistrationTime stored in per NSE metadata,
+func load(ctx context.Context) (value *timestamppb.Timestamp, ok bool) {
+	rawValue, ok := metadata.Map(ctx, false).Load(key{})
+	if !ok {
+		return
+	}
+	value, ok = rawValue.(*timestamppb.Timestamp)
+	return value, ok
+}
+
+// deleteTime deletes the initialRegistrationTime stored in per NSE metadata,
+func deleteTime(ctx context.Context) {
+	metadata.Map(ctx, false).Delete(key{})
+}

--- a/pkg/registry/common/setregistrationtime/nse_server.go
+++ b/pkg/registry/common/setregistrationtime/nse_server.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,15 +21,19 @@ package setregistrationtime
 import (
 	"context"
 
+	"github.com/edwarnicke/genericsync"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/clock"
 )
 
-type setregtimeNSEServer struct{}
+type setregtimeNSEServer struct {
+	genericsync.Map[string, *timestamppb.Timestamp]
+}
 
 // NewNetworkServiceEndpointRegistryServer creates a new NetworkServiceServer chain element that sets initial
 // registration time.
@@ -36,8 +42,13 @@ func NewNetworkServiceEndpointRegistryServer() registry.NetworkServiceEndpointRe
 }
 
 func (r *setregtimeNSEServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
-	if nse.InitialRegistrationTime == nil {
-		nse.InitialRegistrationTime = timestamppb.New(clock.FromContext(ctx).Now())
+	if v, ok := r.Load(nse.GetName()); ok {
+		nse.InitialRegistrationTime = v
+	} else {
+		if nse.InitialRegistrationTime == nil {
+			nse.InitialRegistrationTime = timestamppb.New(clock.FromContext(ctx).Now())
+		}
+		r.Store(nse.GetName(), proto.Clone(nse.InitialRegistrationTime).(*timestamppb.Timestamp))
 	}
 
 	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, nse)
@@ -48,5 +59,6 @@ func (r *setregtimeNSEServer) Find(q *registry.NetworkServiceEndpointQuery, s re
 }
 
 func (r *setregtimeNSEServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	r.Delete(nse.GetName())
 	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, nse)
 }

--- a/pkg/registry/common/setregistrationtime/nse_server_test.go
+++ b/pkg/registry/common/setregistrationtime/nse_server_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,8 +67,17 @@ func TestRegTimeServer_Register(t *testing.T) {
 	require.Len(t, nses, 1)
 	require.True(t, proto.Equal(nses[0].InitialRegistrationTime, registeredNse.InitialRegistrationTime))
 
-	// 3. Refresh
+	// 3.1 Refresh
 	reg, err = s.Register(ctx, reg.Clone())
+	require.NoError(t, err)
+	require.NotNil(t, reg.InitialRegistrationTime)
+	require.True(t, proto.Equal(reg.InitialRegistrationTime, registeredNse.InitialRegistrationTime))
+
+	// 3.2 Refresh with empty field
+	regClone := reg.Clone()
+	regClone.InitialRegistrationTime = nil
+	clockMock.Add(time.Second)
+	reg, err = s.Register(ctx, regClone)
 	require.NoError(t, err)
 	require.NotNil(t, reg.InitialRegistrationTime)
 	require.True(t, proto.Equal(reg.InitialRegistrationTime, registeredNse.InitialRegistrationTime))

--- a/pkg/registry/common/setregistrationtime/nse_server_test.go
+++ b/pkg/registry/common/setregistrationtime/nse_server_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/setregistrationtime"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/metadata"
 )
 
 func testNSE() *registry.NetworkServiceEndpoint {
@@ -45,6 +46,7 @@ func testNSE() *registry.NetworkServiceEndpoint {
 
 func TestRegTimeServer_Register(t *testing.T) {
 	s := next.NewNetworkServiceEndpointRegistryServer(
+		metadata.NewNetworkServiceEndpointServer(),
 		setregistrationtime.NewNetworkServiceEndpointRegistryServer(),
 		memory.NewNetworkServiceEndpointRegistryServer(),
 	)

--- a/pkg/registry/utils/inject/injecterror/ns_server.go
+++ b/pkg/registry/utils/inject/injecterror/ns_server.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package injecterror
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+)
+
+type injectErrorNSServer struct {
+	registerErrorSupplier, findErrorSupplier, unregisterErrorSupplier *errorSupplier
+}
+
+// NewNetworkServiceRegistryServer returns a server chain element returning error on Register/Find/Unregister on given times
+func NewNetworkServiceRegistryServer(opts ...Option) registry.NetworkServiceRegistryServer {
+	o := &options{
+		err:                  errors.New("error originates in injectErrorNSServer"),
+		registerErrorTimes:   []int{-1},
+		findErrorTimes:       []int{-1},
+		unregisterErrorTimes: []int{-1},
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return &injectErrorNSServer{
+		registerErrorSupplier: &errorSupplier{
+			err:        o.err,
+			errorTimes: o.registerErrorTimes,
+		},
+		findErrorSupplier: &errorSupplier{
+			err:        o.err,
+			errorTimes: o.findErrorTimes,
+		},
+		unregisterErrorSupplier: &errorSupplier{
+			err:        o.err,
+			errorTimes: o.unregisterErrorTimes,
+		},
+	}
+}
+
+func (c *injectErrorNSServer) Register(ctx context.Context, in *registry.NetworkService) (*registry.NetworkService, error) {
+	if err := c.registerErrorSupplier.supply(); err != nil {
+		return nil, err
+	}
+	return next.NetworkServiceRegistryServer(ctx).Register(ctx, in)
+}
+
+func (c *injectErrorNSServer) Find(query *registry.NetworkServiceQuery, server registry.NetworkServiceRegistry_FindServer) error {
+	if err := c.findErrorSupplier.supply(); err != nil {
+		return err
+	}
+	return next.NetworkServiceRegistryServer(server.Context()).Find(query, server)
+}
+
+func (c *injectErrorNSServer) Unregister(ctx context.Context, in *registry.NetworkService) (*empty.Empty, error) {
+	if err := c.unregisterErrorSupplier.supply(); err != nil {
+		return nil, err
+	}
+	return next.NetworkServiceRegistryServer(ctx).Unregister(ctx, in)
+}

--- a/pkg/registry/utils/metadata/context.go
+++ b/pkg/registry/utils/metadata/context.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+	"sync"
+
+	"github.com/edwarnicke/genericsync"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+)
+
+type metaDataKey struct{}
+
+type metaData struct {
+	client sync.Map
+	server sync.Map
+}
+
+func store(parent context.Context, id string, mdMap *genericsync.Map[string, *metaData]) context.Context {
+	if _, ok := parent.Value(metaDataKey{}).(*metaData); !ok {
+		md, _ := mdMap.LoadOrStore(id, &metaData{})
+		return context.WithValue(parent, metaDataKey{}, md)
+	}
+	return parent
+}
+
+func load(parent context.Context, id string, mdMap *genericsync.Map[string, *metaData]) context.Context {
+	if _, ok := parent.Value(metaDataKey{}).(*metaData); !ok {
+		if md, mdOk := mdMap.Load(id); mdOk {
+			return context.WithValue(parent, metaDataKey{}, md)
+		}
+	}
+	return parent
+}
+
+func del(parent context.Context, id string, mdMap *genericsync.Map[string, *metaData]) context.Context {
+	if _, ok := parent.Value(metaDataKey{}).(*metaData); !ok {
+		if md, ok := mdMap.LoadAndDelete(id); ok {
+			return context.WithValue(parent, metaDataKey{}, md)
+		}
+		return context.WithValue(parent, metaDataKey{}, new(metaData))
+	}
+	return parent
+}
+
+// Map - Return the client (or server) per Connection.Id metadata *sync.Map
+func Map(parent context.Context, isClient bool) *sync.Map {
+	m, ok := parent.Value(metaDataKey{}).(*metaData)
+	if !ok || m == nil {
+		panic("please add metadata chain element to your chain")
+	}
+	if isClient {
+		return &m.client
+	}
+	return &m.server
+}
+
+// IsClient - returns true if in implements networkservice.NetworkServiceClient
+func IsClient(in interface{}) bool {
+	_, ok := in.(networkservice.NetworkServiceClient)
+	return ok
+}

--- a/pkg/registry/utils/metadata/doc.go
+++ b/pkg/registry/utils/metadata/doc.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metadata provides per nsName/nseName metadata
+package metadata

--- a/pkg/registry/utils/metadata/ns_client.go
+++ b/pkg/registry/utils/metadata/ns_client.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+
+	"github.com/edwarnicke/genericsync"
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+type metaDataNSClient struct {
+	Map genericsync.Map[string, *metaData]
+}
+
+// NewNetworkServiceClient - enables per ns.Name metadata for the ns registry client
+func NewNetworkServiceClient() registry.NetworkServiceRegistryClient {
+	return &metaDataNSClient{}
+}
+
+func (m *metaDataNSClient) Register(ctx context.Context, ns *registry.NetworkService, opts ...grpc.CallOption) (*registry.NetworkService, error) {
+	nsName := ns.GetName()
+	_, isEstablished := m.Map.Load(nsName)
+
+	n, err := next.NetworkServiceRegistryClient(ctx).Register(store(ctx, nsName, &m.Map), ns, opts...)
+	if err != nil {
+		if !isEstablished {
+			del(ctx, nsName, &m.Map)
+			log.FromContext(ctx).
+				WithField("metadata", "ns client").
+				WithField("nsName", nsName).
+				Debugf("metadata deleted")
+		}
+		return nil, err
+	}
+	return n, nil
+}
+
+func (m *metaDataNSClient) Find(ctx context.Context, query *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
+	nsName := query.GetNetworkService().GetName()
+	return next.NetworkServiceRegistryClient(ctx).Find(load(ctx, nsName, &m.Map), query, opts...)
+}
+
+func (m *metaDataNSClient) Unregister(ctx context.Context, ns *registry.NetworkService, opts ...grpc.CallOption) (*empty.Empty, error) {
+	delCtx := del(ctx, ns.GetName(), &m.Map)
+	log.FromContext(ctx).
+		WithField("metadata", "ns client").
+		WithField("ns name", ns.GetName()).
+		Debugf("metadata deleted")
+
+	return next.NetworkServiceRegistryClient(ctx).Unregister(delCtx, ns, opts...)
+}

--- a/pkg/registry/utils/metadata/ns_server.go
+++ b/pkg/registry/utils/metadata/ns_server.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+
+	"github.com/edwarnicke/genericsync"
+	"github.com/golang/protobuf/ptypes/empty"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/streamcontext"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+type metadataNSServer struct {
+	Map genericsync.Map[string, *metaData]
+}
+
+// NewNetworkServiceServer - enables per ns.Name metadata for the ns registry server
+func NewNetworkServiceServer() registry.NetworkServiceRegistryServer {
+	return &metadataNSServer{}
+}
+
+func (m *metadataNSServer) Register(ctx context.Context, ns *registry.NetworkService) (*registry.NetworkService, error) {
+	nsName := ns.GetName()
+	_, isEstablished := m.Map.Load(nsName)
+
+	n, err := next.NetworkServiceRegistryServer(ctx).Register(store(ctx, nsName, &m.Map), ns)
+	if err != nil {
+		if !isEstablished {
+			del(ctx, nsName, &m.Map)
+			log.FromContext(ctx).
+				WithField("metadata", "ns server").
+				WithField("nsName", nsName).
+				Debugf("metadata deleted")
+		}
+		return nil, err
+	}
+	return n, nil
+}
+
+func (m *metadataNSServer) Find(query *registry.NetworkServiceQuery, s registry.NetworkServiceRegistry_FindServer) error {
+	nsName := query.GetNetworkService().GetName()
+	s = streamcontext.NetworkServiceRegistryFindServer(load(s.Context(), nsName, &m.Map), s)
+	return next.NetworkServiceRegistryServer(s.Context()).Find(query, s)
+}
+
+func (m *metadataNSServer) Unregister(ctx context.Context, ns *registry.NetworkService) (*empty.Empty, error) {
+	delCtx := del(ctx, ns.GetName(), &m.Map)
+	log.FromContext(ctx).
+		WithField("metadata", "ns server").
+		WithField("ns name", ns.GetName()).
+		Debugf("metadata deleted")
+	return next.NetworkServiceRegistryServer(ctx).Unregister(delCtx, ns)
+}

--- a/pkg/registry/utils/metadata/ns_test.go
+++ b/pkg/registry/utils/metadata/ns_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/checks/checkcontext"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/inject/injecterror"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/metadata"
+)
+
+const (
+	testNSKey = "test"
+)
+
+func testNS() *registry.NetworkService {
+	return &registry.NetworkService{
+		Name: "nse",
+	}
+}
+
+type nsSample struct {
+	name string
+	test func(t *testing.T, server registry.NetworkServiceRegistryServer, isClient bool)
+}
+
+var nsSamples = []*nsSample{
+	{
+		name: "Register",
+		test: func(t *testing.T, server registry.NetworkServiceRegistryServer, isClient bool) {
+			var actual, expected map[string]string = nil, map[string]string{"a": "A"}
+
+			chainServer := next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(_ *testing.T, ctx context.Context) {
+					metadata.Map(ctx, isClient).Store(testNSKey, expected)
+				}),
+			)
+			_, err := chainServer.Register(context.Background(), testNS())
+			require.NoError(t, err)
+
+			chainServer = next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(_ *testing.T, ctx context.Context) {
+					if raw, ok := metadata.Map(ctx, isClient).Load(testNSKey); ok {
+						actual = raw.(map[string]string)
+					} else {
+						actual = nil
+					}
+				}),
+			)
+			_, err = chainServer.Register(context.Background(), testNS())
+			require.NoError(t, err)
+
+			require.Equal(t, expected, actual)
+		},
+	},
+	{
+		name: "Register failed",
+		test: func(t *testing.T, server registry.NetworkServiceRegistryServer, isClient bool) {
+			chainServer := next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(_ *testing.T, ctx context.Context) {
+					metadata.Map(ctx, isClient).Store(testNSKey, 0)
+				}),
+				injecterror.NewNetworkServiceRegistryServer(),
+			)
+			_, err := chainServer.Register(context.Background(), testNS())
+			require.Error(t, err)
+
+			chainServer = next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(t *testing.T, ctx context.Context) {
+					_, ok := metadata.Map(ctx, isClient).Load(testNSKey)
+					require.False(t, ok)
+				}),
+			)
+			_, err = chainServer.Register(context.Background(), testNS())
+			require.NoError(t, err)
+		},
+	},
+	{
+		name: "Refresh failed",
+		test: func(t *testing.T, server registry.NetworkServiceRegistryServer, isClient bool) {
+			chainServer := next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(_ *testing.T, ctx context.Context) {
+					metadata.Map(ctx, isClient).Store(testNSKey, 0)
+				}),
+				injecterror.NewNetworkServiceRegistryServer(
+					injecterror.WithRegisterErrorTimes(1),
+				),
+			)
+			_, err := chainServer.Register(context.Background(), testNS())
+			require.NoError(t, err)
+
+			_, err = chainServer.Register(context.Background(), testNS())
+			require.Error(t, err)
+
+			chainServer = next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(t *testing.T, ctx context.Context) {
+					_, ok := metadata.Map(ctx, isClient).Load(testNSKey)
+					require.True(t, ok)
+				}),
+			)
+			_, err = chainServer.Register(context.Background(), testNS())
+			require.NoError(t, err)
+		},
+	},
+	{
+		name: "Unregister",
+		test: func(t *testing.T, server registry.NetworkServiceRegistryServer, isClient bool) {
+			data := map[string]string{"a": "A"}
+
+			chainServer := next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(_ *testing.T, ctx context.Context) {
+					metadata.Map(ctx, isClient).Store(testNSKey, data)
+				}),
+			)
+			registeredNSE, err := chainServer.Register(context.Background(), testNS())
+			require.NoError(t, err)
+
+			_, err = server.Unregister(context.Background(), registeredNSE)
+			require.NoError(t, err)
+
+			chainServer = next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(_ *testing.T, ctx context.Context) {
+					if raw, ok := metadata.Map(ctx, isClient).Load(testNSKey); ok {
+						data = raw.(map[string]string)
+					} else {
+						data = nil
+					}
+				}),
+			)
+			_, err = chainServer.Register(context.Background(), testNS())
+			require.NoError(t, err)
+
+			require.Nil(t, data)
+		},
+	},
+	{
+		name: "Double Unregister",
+		test: func(t *testing.T, server registry.NetworkServiceRegistryServer, isClient bool) {
+			chainServer := next.NewNetworkServiceRegistryServer(
+				server,
+				checkcontext.NewNSServer(t, func(t *testing.T, ctx context.Context) {
+					require.NotNil(t, metadata.Map(ctx, isClient))
+				}),
+			)
+
+			registeredNSE, err := chainServer.Register(context.Background(), testNS())
+			require.NoError(t, err)
+
+			_, err = chainServer.Unregister(context.Background(), registeredNSE)
+			require.NoError(t, err)
+
+			_, err = chainServer.Unregister(context.Background(), registeredNSE)
+			require.NoError(t, err)
+		},
+	},
+}
+
+func TestMetaDataServer(t *testing.T) {
+	for i := range nsSamples {
+		sample := nsSamples[i]
+		t.Run(sample.name, func(t *testing.T) {
+			sample.test(t, metadata.NewNetworkServiceServer(), false)
+		})
+	}
+}
+
+func TestMetaDataClient(t *testing.T) {
+	for i := range nsSamples {
+		sample := nsSamples[i]
+		t.Run(sample.name, func(t *testing.T) {
+			sample.test(t, adapters.NetworkServiceClientToServer(metadata.NewNetworkServiceClient()), true)
+		})
+	}
+}

--- a/pkg/registry/utils/metadata/nse_client.go
+++ b/pkg/registry/utils/metadata/nse_client.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+
+	"github.com/edwarnicke/genericsync"
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+type metaDataNSEClient struct {
+	Map genericsync.Map[string, *metaData]
+}
+
+// NewNetworkServiceEndpointClient - enables per nse.Name metadata for the nse registry client
+func NewNetworkServiceEndpointClient() registry.NetworkServiceEndpointRegistryClient {
+	return &metaDataNSEClient{}
+}
+
+func (m *metaDataNSEClient) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*registry.NetworkServiceEndpoint, error) {
+	nseName := nse.GetName()
+	_, isEstablished := m.Map.Load(nseName)
+
+	n, err := next.NetworkServiceEndpointRegistryClient(ctx).Register(store(ctx, nseName, &m.Map), nse, opts...)
+	if err != nil {
+		if !isEstablished {
+			del(ctx, nseName, &m.Map)
+			log.FromContext(ctx).
+				WithField("metadata", "nse client").
+				WithField("nseName", nseName).
+				Debugf("metadata deleted")
+		}
+		return nil, err
+	}
+	return n, nil
+}
+
+func (m *metaDataNSEClient) Find(ctx context.Context, query *registry.NetworkServiceEndpointQuery, opts ...grpc.CallOption) (registry.NetworkServiceEndpointRegistry_FindClient, error) {
+	nseName := query.GetNetworkServiceEndpoint().GetName()
+	return next.NetworkServiceEndpointRegistryClient(ctx).Find(load(ctx, nseName, &m.Map), query, opts...)
+}
+
+func (m *metaDataNSEClient) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint, opts ...grpc.CallOption) (*empty.Empty, error) {
+	delCtx := del(ctx, nse.GetName(), &m.Map)
+	log.FromContext(ctx).
+		WithField("metadata", "nse client").
+		WithField("nse name", nse.GetName()).
+		Debugf("metadata deleted")
+
+	return next.NetworkServiceEndpointRegistryClient(ctx).Unregister(delCtx, nse, opts...)
+}

--- a/pkg/registry/utils/metadata/nse_server.go
+++ b/pkg/registry/utils/metadata/nse_server.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+
+	"github.com/edwarnicke/genericsync"
+	"github.com/golang/protobuf/ptypes/empty"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/streamcontext"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+type metadataNSEServer struct {
+	Map genericsync.Map[string, *metaData]
+}
+
+// NewNetworkServiceEndpointServer - enables per nse.Name metadata for the nse registry client
+func NewNetworkServiceEndpointServer() registry.NetworkServiceEndpointRegistryServer {
+	return &metadataNSEServer{}
+}
+
+func (m *metadataNSEServer) Register(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	nseName := nse.GetName()
+	_, isEstablished := m.Map.Load(nseName)
+
+	n, err := next.NetworkServiceEndpointRegistryServer(ctx).Register(store(ctx, nseName, &m.Map), nse)
+	if err != nil {
+		if !isEstablished {
+			del(ctx, nseName, &m.Map)
+			log.FromContext(ctx).
+				WithField("metadata", "nse server").
+				WithField("nseName", nseName).
+				Debugf("metadata deleted")
+		}
+		return nil, err
+	}
+	return n, nil
+}
+
+func (m *metadataNSEServer) Find(query *registry.NetworkServiceEndpointQuery, s registry.NetworkServiceEndpointRegistry_FindServer) error {
+	nseName := query.GetNetworkServiceEndpoint().GetName()
+	s = streamcontext.NetworkServiceEndpointRegistryFindServer(load(s.Context(), nseName, &m.Map), s)
+	return next.NetworkServiceEndpointRegistryServer(s.Context()).Find(query, s)
+}
+
+func (m *metadataNSEServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	delCtx := del(ctx, nse.GetName(), &m.Map)
+	log.FromContext(ctx).
+		WithField("metadata", "nse server").
+		WithField("nse name", nse.GetName()).
+		Debugf("metadata deleted")
+	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(delCtx, nse)
+}

--- a/pkg/registry/utils/metadata/nse_test.go
+++ b/pkg/registry/utils/metadata/nse_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/checks/checkcontext"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/inject/injecterror"
+	"github.com/networkservicemesh/sdk/pkg/registry/utils/metadata"
+)
+
+const (
+	testNSEKey = "test"
+)
+
+func testNSE() *registry.NetworkServiceEndpoint {
+	return &registry.NetworkServiceEndpoint{
+		Name:                "nse",
+		NetworkServiceNames: []string{"ns-name"},
+	}
+}
+
+type nseSample struct {
+	name string
+	test func(t *testing.T, server registry.NetworkServiceEndpointRegistryServer, isClient bool)
+}
+
+var nseSamples = []*nseSample{
+	{
+		name: "Register",
+		test: func(t *testing.T, server registry.NetworkServiceEndpointRegistryServer, isClient bool) {
+			var actual, expected map[string]string = nil, map[string]string{"a": "A"}
+
+			chainServer := next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(_ *testing.T, ctx context.Context) {
+					metadata.Map(ctx, isClient).Store(testNSEKey, expected)
+				}),
+			)
+			_, err := chainServer.Register(context.Background(), testNSE())
+			require.NoError(t, err)
+
+			chainServer = next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(_ *testing.T, ctx context.Context) {
+					if raw, ok := metadata.Map(ctx, isClient).Load(testNSEKey); ok {
+						actual = raw.(map[string]string)
+					} else {
+						actual = nil
+					}
+				}),
+			)
+			_, err = chainServer.Register(context.Background(), testNSE())
+			require.NoError(t, err)
+
+			require.Equal(t, expected, actual)
+		},
+	},
+	{
+		name: "Register failed",
+		test: func(t *testing.T, server registry.NetworkServiceEndpointRegistryServer, isClient bool) {
+			chainServer := next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(_ *testing.T, ctx context.Context) {
+					metadata.Map(ctx, isClient).Store(testNSEKey, 0)
+				}),
+				injecterror.NewNetworkServiceEndpointRegistryServer(),
+			)
+			_, err := chainServer.Register(context.Background(), testNSE())
+			require.Error(t, err)
+
+			chainServer = next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(t *testing.T, ctx context.Context) {
+					_, ok := metadata.Map(ctx, isClient).Load(testNSEKey)
+					require.False(t, ok)
+				}),
+			)
+			_, err = chainServer.Register(context.Background(), testNSE())
+			require.NoError(t, err)
+		},
+	},
+	{
+		name: "Refresh failed",
+		test: func(t *testing.T, server registry.NetworkServiceEndpointRegistryServer, isClient bool) {
+			chainServer := next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(_ *testing.T, ctx context.Context) {
+					metadata.Map(ctx, isClient).Store(testNSEKey, 0)
+				}),
+				injecterror.NewNetworkServiceEndpointRegistryServer(
+					injecterror.WithRegisterErrorTimes(1),
+				),
+			)
+			_, err := chainServer.Register(context.Background(), testNSE())
+			require.NoError(t, err)
+
+			_, err = chainServer.Register(context.Background(), testNSE())
+			require.Error(t, err)
+
+			chainServer = next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(t *testing.T, ctx context.Context) {
+					_, ok := metadata.Map(ctx, isClient).Load(testNSEKey)
+					require.True(t, ok)
+				}),
+			)
+			_, err = chainServer.Register(context.Background(), testNSE())
+			require.NoError(t, err)
+		},
+	},
+	{
+		name: "Unregister",
+		test: func(t *testing.T, server registry.NetworkServiceEndpointRegistryServer, isClient bool) {
+			data := map[string]string{"a": "A"}
+
+			chainServer := next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(_ *testing.T, ctx context.Context) {
+					metadata.Map(ctx, isClient).Store(testNSEKey, data)
+				}),
+			)
+			registeredNSE, err := chainServer.Register(context.Background(), testNSE())
+			require.NoError(t, err)
+
+			_, err = server.Unregister(context.Background(), registeredNSE)
+			require.NoError(t, err)
+
+			chainServer = next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(_ *testing.T, ctx context.Context) {
+					if raw, ok := metadata.Map(ctx, isClient).Load(testNSEKey); ok {
+						data = raw.(map[string]string)
+					} else {
+						data = nil
+					}
+				}),
+			)
+			_, err = chainServer.Register(context.Background(), testNSE())
+			require.NoError(t, err)
+
+			require.Nil(t, data)
+		},
+	},
+	{
+		name: "Double Unregister",
+		test: func(t *testing.T, server registry.NetworkServiceEndpointRegistryServer, isClient bool) {
+			chainServer := next.NewNetworkServiceEndpointRegistryServer(
+				server,
+				checkcontext.NewNSEServer(t, func(t *testing.T, ctx context.Context) {
+					require.NotNil(t, metadata.Map(ctx, isClient))
+				}),
+			)
+
+			registeredNSE, err := chainServer.Register(context.Background(), testNSE())
+			require.NoError(t, err)
+
+			_, err = chainServer.Unregister(context.Background(), registeredNSE)
+			require.NoError(t, err)
+
+			_, err = chainServer.Unregister(context.Background(), registeredNSE)
+			require.NoError(t, err)
+		},
+	},
+}
+
+func TestMetaDataNSEServer(t *testing.T) {
+	for i := range nseSamples {
+		sample := nseSamples[i]
+		t.Run(sample.name, func(t *testing.T) {
+			sample.test(t, metadata.NewNetworkServiceEndpointServer(), false)
+		})
+	}
+}
+
+func TestMetaDataNSEClient(t *testing.T) {
+	for i := range nseSamples {
+		sample := nseSamples[i]
+		t.Run(sample.name, func(t *testing.T) {
+			sample.test(t, adapters.NetworkServiceEndpointClientToServer(metadata.NewNetworkServiceEndpointClient()), true)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
We should not change the `InitialRegistrationTime` field if we have already registered the NSE before.

Added registry `metadata` chain element

## Issue link
https://github.com/networkservicemesh/deployments-k8s/issues/9063

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
