### PR TITLE
[begin]: event_factory should cancel Close context in case of reselect

### DIFF
--- a/pkg/networkservice/common/begin/event_factory.go
+++ b/pkg/networkservice/common/begin/event_factory.go
@@ -101,13 +101,13 @@ func (f *eventFactoryClient) Request(opts ...Option) <-chan error {
 			request := f.request.Clone()
 			if o.reselect {
 				ctx, cancel := f.ctxFunc()
-				defer cancel()
 				_, _ = f.client.Close(ctx, request.GetConnection(), f.opts...)
 				if request.GetConnection() != nil {
 					request.GetConnection().Mechanism = nil
 					request.GetConnection().NetworkServiceEndpointName = ""
 					request.GetConnection().State = networkservice.State_RESELECT_REQUESTED
 				}
+				cancel()
 			}
 			ctx, cancel := f.ctxFunc()
 			defer cancel()


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Chain elements in Closes can rely on the context and its timeout. Therefore, after the operation is completed, the context must be canceled.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
