### PR TITLE
Add a Path to Registry Find Requests

### DIFF
--- a/pkg/registry/common/grpcmetadata/common.go
+++ b/pkg/registry/common/grpcmetadata/common.go
@@ -103,3 +103,13 @@ func nsFindServerSendPath(server registry.NetworkServiceRegistry_FindServer, pat
 	header := metadata.Pairs(pathKey, string(bytes))
 	return server.SendHeader(header)
 }
+
+func nseFindServerSendPath(server registry.NetworkServiceEndpointRegistry_FindServer, path *Path) error {
+	bytes, err := json.Marshal(path)
+	if err != nil {
+		return errors.Wrap(err, "failed to convert a provided path into JSON")
+	}
+
+	header := metadata.Pairs(pathKey, string(bytes))
+	return server.SendHeader(header)
+}

--- a/pkg/registry/common/grpcmetadata/common.go
+++ b/pkg/registry/common/grpcmetadata/common.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/networkservicemesh/api/pkg/api/registry"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -91,4 +92,14 @@ func sendPath(ctx context.Context, path *Path) error {
 
 	header := metadata.Pairs(pathKey, string(bytes))
 	return grpc.SendHeader(ctx, header)
+}
+
+func nsFindServerSendPath(server registry.NetworkServiceRegistry_FindServer, path *Path) error {
+	bytes, err := json.Marshal(path)
+	if err != nil {
+		return errors.Wrap(err, "failed to convert a provided path into JSON")
+	}
+
+	header := metadata.Pairs(pathKey, string(bytes))
+	return server.SendHeader(header)
 }

--- a/pkg/registry/common/grpcmetadata/ns_client.go
+++ b/pkg/registry/common/grpcmetadata/ns_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/grpcmetadata/ns_client.go
+++ b/pkg/registry/common/grpcmetadata/ns_client.go
@@ -19,6 +19,7 @@ package grpcmetadata
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
@@ -88,6 +89,8 @@ func (c *grpcMetadataNSClient) Find(ctx context.Context, query *registry.Network
 		path.Index = newpath.Index
 		path.PathSegments = newpath.PathSegments
 	}
+
+	fmt.Printf("newpath: %v\n", newpath)
 
 	return resp, nil
 }

--- a/pkg/registry/common/grpcmetadata/ns_server.go
+++ b/pkg/registry/common/grpcmetadata/ns_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/grpcmetadata/ns_server.go
+++ b/pkg/registry/common/grpcmetadata/ns_server.go
@@ -72,8 +72,7 @@ func (s *grpcMetadataNSServer) Find(query *registry.NetworkServiceQuery, server 
 		return err
 	}
 
