### PR TITLE
Fix healing after failed refresh

### DIFF
--- a/pkg/networkservice/chains/client/options.go
+++ b/pkg/networkservice/chains/client/options.go
@@ -109,3 +109,13 @@ func WithoutRefresh() Option {
 		c.refreshClient = null.NewClient()
 	}
 }
+
+// WithRefresh sets a custom refreshClient for the client chain
+func WithRefresh(refreshClient networkservice.NetworkServiceClient) Option {
+	if refreshClient == nil {
+		panic("refreshClient cannot be nil")
+	}
+	return Option(func(c *clientOptions) {
+		c.refreshClient = refreshClient
+	})
+}

--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -34,8 +35,14 @@ import (
 	nsclient "github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/heal"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/refresh"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/checks/checkresponse"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injectclock"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injecterror"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
+	"github.com/networkservicemesh/sdk/pkg/tools/clockmock"
 	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
 )
 
@@ -730,4 +737,138 @@ func testForwarderShouldBeSelectedCorrectlyOnNSMgrRestart(t *testing.T, nodeNum,
 			},
 		}, sandbox.GenerateTestToken)
 	}
+}
+
+func TestNSMGR_RefreshFailed_DataPlaneHealthy(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	domain := sandbox.NewBuilder(ctx, t).
+		SetNodesCount(1).
+		Build()
+
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg := defaultRegistryService(t.Name())
+	nsReg, err := nsRegistryClient.Register(ctx, nsReg)
+	require.NoError(t, err)
+
+	nseReg := defaultRegistryEndpoint(nsReg.Name)
+
+	counter := new(count.Server)
+	// allow only one successful request
+	inject := injecterror.NewServer(injecterror.WithCloseErrorTimes(), injecterror.WithRequestErrorTimes(1))
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, inject, counter)
+
+	request := defaultRequest(nsReg.Name)
+
+	tokenDuration := time.Minute * 15
+	clk := clockmock.New(ctx)
+	clk.Set(time.Now())
+	refreshClient := next.NewNetworkServiceClient(
+		injectclock.NewClient(clk),
+		refresh.NewClient(ctx),
+	)
+	nsc := domain.Nodes[0].NewClient(ctx,
+		sandbox.GenerateExpiringToken(tokenDuration),
+		nsclient.WithRefresh(refreshClient),
+		nsclient.WithHealClient(heal.NewClient(ctx,
+			heal.WithLivenessCheck(func(ctx context.Context, conn *networkservice.Connection) bool {
+				return true
+			}),
+			heal.WithLivenessCheckInterval(time.Millisecond*10),
+		)),
+	)
+
+	requestCtx, requestCalcel := context.WithTimeout(ctx, time.Second)
+	defer requestCalcel()
+	conn, err := nsc.Request(requestCtx, request.Clone())
+	require.NoError(t, err)
+	require.Equal(t, 1, counter.Requests())
+
+	// refresh interval in this test is expected to be 3 minutes and a few milliseconds
+	clk.Add(time.Second * 190)
+
+	require.Eventually(t, checkSecondRequestsReceived(counter.Requests), timeout, tick)
+	require.Equal(t, 1, counter.UniqueRequests())
+	require.Equal(t, 2, counter.Requests())
+
+	_, err = nsc.Close(ctx, conn.Clone())
+	require.NoError(t, err)
+}
+
+func TestNSMGR_RefreshFailed_DataPlaneBroken(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	domain := sandbox.NewBuilder(ctx, t).
+		SetNodesCount(1).
+		Build()
+
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg := defaultRegistryService(t.Name())
+	nsReg, err := nsRegistryClient.Register(ctx, nsReg)
+	require.NoError(t, err)
+
+	nseReg := defaultRegistryEndpoint(nsReg.Name)
+
+	counter := new(count.Server)
+	// allow only one successful request
+	inject := injecterror.NewServer(injecterror.WithCloseErrorTimes(), injecterror.WithRequestErrorTimes(1, -1))
+	isDataplaneHealthy := atomic.Bool{}
+	dataPlaneNotifier := checkresponse.NewServer(t, func(t *testing.T, c *networkservice.Connection) {
+		if c != nil {
+			isDataplaneHealthy.Store(true)
+		}
+	})
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, inject, counter)
+
+	request := defaultRequest(nsReg.Name)
+
+	tokenDuration := time.Minute * 15
+	clk := clockmock.New(ctx)
+	clk.Set(time.Now())
+	refreshClient := next.NewNetworkServiceClient(
+		injectclock.NewClient(clk),
+		refresh.NewClient(ctx),
+	)
+
+	nsc := domain.Nodes[0].NewClient(ctx,
+		sandbox.GenerateExpiringToken(tokenDuration),
+		nsclient.WithRefresh(refreshClient),
+		nsclient.WithHealClient(heal.NewClient(ctx,
+			heal.WithLivenessCheck(func(ctx context.Context, conn *networkservice.Connection) bool {
+				return isDataplaneHealthy.Load()
+			}),
+			heal.WithLivenessCheckInterval(time.Millisecond*10),
+		)),
+	)
+
+	requestCtx, requestCalcel := context.WithTimeout(ctx, time.Second)
+	defer requestCalcel()
+	conn, err := nsc.Request(requestCtx, request.Clone())
+	require.NoError(t, err)
+	require.Equal(t, 1, counter.Requests())
+
+	nseReg2 := defaultRegistryEndpoint(nsReg.Name)
+	nseReg2.Name += "-2"
+
+	domain.Nodes[0].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, dataPlaneNotifier, counter)
+
+	// refresh interval in this test is expected to be 3 minutes and a few milliseconds
+	clk.Add(time.Second * 190)
+
+	isDataplaneHealthy.Store(false)
+
+	require.Eventually(t, checkSecondRequestsReceived(counter.Requests), timeout, tick)
+	require.Equal(t, 2, counter.UniqueRequests())
+	require.Equal(t, 2, counter.Requests())
+
+	_, err = nsc.Close(ctx, conn.Clone())
+	require.NoError(t, err)
 }

