### PR TITLE
Add cleanup when connection state is RESELECT_REQUESTED (using connection monitor server)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -292,6 +292,9 @@ issues:
     - path: pkg/networkservice/chains/nsmgrproxy/server_test.go
       linters:
         - funlen
+    - path: pkg/networkservice/connectioncontext/mtu/vl3mtu/server_test.go
+      linters:
+        - funlen
     - path: pkg/networkservice/core/next/.*_test.go
       linters:
         - dupl

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/networkservicemesh/sdk
 
 go 1.18
 
+replace github.com/networkservicemesh/api => github.com/d-uzlov/api v0.0.0-20230616082206-da35f22b2940
+
 require (
 	github.com/RoaringBitmap/roaring v0.9.4
 	github.com/antonfisher/nested-logrus-formatter v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/d-uzlov/api v0.0.0-20230616082206-da35f22b2940 h1:10vh/pmummEJcYHMvegCONZCTHc5GT3WKeZbk8ia32A=
+github.com/d-uzlov/api v0.0.0-20230616082206-da35f22b2940/go.mod h1:hOF2844BSstH1311oDMDgqqXS+kdc77htZNPRKl9mf8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -292,8 +294,6 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nats-io/stan.go v0.10.2/go.mod h1:vo2ax8K2IxaR3JtEMLZRFKIdoK/3o1/PKueapB7ezX0=
 github.com/nats-io/stan.go v0.10.3 h1:8DOyQJ0+nza3zSVJZ19/cpikkrWA4rSKB3YvckIGOTI=
 github.com/nats-io/stan.go v0.10.3/go.mod h1:Cgf5zk6kKpOCqqUIJeuBz6ZDz9osT791VhS6m28sSQQ=
-github.com/networkservicemesh/api v1.7.2-0.20230123083145-4a6c3ec589e1 h1:RxNKksXsXsnDsEo+Cfn43pdPfML024ad//QcdKfgXK4=
-github.com/networkservicemesh/api v1.7.2-0.20230123083145-4a6c3ec589e1/go.mod h1:hOF2844BSstH1311oDMDgqqXS+kdc77htZNPRKl9mf8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/networkservice/chains/endpoint/combine_test.go
+++ b/pkg/networkservice/chains/endpoint/combine_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco Systems, Inc.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -312,11 +314,12 @@ type testEndpoint struct {
 
 func newTestEndpoint(ctx context.Context, name string) *testEndpoint {
 	e := new(testEndpoint)
+	var connectionProvider monitor.ConnectionProvider
 	e.NetworkServiceServer = next.NewNetworkServiceServer(
 		updatepath.NewServer(name),
 		begin.NewServer(),
 		metadata.NewServer(),
-		monitor.NewServer(ctx, &e.MonitorConnectionServer),
+		monitor.NewServer(ctx, &e.MonitorConnectionServer, &connectionProvider),
 	)
 	return e
 }

--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco Systems, Inc.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -452,7 +454,7 @@ func testNSMGRHealNSMgr(t *testing.T, nodeNum int, restored bool) {
 
 	if restored {
 		require.Equal(t, 3, counter.Requests())
-		require.Equal(t, 1, counter.Closes())
+		require.Equal(t, 2, counter.Closes())
 	} else {
 		require.Equal(t, 2, counter.UniqueRequests())
 		require.Equal(t, closes+1, counter.UniqueCloses())

--- a/pkg/networkservice/chains/nsmgr/reselect_test.go
+++ b/pkg/networkservice/chains/nsmgr/reselect_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsmgr_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/nsmgr"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
+	"github.com/networkservicemesh/sdk/pkg/tools/sandbox"
+)
+
+// even if local NSMgr has restarted,
+// we expect that all apps after it should get a Close call
+// and treat new request as reselect request
+func TestReselect_LocalNsmgrRestart(t *testing.T) {
+	var samples = []struct {
+		name    string
+		nodeNum int
+	}{
+		{
+			name:    "Local",
+			nodeNum: 1,
+		},
+		{
+			name:    "Remote",
+			nodeNum: 2,
+		},
+	}
+
+	for _, sample := range samples {
+		t.Run(sample.name, func(t *testing.T) {
+			// nolint:scopelint
+			testReselectWithLocalNsmgrRestart(t, sample.nodeNum)
+		})
+	}
+}
+
+func testReselectWithLocalNsmgrRestart(t *testing.T, nodeNum int) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	// in this test we add counters to apps in chain
+	// to make sure that in each app Close call goes through the whole chain,
+	// without stopping on an error mid-chain
+	var counterFwd []*count.Server
+	for i := 0; i < nodeNum; i++ {
+		counterFwd = append(counterFwd, new(count.Server))
+	}
+
+	defer cancel()
+	domain := sandbox.NewBuilder(ctx, t).
+		SetNodesCount(nodeNum).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, i int) {
+			node.NewNSMgr(ctx, "nsmgr", nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+			node.NewForwarder(ctx, &registry.NetworkServiceEndpoint{
+				Name:                sandbox.UniqueName("forwarder"),
+				NetworkServiceNames: []string{"forwarder"},
+			}, sandbox.GenerateTestToken, counterFwd[i])
+		}).
+		Build()
+
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService(t.Name()))
+	require.NoError(t, err)
+
+	nseReg := defaultRegistryEndpoint(nsReg.Name)
+
+	counterNse := new(count.Server)
+	nse := domain.Nodes[nodeNum-1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counterNse)
+
+	request := defaultRequest(nsReg.Name)
+
+	counterClient := new(count.Client)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken, client.WithAdditionalFunctionality(counterClient))
+
+	conn, err := nsc.Request(ctx, request.Clone())
+	require.NoError(t, err)
+
+	domain.Nodes[0].NSMgr.Restart()
+
+	nse.Cancel()
+
+	nseReg2 := defaultRegistryEndpoint(nsReg.Name)
+	nseReg2.Name += "-2"
+	domain.Nodes[nodeNum-1].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, counterNse)
+
+	// Wait for heal to finish successfully
+	require.Eventually(t, checkSecondRequestsReceived(counterNse.UniqueRequests), timeout, tick)
+	// Client should try to close connection before reselect
+	require.Equal(t, 1, counterClient.UniqueCloses())
+	// Forwarder should get a Close, even though NSMgr restarted and didn't pass the Close
+	for i := 0; i < nodeNum; i++ {
+		require.Equal(t, 1, counterFwd[i].Closes())
+	}
+	// Old NSE died, new NSE should not get a Close call
+	require.Equal(t, 0, counterNse.Closes())
+
+	// Refresh shouldn't cause Close calls
+	request.Connection = conn
+	_, err = nsc.Request(ctx, request.Clone())
+	require.NoError(t, err)
+	require.Equal(t, 0, counterNse.Closes())
+	for i := 0; i < nodeNum; i++ {
+		require.Equal(t, 1, counterFwd[i].Closes())
+	}
+
+	clientCloses := counterClient.Closes()
+	// Close should still be able to pass though the whole connection path
+	_, err = nsc.Close(ctx, conn)
+	require.NoError(t, err)
+	require.Equal(t, clientCloses+1, counterClient.Closes())
+	require.Equal(t, 1, counterNse.Closes())
+	for i := 0; i < nodeNum; i++ {
+		require.Equal(t, 1, counterFwd[i].UniqueCloses(), i)
+		require.Equal(t, 2, counterFwd[i].Closes(), i)
+	}
+}
+func TestReselect_LocalForwarderRestart(t *testing.T) {
+	var samples = []struct {
+		name    string
+		nodeNum int
+	}{
+		{
+			name:    "Local",
+			nodeNum: 1,
+		},
+		{
+			name:    "Remote",
+			nodeNum: 2,
+		},
+	}
+
+	for _, sample := range samples {
+		t.Run(sample.name, func(t *testing.T) {
+			// nolint:scopelint
+			testReselectWithLocalForwarderRestart(t, sample.nodeNum)
+		})
+	}
+}
+func testReselectWithLocalForwarderRestart(t *testing.T, nodeNum int) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	// in this test we add counters to apps in chain
+	// to make sure that in each app Close call goes through the whole chain,
+	// without stopping on an error mid-chain
+	var counterFwd []*count.Server
+	for i := 0; i < nodeNum; i++ {
+		counterFwd = append(counterFwd, new(count.Server))
+	}
+
+	defer cancel()
+	domain := sandbox.NewBuilder(ctx, t).
+		SetNodesCount(nodeNum).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, i int) {
+			node.NewNSMgr(ctx, "nsmgr", nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+			node.NewForwarder(ctx, &registry.NetworkServiceEndpoint{
+				Name:                sandbox.UniqueName("forwarder"),
+				NetworkServiceNames: []string{"forwarder"},
+			}, sandbox.GenerateTestToken, counterFwd[i])
+		}).
+		Build()
+
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService(t.Name()))
+	require.NoError(t, err)
+
+	nseReg := defaultRegistryEndpoint(nsReg.Name)
+
+	counterNse := new(count.Server)
+	nse := domain.Nodes[nodeNum-1].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counterNse)
+
+	request := defaultRequest(nsReg.Name)
+
+	counterClient := new(count.Client)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken, client.WithAdditionalFunctionality(counterClient))
+
+	conn, err := nsc.Request(ctx, request.Clone())
+	require.NoError(t, err)
+
+	for _, fwd := range domain.Nodes[0].Forwarders {
+		fwd.Restart()
+	}
+
+	nse.Cancel()
+
+	nseReg2 := defaultRegistryEndpoint(nsReg.Name)
+	nseReg2.Name += "-2"
+	domain.Nodes[nodeNum-1].NewEndpoint(ctx, nseReg2, sandbox.GenerateTestToken, counterNse)
+
+	// Wait for heal to finish successfully
+	require.Eventually(t, checkSecondRequestsReceived(counterNse.UniqueRequests), timeout, tick)
+	// Client should try to close connection before reselect
+	require.Equal(t, 1, counterClient.UniqueCloses())
+	// local Forwarder has restarted, new forwarder should not get a Close call
+	require.Equal(t, 0, counterFwd[0].Closes())
+	if nodeNum > 1 {
+		// remote forwarder should get Close
+		require.Equal(t, 1, counterFwd[1].Closes())
+	}
+	require.Equal(t, 0, counterNse.Closes())
+
+	// Refresh shouldn't cause any Close calls
+	request.Connection = conn
+	_, err = nsc.Request(ctx, request.Clone())
+	require.NoError(t, err)
+	require.Equal(t, 0, counterNse.Closes())
+	require.Equal(t, 0, counterFwd[0].Closes())
+	if nodeNum > 1 {
+		require.Equal(t, 1, counterFwd[1].Closes())
+	}
+
+	clientCloses := counterClient.Closes()
+	// Close should still be able to pass though the whole connection path
+	_, err = nsc.Close(ctx, conn)
+	require.NoError(t, err)
+	require.Equal(t, clientCloses+1, counterClient.Closes())
+	require.Equal(t, 1, counterNse.Closes())
+	require.Equal(t, 1, counterFwd[0].Closes())
+	if nodeNum > 1 {
+		require.Equal(t, 2, counterFwd[1].Closes())
+	}
+}
+
+// If registry died, discover and discoverForwarder elements
+// will not be able to query it to get URLs to next app
+// but we still expect Close call to finish successfully
+func TestReselect_Close_RegistryDied(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	// in this test we add counters to apps in chain
+	// to make sure that in each app Close call goes through the whole chain,
+	// without stopping on an error mid-chain
+	counterFwd := new(count.Server)
+
+	defer cancel()
+	domain := sandbox.NewBuilder(ctx, t).
+		SetNSMgrProxySupplier(nil).
+		SetRegistryProxySupplier(nil).
+		SetNSMgrSupplier(nil).
+		SetNodeSetup(func(ctx context.Context, node *sandbox.Node, _ int) {
+			node.NewNSMgr(ctx, "nsmgr", nil, sandbox.GenerateTestToken, nsmgr.NewServer)
+			node.NewForwarder(ctx, &registry.NetworkServiceEndpoint{
+				Name:                sandbox.UniqueName("forwarder"),
+				NetworkServiceNames: []string{"forwarder"},
+			}, sandbox.GenerateTestToken, counterFwd)
+		}).
+		Build()
+
+	nsRegistryClient := domain.NewNSRegistryClient(ctx, sandbox.GenerateTestToken)
+
+	nsReg, err := nsRegistryClient.Register(ctx, defaultRegistryService(t.Name()))
+	require.NoError(t, err)
+
+	nseReg := defaultRegistryEndpoint(nsReg.Name)
+
+	counterNse := new(count.Server)
+	domain.Nodes[0].NewEndpoint(ctx, nseReg, sandbox.GenerateTestToken, counterNse)
+
+	request := defaultRequest(nsReg.Name)
+
+	counterClient := new(count.Client)
+	nsc := domain.Nodes[0].NewClient(ctx, sandbox.GenerateTestToken, client.WithAdditionalFunctionality(counterClient))
+
+	conn, err := nsc.Request(ctx, request.Clone())
+	require.NoError(t, err)
+
+	domain.Registry.Cancel()
+
+	_, err = nsc.Close(ctx, conn)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, counterClient.Closes())
+	require.Equal(t, 1, counterFwd.Closes())
+	require.Equal(t, 1, counterNse.Closes())
+}

