### PR TITLE
Delete extra dependencies from workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,10 +48,8 @@ jobs:
         "cmd-registry-proxy-dns",
         "cmd-nse-remote-vlan",
         "cmd-nse-vfio",
-        "cmd-nsc-init",
         "cmd-ipam-vl3",
         "cmd-map-ip-k8s",
-        "cmd-admission-webhook-k8s",
         "cmd-cluster-info-k8s",
         "cmd-csi-driver",
         "cmd-dashboard-backend"]

--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -23,10 +23,8 @@ jobs:
         "cmd-registry-proxy-dns",
         "cmd-nse-vfio",
         "cmd-nse-remote-vlan",
-        "cmd-nsc-init",
         "cmd-ipam-vl3",
         "cmd-map-ip-k8s",
-        "cmd-admission-webhook-k8s",
         "cmd-cluster-info-k8s",
         "cmd-csi-driver",
         "cmd-dashboard-backend"]


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Two additional dependencies in workflow need to be removed

1. `sdk` -> `cmd-nsc-init` (is extra for `sdk` -> `sdk-kernel` -> `sdk-sriov` -> `cmd-nsc-init` )
2. `sdk` -> `cmd-admission-webhook-k8s` (is extra for `sdk` -> `sdk-k8s` -> `cmd-admission-webhook-k8s` )

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [x] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [x] CI
