### PR TITLE
`begin` should let NSE unregister it self even if it doesn't have an event factory

### DIFF
--- a/pkg/registry/common/begin/close_server_test.go
+++ b/pkg/registry/common/begin/close_server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/begin/nse_server.go
+++ b/pkg/registry/common/begin/nse_server.go
@@ -92,8 +92,7 @@ func (b *beginNSEServer) Unregister(ctx context.Context, in *registry.NetworkSer
 	}
 	eventFactoryServer, ok := b.Load(id)
 	if !ok {
-		// If we don't have a connection to Close, just let it be
-		return &emptypb.Empty{}, nil
+		return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, in)
 	}
 	var err error
 	<-eventFactoryServer.executor.AsyncExec(func() {

--- a/pkg/registry/common/begin/nse_server.go
+++ b/pkg/registry/common/begin/nse_server.go
@@ -106,9 +106,8 @@ func (b *beginNSEServer) Unregister(ctx context.Context, in *registry.NetworkSer
 
 			if !loaded {
 				b.queueMap.Store(id, q)
-			} else {
-				q.eventCount++
 			}
+			q.eventCount++
 			q.Unlock()
 		}
 

--- a/pkg/registry/common/begin/nse_server.go
+++ b/pkg/registry/common/begin/nse_server.go
@@ -103,16 +103,13 @@ func (b *beginNSEServer) Unregister(ctx context.Context, in *registry.NetworkSer
 		if loaded {
 			q.Lock()
 			_, loaded := b.queueMap.Load(id)
-			var newQ *queue = nil
+
 			if !loaded {
-				newQ, _ = b.queueMap.LoadOrStore(id, &queue{eventCount: 1})
+				b.queueMap.Store(id, q)
 			} else {
 				q.eventCount++
 			}
 			q.Unlock()
-			if newQ != nil {
-				q = newQ
-			}
 		}
 
 		q.Lock()

--- a/pkg/registry/common/begin/nse_server_data_race_test.go
+++ b/pkg/registry/common/begin/nse_server_data_race_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/registry"
@@ -33,7 +34,7 @@ import (
 )
 
 const (
-	eventCount = 10
+	eventCount = 100
 )
 
 type dataRaceServer struct {
@@ -61,20 +62,14 @@ func TestServerDataRaceOnUnregister(t *testing.T) {
 		begin.NewNetworkServiceEndpointRegistryServer(),
 		datarace,
 	)
-	id := "1"
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-
-	nse := &registry.NetworkServiceEndpoint{
-		Name: id,
-	}
 
 	var wg sync.WaitGroup
 	wg.Add(eventCount)
-
 	for i := 0; i < eventCount; i++ {
 		go func() {
-			_, err := server.Unregister(ctx, nse)
+			_, err := server.Unregister(ctx, &registry.NetworkServiceEndpoint{Name: "1"})
 			require.NoError(t, err)
 			wg.Done()
 		}()

--- a/pkg/registry/common/begin/nse_server_data_race_test.go
+++ b/pkg/registry/common/begin/nse_server_data_race_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package begin_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/common/begin"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/chain"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+
+	"go.uber.org/goleak"
+)
+
+const (
+	eventCount = 10
+)
+
+type dataRaceServer struct {
+	count int
+}
+
+func (s *dataRaceServer) Register(ctx context.Context, in *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
+	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, in)
+
+}
+
+func (s *dataRaceServer) Find(query *registry.NetworkServiceEndpointQuery, server registry.NetworkServiceEndpointRegistry_FindServer) error {
+	return next.NetworkServiceEndpointRegistryServer(server.Context()).Find(query, server)
+}
+
+func (s *dataRaceServer) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
+	s.count = s.count + 1
+	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, in)
+}
+
+func TestServerDataRaceOnUnregister(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	datarace := &dataRaceServer{count: 0}
+	server := chain.NewNetworkServiceEndpointRegistryServer(
+		begin.NewNetworkServiceEndpointRegistryServer(),
+		datarace,
+	)
+	id := "1"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nse := &registry.NetworkServiceEndpoint{
+		Name: id,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(eventCount)
+
+	for i := 0; i < eventCount; i++ {
+		go func() {
+			server.Unregister(ctx, nse)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	require.Equal(t, datarace.count, eventCount)
+}

--- a/pkg/registry/common/begin/nse_server_data_race_test.go
+++ b/pkg/registry/common/begin/nse_server_data_race_test.go
@@ -42,7 +42,6 @@ type dataRaceServer struct {
 
 func (s *dataRaceServer) Register(ctx context.Context, in *registry.NetworkServiceEndpoint) (*registry.NetworkServiceEndpoint, error) {
 	return next.NetworkServiceEndpointRegistryServer(ctx).Register(ctx, in)
-
 }
 
 func (s *dataRaceServer) Find(query *registry.NetworkServiceEndpointQuery, server registry.NetworkServiceEndpointRegistry_FindServer) error {
@@ -50,7 +49,7 @@ func (s *dataRaceServer) Find(query *registry.NetworkServiceEndpointQuery, serve
 }
 
 func (s *dataRaceServer) Unregister(ctx context.Context, in *registry.NetworkServiceEndpoint) (*empty.Empty, error) {
-	s.count = s.count + 1
+	s.count++
 	return next.NetworkServiceEndpointRegistryServer(ctx).Unregister(ctx, in)
 }
 
@@ -75,12 +74,12 @@ func TestServerDataRaceOnUnregister(t *testing.T) {
 
 	for i := 0; i < eventCount; i++ {
 		go func() {
-			server.Unregister(ctx, nse)
+			_, err := server.Unregister(ctx, nse)
+			require.NoError(t, err)
 			wg.Done()
 		}()
 	}
 
 	wg.Wait()
-
 	require.Equal(t, datarace.count, eventCount)
 }

--- a/pkg/registry/common/expire/nse_server.go
+++ b/pkg/registry/common/expire/nse_server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/begin"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/clock"
+	"github.com/networkservicemesh/sdk/pkg/tools/extend"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
@@ -97,7 +98,7 @@ func (s *expireNSEServer) Register(ctx context.Context, nse *registry.NetworkSer
 		case <-expireContext.Done():
 			return
 		case <-expireCh:
-			factory.Unregister(begin.CancelContext(expireContext))
+			factory.Unregister(begin.CancelContext(extend.WithValuesFromContext(expireContext, ctx)))
 		}
 	}()
 

--- a/pkg/registry/common/expire/nse_server.go
+++ b/pkg/registry/common/expire/nse_server.go
@@ -31,7 +31,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/registry/common/begin"
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/clock"
-	"github.com/networkservicemesh/sdk/pkg/tools/extend"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
@@ -98,7 +97,7 @@ func (s *expireNSEServer) Register(ctx context.Context, nse *registry.NetworkSer
 		case <-expireContext.Done():
 			return
 		case <-expireCh:
-			factory.Unregister(begin.CancelContext(extend.WithValuesFromContext(expireContext, ctx)))
+			factory.Unregister(begin.CancelContext(expireContext))
 		}
 	}()
 


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
`begin` should let NSE unregister it self even if it doesn't have an event factory. Also change `expire` a bit to distinguish between events coming from `begin` and NSE.

## Issue link
https://github.com/networkservicemesh/sdk-k8s/issues/456


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
