### PR TITLE
fix: Correctly handle RESELECT_REQUESTED state and clearing point2pointipam

### DIFF
--- a/pkg/networkservice/common/discoverforwarder/server.go
+++ b/pkg/networkservice/common/discoverforwarder/server.go
@@ -69,6 +69,10 @@ func (d *discoverForwarderServer) Request(ctx context.Context, request *networks
 	var forwarderName = loadForwarderName(ctx)
 	var logger = log.FromContext(ctx).WithField("discoverForwarderServer", "request")
 
+	if request.GetConnection().State == networkservice.State_RESELECT_REQUESTED {
+		forwarderName = ""
+	}
+
 	ns, err := d.discoverNetworkService(ctx, request.GetConnection().GetNetworkService(), request.GetConnection().GetPayload())
 	if err != nil {
 		return nil, err
@@ -96,7 +100,7 @@ func (d *discoverForwarderServer) Request(ctx context.Context, request *networks
 		return nil, errors.New("no candidates found")
 	}
 
-	if forwarderName == "" {
+	if forwarderName == "" && request.GetConnection().GetState() != networkservice.State_RESELECT_REQUESTED {
 		segments := request.Connection.GetPath().GetPathSegments()
 		if pathIndex := int(request.Connection.GetPath().Index); len(segments) > pathIndex+1 {
 			for i, candidate := range nses {

--- a/pkg/networkservice/ipam/groupipam/server_test.go
+++ b/pkg/networkservice/ipam/groupipam/server_test.go
@@ -174,7 +174,6 @@ func TestOutOfIPs(t *testing.T) {
 		_, err = srv1.Close(context.Background(), req1.GetConnection())
 		require.NoError(t, err)
 	}
-
 }
 
 func requireConns(t *testing.T, conn *networkservice.Connection, dstAddr, srcAddr string) {

--- a/pkg/networkservice/ipam/groupipam/server_test.go
+++ b/pkg/networkservice/ipam/groupipam/server_test.go
@@ -156,10 +156,12 @@ func TestOutOfIPs(t *testing.T) {
 		conn1, err := srv1.Request(context.Background(), req1)
 		require.NoError(t, err)
 		requireConns(t, conn1, "192.168.1.2/32", "192.168.1.3/32")
+		req1.Connection = conn1
 
 		conn2, err := srv2.Request(context.Background(), req2)
 		require.NoError(t, err)
 		requireConns(t, conn2, "192.168.1.2/32", "192.168.1.3/32")
+		req2.Connection = conn2
 
 		_, err = srv1.Request(context.Background(), req2)
 		require.Error(t, err)
@@ -167,9 +169,10 @@ func TestOutOfIPs(t *testing.T) {
 		_, err = srv2.Request(context.Background(), req1)
 		require.Error(t, err)
 
-		srv2.Close(context.Background(), req2.GetConnection())
-		srv1.Close(context.Background(), req1.GetConnection())
-
+		_, err = srv2.Close(context.Background(), req2.GetConnection())
+		require.NoError(t, err)
+		_, err = srv1.Close(context.Background(), req1.GetConnection())
+		require.NoError(t, err)
 	}
 
 }

--- a/pkg/networkservice/ipam/point2pointipam/server.go
+++ b/pkg/networkservice/ipam/point2pointipam/server.go
@@ -219,7 +219,7 @@ func (s *ipamServer) Close(ctx context.Context, conn *networkservice.Connection)
 		return nil, errors.Wrap(s.initErr, "failed to init IPAM server during close")
 	}
 
-	if connInfo, ok := s.Load(conn.GetId()); ok {
+	if connInfo, ok := s.LoadAndDelete(conn.GetId()); ok {
 		s.free(connInfo)
 	}
 

--- a/pkg/networkservice/ipam/point2pointipam/server_test.go
+++ b/pkg/networkservice/ipam/point2pointipam/server_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
 //
-// Copyright (c) 2022-2023 Cisco and/or its affiliates.
+// Copyright (c) 2022 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -23,7 +23,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
@@ -48,7 +47,6 @@ func newIpamServer(prefixes ...*net.IPNet) networkservice.NetworkServiceServer {
 func newRequest() *networkservice.NetworkServiceRequest {
 	return &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
-			Id: uuid.NewString(),
 			Context: &networkservice.ConnectionContext{
 				IpContext: new(networkservice.IPContext),
 			},
@@ -225,21 +223,15 @@ func TestOutOfIPs(t *testing.T) {
 	_, ipNet, err := net.ParseCIDR("192.168.1.2/31")
 	require.NoError(t, err)
 
-	srv1 := newIpamServer(ipNet)
-	srv2 := newIpamServer(ipNet)
+	srv := newIpamServer(ipNet)
 
 	req1 := newRequest()
-	conn1, err := srv1.Request(context.Background(), req1)
+	conn1, err := srv.Request(context.Background(), req1)
 	require.NoError(t, err)
 	validateConn(t, conn1, "192.168.1.2/32", "192.168.1.3/32")
 
 	req2 := newRequest()
-	req2.Connection.Context = conn1.Context
-	conn2, err := srv2.Request(context.Background(), req2)
-	require.NoError(t, err)
-	validateConn(t, conn2, "192.168.1.2/32", "192.168.1.3/32")
-
-	_, err = srv1.Request(context.Background(), req2)
+	_, err = srv.Request(context.Background(), req2)
 	require.Error(t, err)
 }
 

--- a/pkg/networkservice/ipam/point2pointipam/server_test.go
+++ b/pkg/networkservice/ipam/point2pointipam/server_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
 //
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -23,6 +23,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
@@ -47,6 +48,7 @@ func newIpamServer(prefixes ...*net.IPNet) networkservice.NetworkServiceServer {
 func newRequest() *networkservice.NetworkServiceRequest {
 	return &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
+			Id: uuid.NewString(),
 			Context: &networkservice.ConnectionContext{
 				IpContext: new(networkservice.IPContext),
 			},
@@ -223,15 +225,21 @@ func TestOutOfIPs(t *testing.T) {
 	_, ipNet, err := net.ParseCIDR("192.168.1.2/31")
 	require.NoError(t, err)
 
-	srv := newIpamServer(ipNet)
+	srv1 := newIpamServer(ipNet)
+	srv2 := newIpamServer(ipNet)
 
 	req1 := newRequest()
-	conn1, err := srv.Request(context.Background(), req1)
+	conn1, err := srv1.Request(context.Background(), req1)
 	require.NoError(t, err)
 	validateConn(t, conn1, "192.168.1.2/32", "192.168.1.3/32")
 
 	req2 := newRequest()
-	_, err = srv.Request(context.Background(), req2)
+	req2.Connection.Context = conn1.Context
+	conn2, err := srv2.Request(context.Background(), req2)
+	require.NoError(t, err)
+	validateConn(t, conn2, "192.168.1.2/32", "192.168.1.3/32")
+
+	_, err = srv1.Request(context.Background(), req2)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
Related to https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/664

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