--- a/pkg/networkservice/chains/nsmgr/select_forwarder_test.go
+++ b/pkg/networkservice/chains/nsmgr/select_forwarder_test.go
@@ -289,6 +289,6 @@ func Test_DiscoverForwarder_ChangeRemoteForwarderOnDeath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, counter.UniqueRequests())
 	require.Equal(t, 3, counter.Requests())
-	require.Equal(t, 0, counter.Closes())
+	require.Equal(t, 1, counter.Closes())
 	require.NotEqual(t, selectedFwd, conn.GetPath().GetPathSegments()[4].Name)
 }

--- a/pkg/networkservice/common/begin/event_factory.go
+++ b/pkg/networkservice/common/begin/event_factory.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Cisco and/or its affiliates.
+// Copyright (c) 2021-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -106,6 +106,7 @@ func (f *eventFactoryClient) Request(opts ...Option) <-chan error {
 				if request.GetConnection() != nil {
 					request.GetConnection().Mechanism = nil
 					request.GetConnection().NetworkServiceEndpointName = ""
+					request.GetConnection().State = networkservice.State_RESELECT_REQUESTED
 				}
 			}
 			ctx, cancel := f.ctxFunc()
@@ -113,6 +114,7 @@ func (f *eventFactoryClient) Request(opts ...Option) <-chan error {
 			conn, err := f.client.Request(ctx, request, f.opts...)
 			if err == nil && f.request != nil {
 				f.request.Connection = conn
+				f.request.Connection.State = networkservice.State_UP
 			}
 			ch <- err
 		}

