### PR TITLE
[qfix] Use clearer function name in `extend` package

### DIFF
--- a/pkg/registry/common/begin/nse_event_factory.go
+++ b/pkg/registry/common/begin/nse_event_factory.go
@@ -202,7 +202,7 @@ func (f *eventNSEFactoryServer) Unregister(opts ...Option) <-chan error {
 		default:
 			ctx, cancel := f.ctxFunc()
 			defer cancel()
-			_, err := f.server.Unregister(extend.WithJoinedValues(ctx, o.extendContext), f.registration)
+			_, err := f.server.Unregister(extend.WithBothValuesFromContext(ctx, o.extendContext), f.registration)
 			f.afterCloseFunc()
 			ch <- err
 		}

--- a/pkg/tools/extend/extended.go
+++ b/pkg/tools/extend/extended.go
@@ -51,7 +51,7 @@ func WithValuesFromContext(parent, valuesContext context.Context) context.Contex
 	}
 }
 
-// WithJoinedValues - creates a child context with the Values from both parent and values Contexts
+// WithBothValuesFromContext - creates a child context with the Values from both parent and values Contexts
 func WithBothValuesFromContext(parent, valuesContext context.Context) context.Context {
 	return &joinedValuesContext{
 		Context:       parent,

--- a/pkg/tools/extend/extended.go
+++ b/pkg/tools/extend/extended.go
@@ -52,7 +52,7 @@ func WithValuesFromContext(parent, valuesContext context.Context) context.Contex
 }
 
 // WithJoinedValues - creates a child context with the Values from both parent and values Contexts
-func WithJoinedValues(parent, valuesContext context.Context) context.Context {
+func WithBothValuesFromContext(parent, valuesContext context.Context) context.Context {
 	return &joinedValuesContext{
 		Context:       parent,
 		valuesContext: valuesContext,


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Fixes this comment: https://github.com/networkservicemesh/sdk/pull/1533#pullrequestreview-1724706085
