### PR TITLE
fix: Skip similar networkservices in netsvcmonitor element

### DIFF
--- a/pkg/networkservice/common/netsvcmonitor/server.go
+++ b/pkg/networkservice/common/netsvcmonitor/server.go
@@ -91,6 +91,12 @@ func (m *monitorServer) Request(ctx context.Context, request *networkservice.Net
 						netsvcStreamIsAlive = false
 						break
 					}
+
+					// TODO: Remove this condition when https://github.com/networkservicemesh/api/issues/51 will be done
+					if netsvc.GetNetworkService().GetName() != conn.GetNetworkService() {
+						continue
+					}
+
 					nseStream, err := m.nseClient.Find(monitorCtx, &registry.NetworkServiceEndpointQuery{
 						NetworkServiceEndpoint: &registry.NetworkServiceEndpoint{
 							Name: conn.GetNetworkServiceEndpointName(),

--- a/pkg/networkservice/common/netsvcmonitor/server_test.go
+++ b/pkg/networkservice/common/netsvcmonitor/server_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 Cisco Systems, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netsvcmonitor_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/begin"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/netsvcmonitor"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Netsvcmonitor_And_GroupOfSimilarNetworkServices(t *testing.T) {
+	var testCtx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	var nsServer = memory.NewNetworkServiceRegistryServer()
+	var nseServer = memory.NewNetworkServiceEndpointRegistryServer()
+	var counter count.Server
+
+	_, _ = nsServer.Register(context.Background(), &registry.NetworkService{
+		Name: "service-1",
+	})
+
+	_, _ = nseServer.Register(context.Background(), &registry.NetworkServiceEndpoint{
+		Name:                "endpoint-1",
+		NetworkServiceNames: []string{"service-1"},
+	})
+
+	var server = chain.NewNetworkServiceServer(
+		metadata.NewServer(),
+		begin.NewServer(),
+		netsvcmonitor.NewServer(
+			testCtx,
+			adapters.NetworkServiceServerToClient(nsServer),
+			adapters.NetworkServiceEndpointServerToClient(nseServer),
+		),
+		&counter,
+	)
+
+	var request = &networkservice.NetworkServiceRequest{
+		Connection: &networkservice.Connection{
+			Id:                         "1",
+			NetworkService:             "service-1",
+			NetworkServiceEndpointName: "endpoint-1",
+		},
+	}
+	var _, err = server.Request(testCtx, request)
+	require.NoError(t, err)
+	require.Equal(t, 0, counter.Closes())
+	for i := 0; i < 10; i++ {
+		_, err = nsServer.Register(context.Background(), &registry.NetworkService{
+			Name: fmt.Sprintf("service-1%v", i),
+			Matches: []*registry.Match{
+				{
+					SourceSelector: map[string]string{
+						"color": "red",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	require.Never(t, func() bool {
+		return counter.Closes() > 0
+	}, time.Millisecond*300, time.Millisecond*50)
+}

--- a/pkg/networkservice/common/netsvcmonitor/server_test.go
+++ b/pkg/networkservice/common/netsvcmonitor/server_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
+
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/begin"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/netsvcmonitor"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
@@ -31,7 +33,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_Netsvcmonitor_And_GroupOfSimilarNetworkServices(t *testing.T) {


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Currenly, we're not support adanced query parameters https://github.com/networkservicemesh/api/issues/51 and for now Find queries could return similar network services

## Issue link
https://github.com/networkservicemesh/sdk/issues/1521


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