--- a/pkg/networkservice/common/dial/client.go
+++ b/pkg/networkservice/common/dial/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Cisco and/or its affiliates.
+// Copyright (c) 2021-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -101,24 +101,31 @@ func (d *dialClient) Request(ctx context.Context, request *networkservice.Networ
 }
 
 func (d *dialClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-	// If no clientURL, we have no work to do
-	// call the next in the chain
-	clientURL := clienturlctx.ClientURL(ctx)
-	if clientURL == nil {
-		return next.Client(ctx).Close(ctx, conn, opts...)
-	}
-
 	cc, _ := clientconn.Load(ctx)
-
 	di, ok := cc.(*dialer)
 	if !ok {
 		return next.Client(ctx).Close(ctx, conn, opts...)
 	}
 	defer func() {
-		_ = di.Close()
+		err := di.Close()
+		if err != nil {
+			log.FromContext(ctx).Errorf("dialer close failed: %v", err)
+		}
 		clientconn.Delete(ctx)
 	}()
-	_ = di.Dial(ctx, clientURL)
 
+	clientURL := clienturlctx.ClientURL(ctx)
+	if clientURL == nil {
+		log.FromContext(ctx).Info("closing the connection using the old url")
+		clientURL = di.clientURL
+	}
+	err := di.Dial(ctx, clientURL)
+	if err != nil {
+		log.FromContext(ctx).Errorf("dial failed: %v", err)
+	}
+
+	// Call next regardless of connection state.
+	// Even if there is something wrong with connection,
+	// we need to clear resources in the current app.
 	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/pkg/networkservice/common/monitor/passthrough_test.go
+++ b/pkg/networkservice/common/monitor/passthrough_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Cisco and/or its affiliates.
+// Copyright (c) 2021-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -249,6 +249,7 @@ func (m *MonitorPassThroughSuite) TestServerUpdate() {
 	expectedConn := endpointConn.Clone()
 	expectedConn.GetPath().Index = m.conn.GetPath().GetIndex()
 	expectedConn.Id = expectedConn.GetCurrentPathSegment().GetId()
+	expectedConn.State = networkservice.State_DOWN
 	m.ValidateEvent(networkservice.ConnectionEventType_UPDATE, expectedConn)
 }
 