-	err = nsFindServerSendPath(server, path)
-	return err
+	return nsFindServerSendPath(server, path)
 }
 
 func (s *grpcMetadataNSServer) Unregister(ctx context.Context, ns *registry.NetworkService) (*empty.Empty, error) {

--- a/pkg/registry/common/grpcmetadata/ns_server.go
+++ b/pkg/registry/common/grpcmetadata/ns_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/streamcontext"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
@@ -58,7 +59,21 @@ func (s *grpcMetadataNSServer) Register(ctx context.Context, ns *registry.Networ
 }
 
 func (s *grpcMetadataNSServer) Find(query *registry.NetworkServiceQuery, server registry.NetworkServiceRegistry_FindServer) error {
-	return next.NetworkServiceRegistryServer(server.Context()).Find(query, server)
+	ctx := server.Context()
+	path, err := fromContext(ctx)
+	if err != nil {
+		log.FromContext(ctx).Warnf("Unregister: failed to load grpc metadata from context: %v", err.Error())
+		return next.NetworkServiceRegistryServer(ctx).Find(query, server)
+	}
+
+	ctx = PathWithContext(ctx, path)
+	err = next.NetworkServiceRegistryServer(ctx).Find(query, streamcontext.NetworkServiceRegistryFindServer(ctx, server))
+	if err != nil {
+		return err
+	}
+
+	err = nsFindServerSendPath(server, path)
+	return err
 }
 
 func (s *grpcMetadataNSServer) Unregister(ctx context.Context, ns *registry.NetworkService) (*empty.Empty, error) {

--- a/pkg/registry/common/grpcmetadata/ns_test.go
+++ b/pkg/registry/common/grpcmetadata/ns_test.go
@@ -77,7 +77,11 @@ func (p *pathCheckerNSClient) Register(ctx context.Context, in *registry.Network
 }
 
 func (p *pathCheckerNSClient) Find(ctx context.Context, query *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
-	return next.NetworkServiceRegistryClient(ctx).Find(ctx, query, opts...)
+	pBefore := p.funcBefore(ctx)
+	c, e := next.NetworkServiceRegistryClient(ctx).Find(ctx, query, opts...)
+	p.funcAfter(ctx, pBefore)
+
+	return c, e
 }
 
 func (p *pathCheckerNSClient) Unregister(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*emptypb.Empty, error) {
@@ -90,7 +94,7 @@ func (p *pathCheckerNSClient) Unregister(ctx context.Context, in *registry.Netwo
 func TestGRPCMetadataNetworkService(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2000)
 	defer cancel()
 
 	clockMock := clockmock.New(ctx)
@@ -164,18 +168,24 @@ func TestGRPCMetadataNetworkService(t *testing.T) {
 	ctx = grpcmetadata.PathWithContext(ctx, &path)
 
 	ns := &registry.NetworkService{Name: "ns"}
-	_, err = client.Register(ctx, ns)
+	ns, err = client.Register(ctx, ns)
 	require.NoError(t, err)
-
 	require.Equal(t, int(path.Index), 0)
 	require.Len(t, path.PathSegments, 3)
+	require.Len(t, ns.PathIds, 3)
 
 	// Simulate refresh
 	_, err = client.Register(ctx, ns)
 	require.NoError(t, err)
 
-	_, err = client.Find(ctx, &registry.NetworkServiceQuery{NetworkService: &registry.NetworkService{Name: "ns"}})
+	query := &registry.NetworkServiceQuery{NetworkService: ns}
+	path = grpcmetadata.Path{}
+	ctx = grpcmetadata.PathWithContext(ctx, &path)
+	_, err = client.Find(ctx, query)
 	require.NoError(t, err)
+	require.Equal(t, int(path.Index), 0)
+	require.Len(t, path.PathSegments, 3)
+	//require.Len(t, query.NetworkService.PathIds, 3)
 
 	_, err = client.Unregister(ctx, ns)
 	require.NoError(t, err)
@@ -270,62 +280,4 @@ func TestGRPCMetadataNetworkService_BackwardCompatibility(t *testing.T) {
 
 	_, err = client.Unregister(ctx, ns)
 	require.NoError(t, err)
-}
-
-func TestGRPCMetadataNetworkServiceFind(t *testing.T) {
-	t.Cleanup(func() { goleak.VerifyNone(t) })
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10000)
-	defer cancel()
-
-	clockMock := clockmock.New(ctx)
-	ctx = clock.WithClock(ctx, clockMock)
-
-	serverLis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	serverGRPCServer := grpc.NewServer()
-	go func() {
-		serveErr := serverGRPCServer.Serve(serverLis)
-		require.NoError(t, serveErr)
-	}()
-
-	server := next.NewNetworkServiceRegistryServer(
-		injectpeertoken.NewNetworkServiceRegistryServer(tokenGeneratorFunc(clockMock, proxyID)),
-		grpcmetadata.NewNetworkServiceRegistryServer(),
-		updatepath.NewNetworkServiceRegistryServer(tokenGeneratorFunc(clockMock, serverID)),
-		checkcontext.NewNSServer(t, func(t *testing.T, ctx context.Context) {
-			path := grpcmetadata.PathFromContext(ctx)
-			require.Equal(t, int(path.Index), 1)
-		}),
-	)
-	registry.RegisterNetworkServiceRegistryServer(serverGRPCServer, server)
-
-	conn, err := grpc.Dial(serverLis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	require.NoError(t, err)
-	defer func() {
-		closeErr := conn.Close()
-		require.NoError(t, closeErr)
-	}()
-
-	client := next.NewNetworkServiceRegistryClient(
-		newPathCheckerNSClient(t, 0),
-		grpcmetadata.NewNetworkServiceRegistryClient(),
-		registry.NewNetworkServiceRegistryClient(conn))
-
-	path := &grpcmetadata.Path{}
-	ctx = grpcmetadata.PathWithContext(ctx, path)
-
-	query := &registry.NetworkServiceQuery{NetworkService: &registry.NetworkService{Name: "ns"}}
-
-	_, err = client.Find(ctx, query)
-	require.NoError(t, err)
-
-	require.Len(t, query.NetworkService.PathIds, 2)
-
-	path = grpcmetadata.PathFromContext(ctx)
-
-	require.Equal(t, int(path.Index), 0)
-	require.Len(t, path.PathSegments, 2)
-
-	serverGRPCServer.Stop()
 }

--- a/pkg/registry/common/grpcmetadata/ns_test.go
+++ b/pkg/registry/common/grpcmetadata/ns_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -90,6 +90,7 @@ func (p *pathCheckerNSClient) Unregister(ctx context.Context, in *registry.Netwo
 	return r, e
 }
 
+// nolint: funlen
 func TestGRPCMetadataNetworkService(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
@@ -193,6 +194,7 @@ func TestGRPCMetadataNetworkService(t *testing.T) {
 	proxyGRPCServer.Stop()
 }
 
+// nolint: funlen
 func TestGRPCMetadataNetworkService_BackwardCompatibility(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 

--- a/pkg/registry/common/grpcmetadata/nse_client.go
+++ b/pkg/registry/common/grpcmetadata/nse_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/grpcmetadata/nse_server.go
+++ b/pkg/registry/common/grpcmetadata/nse_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/grpcmetadata/nse_test.go
+++ b/pkg/registry/common/grpcmetadata/nse_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -86,6 +86,7 @@ func (p *pathCheckerNSEClient) Unregister(ctx context.Context, in *registry.Netw
 	return r, e
 }
 
+// nolint: funlen
 // This test checks that registry Path is correctly updated and passed through grpc metadata
 // Test scheme: client ---> proxyServer ---> server
 func TestGRPCMetadataNetworkServiceEndpoint(t *testing.T) {
@@ -193,6 +194,7 @@ func TestGRPCMetadataNetworkServiceEndpoint(t *testing.T) {
 	proxyGRPCServer.Stop()
 }
 
+// nolint: funlen
 func TestGRPCMetadataNetworkServiceEndpoint_BackwardCompatibility(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 

--- a/pkg/registry/common/heal/find_test.go
+++ b/pkg/registry/common/heal/find_test.go
@@ -34,7 +34,7 @@ import (
 func TestHealClient_FindTest(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10000*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	nsmgrCtx, nsmgrCancel := context.WithCancel(ctx)

--- a/pkg/registry/common/updatepath/ns_server.go
+++ b/pkg/registry/common/updatepath/ns_server.go
@@ -116,7 +116,6 @@ func (s *updatePathNSServer) Find(query *registry.NetworkServiceQuery, server re
 		return err
 	}
 	path.Index = index
-
 	return nil
 }
 

--- a/pkg/registry/common/updatepath/ns_server.go
+++ b/pkg/registry/common/updatepath/ns_server.go
@@ -81,7 +81,43 @@ func (s *updatePathNSServer) Register(ctx context.Context, ns *registry.NetworkS
 }
 
 func (s *updatePathNSServer) Find(query *registry.NetworkServiceQuery, server registry.NetworkServiceRegistry_FindServer) error {
-	return next.NetworkServiceRegistryServer(server.Context()).Find(query, server)
+	ctx := server.Context()
+	path := grpcmetadata.PathFromContext(ctx)
+
+	// Update path
+	peerTok, _, tokenErr := token.FromContext(ctx)
+	if tokenErr != nil {
+		log.FromContext(ctx).Warnf("an error during getting peer token from the context: %+v", tokenErr)
+	}
+	tok, _, tokenErr := generateToken(ctx, s.tokenGenerator)
+	if tokenErr != nil {
+		return errors.Wrap(tokenErr, "an error during generating token")
+	}
+	path, index, err := updatePath(path, peerTok, tok)
+	if err != nil {
+		return err
+	}
+
+	// Update path ids
+	peerID, idErr := getIDFromToken(peerTok)
+	if idErr != nil {
+		log.FromContext(ctx).Warnf("an error during parsing peer token: %+v", tokenErr)
+	}
+	id, idErr := getIDFromToken(tok)
+	if idErr != nil {
+		return idErr
+	}
+	ns := query.NetworkService
+	ns.PathIds = updatePathIds(ns.PathIds, int(path.Index-1), peerID.String())
+	ns.PathIds = updatePathIds(ns.PathIds, int(path.Index), id.String())
+
+	err = next.NetworkServiceRegistryServer(ctx).Find(query, server)
+	if err != nil {
+		return err
+	}
+	path.Index = index
+
+	return nil
 }
 
 func (s *updatePathNSServer) Unregister(ctx context.Context, ns *registry.NetworkService) (*empty.Empty, error) {

--- a/pkg/registry/common/updatepath/nse_server.go
+++ b/pkg/registry/common/updatepath/nse_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/utils/inject/injectpeertoken/ns_server.go
+++ b/pkg/registry/utils/inject/injectpeertoken/ns_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/utils/inject/injectpeertoken/ns_server.go
+++ b/pkg/registry/utils/inject/injectpeertoken/ns_server.go
@@ -50,7 +50,8 @@ func (s *injectSpiffeIDNSServer) Find(query *registry.NetworkServiceQuery, serve
 	peerToken, _, _ := s.tokenGenerator(nil)
 	ctx := withPeerToken(server.Context(), peerToken)
 
-	return next.NetworkServiceRegistryServer(ctx).Find(query, streamcontext.NetworkServiceRegistryFindServer(ctx, server))
+	err := next.NetworkServiceRegistryServer(ctx).Find(query, streamcontext.NetworkServiceRegistryFindServer(ctx, server))
+	return err
 }
 
 func (s *injectSpiffeIDNSServer) Unregister(ctx context.Context, ns *registry.NetworkService) (*emptypb.Empty, error) {

--- a/pkg/registry/utils/inject/injectpeertoken/ns_server.go
+++ b/pkg/registry/utils/inject/injectpeertoken/ns_server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/streamcontext"
 )
 
 type injectSpiffeIDNSServer struct {
@@ -46,7 +47,10 @@ func (s *injectSpiffeIDNSServer) Register(ctx context.Context, ns *registry.Netw
 }
 
 func (s *injectSpiffeIDNSServer) Find(query *registry.NetworkServiceQuery, server registry.NetworkServiceRegistry_FindServer) error {
-	return next.NetworkServiceRegistryServer(server.Context()).Find(query, server)
+	peerToken, _, _ := s.tokenGenerator(nil)
+	ctx := withPeerToken(server.Context(), peerToken)
+
+	return next.NetworkServiceRegistryServer(ctx).Find(query, streamcontext.NetworkServiceRegistryFindServer(ctx, server))
 }
 
 func (s *injectSpiffeIDNSServer) Unregister(ctx context.Context, ns *registry.NetworkService) (*emptypb.Empty, error) {

--- a/pkg/registry/utils/inject/injectpeertoken/nse_server.go
+++ b/pkg/registry/utils/inject/injectpeertoken/nse_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/utils/inject/injectpeertoken/nse_server.go
+++ b/pkg/registry/utils/inject/injectpeertoken/nse_server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
 	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/streamcontext"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 )
 
@@ -45,7 +46,12 @@ func (s *injectSpiffeIDNSEServer) Register(ctx context.Context, nse *registry.Ne
 }
 
 func (s *injectSpiffeIDNSEServer) Find(query *registry.NetworkServiceEndpointQuery, server registry.NetworkServiceEndpointRegistry_FindServer) error {
-	return next.NetworkServiceEndpointRegistryServer(server.Context()).Find(query, server)
+	peerToken, _, _ := s.tokenGenerator(nil)
+	ctx := withPeerToken(server.Context(), peerToken)
+
+	err := next.NetworkServiceEndpointRegistryServer(server.Context()).Find(
+		query, streamcontext.NetworkServiceEndpointRegistryFindServer(ctx, server))
+	return err
 }
 
 func (s *injectSpiffeIDNSEServer) Unregister(ctx context.Context, nse *registry.NetworkServiceEndpoint) (*empty.Empty, error) {


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
We build path on Register and Unregister events using grpc metadata. The same functionality has been added for Find events. 

## Issue link
https://github.com/networkservicemesh/sdk/issues/1534


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