--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -60,6 +60,10 @@ func (h *healClient) Request(ctx context.Context, request *networkservice.Networ
 	// Cancel any existing eventLoop
 	if loopHandle, loaded := loadAndDelete(ctx); loaded {
 		loopHandle.cancel()
+		if !loopHandle.healingStarted {
+			started, ok := <-loopHandle.monitorFinishedCh
+			loopHandle.healingStarted = ok && started
+		}
 	}
 
 	conn, err := next.Client(ctx).Request(ctx, request, opts...)

--- a/pkg/networkservice/common/heal/client.go
+++ b/pkg/networkservice/common/heal/client.go
@@ -21,13 +21,13 @@ import (
 	"time"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clientconn"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/extend"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/postpone"
 )
 
@@ -58,32 +58,33 @@ func NewClient(chainCtx context.Context, opts ...Option) networkservice.NetworkS
 func (h *healClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
 	closeCtxFunc := postpone.ContextWithValues(ctx)
 	// Cancel any existing eventLoop
-	if loopHandle, loaded := loadAndDelete(ctx); loaded {
+	loopHandle, loaded := loadAndDelete(ctx)
+	if loaded {
 		loopHandle.cancel()
-		if !loopHandle.healingStarted {
-			started, ok := <-loopHandle.monitorFinishedCh
-			loopHandle.healingStarted = ok && started
+		if started, ok := <-loopHandle.monitorFinishedCh; ok {
+			loopHandle.healingStarted = started
 		}
 	}
 
 	conn, err := next.Client(ctx).Request(ctx, request, opts...)
 	if err != nil {
+		if loaded && !loopHandle.healingStarted {
+			eventLoopErr := h.startEventLoop(ctx, request.GetConnection())
+			if eventLoopErr != nil {
+				closeCtx, closeCancel := closeCtxFunc()
+				defer closeCancel()
+				_, _ = next.Client(closeCtx).Close(closeCtx, request.GetConnection())
+				log.FromContext(ctx).Errorf("can't start monitoring after a failed refresh: %v", eventLoopErr)
+			}
+		}
 		return nil, err
 	}
-	cc, ccLoaded := clientconn.Load(ctx)
-	if ccLoaded {
-		cancelEventLoop, monitorFinishedCh, eventLoopErr := newEventLoop(
-			extend.WithValuesFromContext(h.chainCtx, ctx), cc, conn, h)
-		if eventLoopErr != nil {
-			closeCtx, closeCancel := closeCtxFunc()
-			defer closeCancel()
-			_, _ = next.Client(closeCtx).Close(closeCtx, conn)
-			return nil, errors.Wrap(eventLoopErr, "unable to monitor")
-		}
-		store(ctx, eventLoopHandle{
-			cancel:            cancelEventLoop,
-			monitorFinishedCh: monitorFinishedCh,
-		})
+	eventLoopErr := h.startEventLoop(ctx, conn)
+	if eventLoopErr != nil {
+		closeCtx, closeCancel := closeCtxFunc()
+		defer closeCancel()
+		_, _ = next.Client(closeCtx).Close(closeCtx, conn)
+		return nil, eventLoopErr
 	}
 	return conn, nil
 }
@@ -94,4 +95,20 @@ func (h *healClient) Close(ctx context.Context, conn *networkservice.Connection,
 		loopHandle.cancel()
 	}
 	return next.Client(ctx).Close(ctx, conn)
+}
+
+func (h *healClient) startEventLoop(ctx context.Context, conn *networkservice.Connection) error {
+	cc, ccLoaded := clientconn.Load(ctx)
+	if !ccLoaded {
+		return nil
+	}
+	cancel, monitorFinishedCh, err := newEventLoop(extend.WithValuesFromContext(h.chainCtx, ctx), cc, conn, h)
+	if err != nil {
+		return err
+	}
+	store(ctx, eventLoopHandle{
+		cancel:            cancel,
+		monitorFinishedCh: monitorFinishedCh,
+	})
+	return nil
 }

--- a/pkg/networkservice/common/heal/metadata.go
+++ b/pkg/networkservice/common/heal/metadata.go
@@ -24,18 +24,24 @@ import (
 
 type key struct{}
 
-// store sets the context.CancelFunc stored in per Connection.Id metadata.
-func store(ctx context.Context, cancel context.CancelFunc) {
+type eventLoopHandle struct {
+	cancel            context.CancelFunc
+	monitorFinishedCh <-chan bool
+	started           bool
+}
+
+// store sets the eventLoopHandle stored in per Connection.Id metadata.
+func store(ctx context.Context, cancel eventLoopHandle) {
 	metadata.Map(ctx, true).Store(key{}, cancel)
 }
 
-// loadAndDelete deletes the context.CancelFunc stored in per Connection.Id metadata,
+// loadAndDelete deletes the eventLoopHandle stored in per Connection.Id metadata,
 // returning the previous value if any. The loaded result reports whether the key was present.
-func loadAndDelete(ctx context.Context) (value context.CancelFunc, ok bool) {
+func loadAndDelete(ctx context.Context) (value eventLoopHandle, loaded bool) {
 	rawValue, ok := metadata.Map(ctx, true).LoadAndDelete(key{})
 	if !ok {
 		return
 	}
-	value, ok = rawValue.(context.CancelFunc)
+	value, ok = rawValue.(eventLoopHandle)
 	return value, ok
 }

--- a/pkg/networkservice/common/heal/metadata.go
+++ b/pkg/networkservice/common/heal/metadata.go
@@ -27,7 +27,7 @@ type key struct{}
 type eventLoopHandle struct {
 	cancel            context.CancelFunc
 	monitorFinishedCh <-chan bool
-	started           bool
+	healingStarted    bool
 }
 
 // store sets the eventLoopHandle stored in per Connection.Id metadata.


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Restart connection monitoring after a failed refresh.

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/sdk/issues/1457

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