--- a/pkg/networkservice/common/monitor/server.go
+++ b/pkg/networkservice/common/monitor/server.go
@@ -1,6 +1,6 @@
-// Copyright (c) 2020-2022 Cisco Systems, Inc.
-//
 // Copyright (c) 2021-2022 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2020-2023 Cisco Systems, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -49,8 +49,13 @@ type monitorServer struct {
 //     networkservice.MonitorConnectionServer that can be used either standalone or in a
 //     networkservice.MonitorConnectionServer chain
 //     chainCtx - context for lifecycle management
-func NewServer(chainCtx context.Context, monitorServerPtr *networkservice.MonitorConnectionServer) networkservice.NetworkServiceServer {
-	*monitorServerPtr = newMonitorConnectionServer(chainCtx)
+//   - connectionProvider - allows you to get monitor.ConnectionProvider,
+//     that will give you a way to get connections locally,
+//     without having to connect to monitor server via loopback.
+func NewServer(chainCtx context.Context, monitorServerPtr *networkservice.MonitorConnectionServer, connectionProvider *ConnectionProvider) networkservice.NetworkServiceServer {
+	connectionsServer := newMonitorConnectionServer(chainCtx)
+	*monitorServerPtr = connectionsServer
+	*connectionProvider = connectionsServer
 	return &monitorServer{
 		chainCtx:                chainCtx,
 		MonitorConnectionServer: *monitorServerPtr,

--- a/pkg/networkservice/common/monitor/server_test.go
+++ b/pkg/networkservice/common/monitor/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Cisco and/or its affiliates.
+// Copyright (c) 2020-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -43,9 +43,10 @@ func TestMonitorServer(t *testing.T) {
 
 	// Create monitorServer, monitorClient, and server.
 	var monitorServer networkservice.MonitorConnectionServer
+	var connectionProvider monitor.ConnectionProvider
 	server := chain.NewNetworkServiceServer(
 		metadata.NewServer(),
-		monitor.NewServer(ctx, &monitorServer),
+		monitor.NewServer(ctx, &monitorServer, &connectionProvider),
 	)
 	monitorClient := adapters.NewMonitorServerToClient(monitorServer)
 

--- a/pkg/networkservice/common/reselectcleanup/server.go
+++ b/pkg/networkservice/common/reselectcleanup/server.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package reselectcleanup provides a server chain element
+// that will call Close before request
+// if an already existing connection has reselect flag
+package reselectcleanup
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/monitor"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+type reselectcleanupServer struct {
+	connectionProvider monitor.ConnectionProvider
+}
+
+// NewServer - create a new reselectcleanup server
+func NewServer(connectionProvider monitor.ConnectionProvider) networkservice.NetworkServiceServer {
+	return &reselectcleanupServer{
+		connectionProvider: connectionProvider,
+	}
+}
+
+func (c *reselectcleanupServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	if request.GetConnection().GetState() != networkservice.State_RESELECT_REQUESTED {
+		return next.Server(ctx).Request(ctx, request)
+	}
+
+	conns, err := c.connectionProvider.Find(&networkservice.MonitorScopeSelector{
+		PathSegments: []*networkservice.PathSegment{
+			{
+				Id:   request.GetConnection().GetCurrentPathSegment().GetId(),
+				Name: request.GetConnection().GetCurrentPathSegment().GetName(),
+			},
+		},
+	})
+	if err != nil {
+		log.FromContext(ctx).Errorf("Can't check if we have an old connection to close on reselect: %v", err)
+		conn, err2 := next.Server(ctx).Request(ctx, request)
+		if err2 == nil {
+			conn.State = networkservice.State_UP
+		}
+		return conn, err2
+	}
+	oldConnection, ok := conns[request.GetConnection().GetId()]
+	if !ok || oldConnection == nil {
+		// most likely the connection has already been closed
+		conn, err2 := next.Server(ctx).Request(ctx, request)
+		if err2 == nil {
+			conn.State = networkservice.State_UP
+		}
+		return conn, err2
+	}
+	log.FromContext(ctx).Info("Closing connection due to RESELECT_REQUESTED state")
+	_, err = next.Server(ctx).Close(ctx, oldConnection)
+	if err != nil {
+		log.FromContext(ctx).Errorf("Can't close old connection: %v", err)
+	}
+	conn, err := next.Server(ctx).Request(ctx, request)
+	if err == nil {
+		conn.State = networkservice.State_UP
+	}
+	return conn, err
+}
+
+func (c *reselectcleanupServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	return next.Server(ctx).Close(ctx, conn)
+}

--- a/pkg/networkservice/connectioncontext/mtu/vl3mtu/server_test.go
+++ b/pkg/networkservice/connectioncontext/mtu/vl3mtu/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -45,9 +45,10 @@ func Test_vl3MtuServer(t *testing.T) {
 
 	// Create monitorServer
 	var monitorServer networkservice.MonitorConnectionServer
+	var connectionProvider monitor.ConnectionProvider
 	server := chain.NewNetworkServiceServer(
 		metadata.NewServer(),
-		monitor.NewServer(ctx, &monitorServer),
+		monitor.NewServer(ctx, &monitorServer, &connectionProvider),
 		vl3mtu.NewServer(),
 	)
 	monitorClient := adapters.NewMonitorServerToClient(monitorServer)

--- a/pkg/tools/spire/server.conf.go
+++ b/pkg/tools/spire/server.conf.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Cisco and/or its affiliates.
+// Copyright (c) 2020-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Add `reselectcleanup` element that calls `Close` when reselect is requested for already existing connection.

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/sdk/issues/1454

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
