### PR TITLE
fix: Do not use settings from the previous connection if the connection was reselected

### DIFF
--- a/pkg/networkservice/common/begin/event_factory.go
+++ b/pkg/networkservice/common/begin/event_factory.go
@@ -105,6 +105,7 @@ func (f *eventFactoryClient) Request(opts ...Option) <-chan error {
 				if request.GetConnection() != nil {
 					request.GetConnection().Mechanism = nil
 					request.GetConnection().NetworkServiceEndpointName = ""
+					request.GetConnection().Context = nil
 					request.GetConnection().State = networkservice.State_RESELECT_REQUESTED
 				}
 				cancel()


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
Closes https://github.com/networkservicemesh/deployments-k8s/issues/9888

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
