### PR TITLE
default_svid_ttl config removed

### DIFF
--- a/pkg/tools/spire/server.conf.go
+++ b/pkg/tools/spire/server.conf.go
@@ -25,7 +25,6 @@ const (
     data_dir = "%[1]s/data"
     log_level = "WARN"
     ca_key_type = "rsa-2048"
-    default_svid_ttl = "1h"
     ca_subject = {
         country = ["US"],
         organization = ["SPIFFE"],


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Removed `default_svid_ttl` configuration parameter since it was renamed in SPIRE 1.6 and the default value (`1h`) is used anyway. This change enables to update the `Dockerfiles` (see below) gradually with the new SPIRE version, no need to change all of them at once, because the default value is the same for both versions however the name of the configurable changed.

```
ADD https://github.com/spiffe/spire/releases/download/v1.6.1/spire-1.6.1-linux-x86_64-glibc.tar.gz .
RUN tar xzvf spire-1.6.1-linux-x86_64-glibc.tar.gz -C /bin --strip=2 spire-1.6.1/bin/spire-server spire-1.6.1/bin/spire-agent
```

## Issue link
<!--- Please link to the issue here. -->
Connected to [#8963](https://github.com/networkservicemesh/deployments-k8s/pull/8963).

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
