### PR TITLE
Fix vl3 dns configurations

### DIFF
--- a/pkg/networkservice/connectioncontext/dnscontext/client.go
+++ b/pkg/networkservice/connectioncontext/dnscontext/client.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
-	"github.com/networkservicemesh/sdk/pkg/tools/dnsutils"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
@@ -72,22 +71,12 @@ func (c *dnsContextClient) Request(ctx context.Context, request *networkservice.
 		request.Connection.Context.DnsContext = &networkservice.DNSContext{}
 	}
 
-	if !dnsutils.ContainsDNSConfig(request.GetConnection().GetContext().GetDnsContext().Configs, c.resolvconfDNSConfig) {
-		request.GetConnection().GetContext().GetDnsContext().Configs = append(request.GetConnection().GetContext().GetDnsContext().Configs, c.resolvconfDNSConfig)
-	}
-
 	rv, err := next.Client(ctx).Request(ctx, request, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	var configs []*networkservice.DNSConfig
-	if rv.GetContext().GetDnsContext() != nil {
-		configs = rv.GetContext().GetDnsContext().GetConfigs()
-	}
-
-	c.dnsConfigsMap.Store(rv.Id, configs)
-
+	c.dnsConfigsMap.Store(rv.Id, append(rv.GetContext().GetDnsContext().Configs, c.resolvconfDNSConfig))
 	return rv, nil
 }
 


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Main changes:
1. NSC shouldn't add private resolv.conf fields to `Request` in `dnsContextClient`
2. vl3-dns should add search domains for the Connection. If DNS record is `"target.d1.d2.d3."` - it adds `["d1.d2.d3", "d2.d3", "d3"]`

## Issue link
https://github.com/networkservicemesh/sdk/issues/1426

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Fixed unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
