### PR TITLE
qfix: Do not reset IPContext configuration on the reselect

### DIFF
--- a/pkg/networkservice/chains/nsmgr/suite_test.go
+++ b/pkg/networkservice/chains/nsmgr/suite_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
 //
-// Copyright (c) 2023 Cisco and/or its affiliates.
+// Copyright (c) 2023-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -48,6 +48,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/passthrough"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/ipam/point2pointipam"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/ipam/strictipam"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/count"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/inject/injecterror"
 	registryclient "github.com/networkservicemesh/sdk/pkg/registry/chains/client"
@@ -240,7 +241,7 @@ func (s *nsmgrSuite) Test_ReselectEndpointWhenNetSvcHasChanged() {
 
 			serv := grpc.NewServer()
 			endpoint.NewServer(ctx, sandbox.GenerateTestToken, endpoint.WithAdditionalFunctionality(
-				point2pointipam.NewServer(ipNet),
+				strictipam.NewServer(point2pointipam.NewServer, ipNet),
 			)).Register(serv)
 			_ = serv.Serve(netListener)
 		}()

--- a/pkg/networkservice/common/begin/event_factory.go
+++ b/pkg/networkservice/common/begin/event_factory.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Cisco and/or its affiliates.
+// Copyright (c) 2021-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -105,7 +105,6 @@ func (f *eventFactoryClient) Request(opts ...Option) <-chan error {
 				if request.GetConnection() != nil {
 					request.GetConnection().Mechanism = nil
 					request.GetConnection().NetworkServiceEndpointName = ""
-					request.GetConnection().Context = nil
 					request.GetConnection().State = networkservice.State_RESELECT_REQUESTED
 				}
 				cancel()

--- a/pkg/networkservice/ipam/strictipam/server.go
+++ b/pkg/networkservice/ipam/strictipam/server.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 Cisco and its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package strictipam provides a networkservice.NetworkService Server chain element for building an IPAM server that prevents IP context configuration out of the settings scope
+package strictipam
+
+import (
+	"context"
+	"net"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/ippool"
+)
+
+type strictIPAMServer struct {
+	ipPool *ippool.IPPool
+}
+
+// NewServer - returns a new ipam networkservice.NetworkServiceServer that validates the incoming IP context parameters and resets them based on the validation result.
+func NewServer(newIPAMServer func(...*net.IPNet) networkservice.NetworkServiceServer, prefixes ...*net.IPNet) networkservice.NetworkServiceServer {
+	if newIPAMServer == nil {
+		panic("newIPAMServer should not be nil")
+	}
+	var ipPool = ippool.New(net.IPv6len)
+	for _, p := range prefixes {
+		ipPool.AddNet(p)
+	}
+	return next.NewNetworkServiceServer(
+		&strictIPAMServer{ipPool: ipPool},
+		newIPAMServer(prefixes...),
+	)
+}
+
+func (n *strictIPAMServer) areAddressesValid(addresses []string) bool {
+	for _, srcIP := range addresses {
+		if !n.ipPool.ContainsString(srcIP) {
+			return false
+		}
+	}
+	return true
+}
+
+func (n *strictIPAMServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	if !n.areAddressesValid(request.GetConnection().GetContext().GetIpContext().GetSrcIpAddrs()) ||
+		!n.areAddressesValid(request.GetConnection().GetContext().GetIpContext().GetDstIpAddrs()) {
+		request.GetConnection().GetContext().IpContext = &networkservice.IPContext{}
+	}
+
+	return next.Server(ctx).Request(ctx, request)
+}
+
+func (n *strictIPAMServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	return next.Server(ctx).Close(ctx, conn)
+}

--- a/pkg/networkservice/ipam/strictipam/server.go
+++ b/pkg/networkservice/ipam/strictipam/server.go
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package strictipam provides a networkservice.NetworkService Server chain element for building an IPAM server that prevents IP context configuration out of the settings scope
+// Package strictipam provides a networkservice.NetworkService Server chain element for building an IPAM server that prevents IP context configuration out of the settings scope
 package strictipam
 
 import (
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/ippool"
 )


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
As we'd discussed on the latest meeting, we decided not to clear the IP context on the NSC side.  See at https://github.com/networkservicemesh/deployments-k8s/issues/9888#issuecomment-1906520918

## Issue link
Closes  https://github.com/networkservicemesh/deployments-k8s/issues/9888


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [X] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
