### PR TITLE
Fix typo in server.go

### DIFF
--- a/pkg/networkservice/common/discoverforwarder/server.go
+++ b/pkg/networkservice/common/discoverforwarder/server.go
@@ -46,7 +46,7 @@ type discoverForwarderServer struct {
 // Requires not nil nsClient.
 func NewServer(nsClient registry.NetworkServiceRegistryClient, nseClient registry.NetworkServiceEndpointRegistryClient, opts ...Option) networkservice.NetworkServiceServer {
 	if nseClient == nil {
-		panic("mseClient can not be nil")
+		panic("nseClient can not be nil")
 	}
 	if nsClient == nil {
 		panic("nsClient can not be nil")


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Typo in server.go:
```panic("mseClient can not be nil")```

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [x] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
