### PR TITLE
opa: token_expired policy should check only the right side of Path

### DIFF
--- a/pkg/tools/opa/common_test.go
+++ b/pkg/tools/opa/common_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,10 +153,11 @@ func genJWTWithClaims(claims *jwt.RegisteredClaims) string {
 	return t
 }
 
-func genConnectionWithTokens(tokens []string) *networkservice.Connection {
+func genConnectionWithTokens(tokens []string, currIndex uint32) *networkservice.Connection {
 	rv := &networkservice.Connection{
 		Path: &networkservice.Path{
 			PathSegments: []*networkservice.PathSegment{},
+			Index:        currIndex,
 		},
 	}
 

--- a/pkg/tools/opa/policies/common/tokens_expired.rego
+++ b/pkg/tools/opa/policies/common/tokens_expired.rego
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2022 Cisco and/or its affiliates.
+# Copyright (c) 2020-2023 Cisco and/or its affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -16,10 +16,14 @@
 
 package nsm
 
-default valid = false
+default valid := false
+default index := 0
+
+index = input.index
 
 valid {
-	count({x | input.path_segments[x]; token_alive(input.path_segments[x].token)}) == count(input.path_segments)
+	right_side_segments := array.slice(input.path_segments, index, count(input.path_segments))
+	count({x | right_side_segments[x]; token_alive(right_side_segments[x].token)}) == count(right_side_segments)
 }
 
 # alive means not expired
@@ -28,7 +32,7 @@ token_alive(token) {
 	now < payload.exp
 }
 
-now = t {
+now := t {
 	ns := time.now_ns()
 	t := ns / 1e9
 }

--- a/pkg/tools/opa/tokens_expired_policy_test.go
+++ b/pkg/tools/opa/tokens_expired_policy_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2020 Doc.ai and/or its affiliates.
 //
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -36,6 +36,7 @@ func TestNoTokensExpiredPolicy(t *testing.T) {
 	suits := []struct {
 		name    string
 		tokens  []string
+		index   uint32
 		expired bool
 	}{
 		{
@@ -61,6 +62,15 @@ func TestNoTokensExpiredPolicy(t *testing.T) {
 			},
 			expired: true,
 		},
+		{
+			name: "left tokens expired",
+			tokens: []string{
+				genJWTWithClaimsWithYear(lastYear),
+				genJWTWithClaimsWithYear(nextYear),
+			},
+			index:   1,
+			expired: false,
+		},
 	}
 
 	p, err := opa.PolicyFromFile("etc/nsm/opa/common/tokens_expired.rego")
@@ -70,7 +80,7 @@ func TestNoTokensExpiredPolicy(t *testing.T) {
 		s := suits[i]
 
 		t.Run(s.name, func(t *testing.T) {
-			conn := genConnectionWithTokens(s.tokens)
+			conn := genConnectionWithTokens(s.tokens, s.index)
 			checkResult := func(err error) {
 				if s.expired {
 					require.NotNil(t, err)


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
Closes: https://github.com/networkservicemesh/sdk/issues/1512


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
