### PR TITLE
Add interface names into NSM metrics

### DIFF
--- a/pkg/networkservice/common/mechanisms/client.go
+++ b/pkg/networkservice/common/mechanisms/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021-2023 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -28,13 +28,24 @@ import (
 )
 
 type mechanismsClient struct {
-	mechanisms map[string]networkservice.NetworkServiceClient
+	mechanisms  map[string]networkservice.NetworkServiceClient
+	withMetrics bool
 }
 
 // NewClient - returns a new mechanisms networkservicemesh.NetworkServiceClient
 func NewClient(mechanisms map[string]networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
+	return newClient(mechanisms, false)
+}
+
+// NewClientWithMetrics - same as NewClient, but will also print the interface type/name metric to Path
+func NewClientWithMetrics(mechanisms map[string]networkservice.NetworkServiceClient) networkservice.NetworkServiceClient {
+	return newClient(mechanisms, true)
+}
+
+func newClient(mechanisms map[string]networkservice.NetworkServiceClient, withMetrics bool) networkservice.NetworkServiceClient {
 	result := &mechanismsClient{
-		mechanisms: make(map[string]networkservice.NetworkServiceClient),
+		mechanisms:  make(map[string]networkservice.NetworkServiceClient),
+		withMetrics: withMetrics,
 	}
 	for m, c := range mechanisms {
 		result.mechanisms[m] = chain.NewNetworkServiceClient(c)
@@ -44,9 +55,13 @@ func NewClient(mechanisms map[string]networkservice.NetworkServiceClient) networ
 }
 
 func (mc *mechanismsClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
-	if request.GetConnection().GetMechanism() != nil {
-		srv, ok := mc.mechanisms[request.GetConnection().GetMechanism().GetType()]
+	mech := request.GetConnection().GetMechanism()
+	if mech != nil {
+		srv, ok := mc.mechanisms[mech.GetType()]
 		if ok {
+			if mc.withMetrics {
+				storeMetrics(request.GetConnection(), mech, true)
+			}
 			return srv.Request(ctx, request, opts...)
 		}
 		return nil, errUnsupportedMech
@@ -57,6 +72,11 @@ func (mc *mechanismsClient) Request(ctx context.Context, request *networkservice
 		if ok {
 			req := request.Clone()
 			var resp *networkservice.Connection
+
+			if mc.withMetrics {
+				storeMetrics(req.GetConnection(), mechanism, true)
+			}
+
 			resp, respErr := cm.Request(ctx, req, opts...)
 			if respErr == nil {
 				return resp, nil
@@ -70,6 +90,9 @@ func (mc *mechanismsClient) Request(ctx context.Context, request *networkservice
 func (mc *mechanismsClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
 	c, ok := mc.mechanisms[conn.GetMechanism().GetType()]
 	if ok {
+		if mc.withMetrics {
+			storeMetrics(conn, conn.GetMechanism(), true)
+		}
 		return c.Close(ctx, conn)
 	}
 	return nil, errCannotSupportMech


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Add interface names into NSM metrics

This change works for NSC and NSE:
![metrixNew drawio (1)](https://github.com/networkservicemesh/sdk/assets/10182393/bbf4112c-d165-413b-8806-05bf5530bc30)


<!--- Provide a general summary of your changes in the Title above -->


## Issue link
Task: https://github.com/networkservicemesh/sdk-vpp/issues/768
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
