### PR TITLE
A new chain element for vl3 endpoints that resets IPContext configuration depending on dst and src addresses

### DIFF
--- a/pkg/ipam/strictipam/server.go
+++ b/pkg/ipam/strictipam/server.go
@@ -20,7 +20,6 @@ package strictipam
 import (
 	"context"
 	"net"
-	"strings"
 	"sync"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -29,7 +28,6 @@ import (
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/ippool"
-	"github.com/networkservicemesh/sdk/pkg/tools/log"
 )
 
 type strictIPAMServer struct {
@@ -66,13 +64,10 @@ func (n *strictIPAMServer) areAddressesValid(addresses []string) bool {
 }
 
 func (n *strictIPAMServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	if strings.HasPrefix(request.Connection.Path.PathSegments[0].Name, "nse") {
-		log.FromContext(ctx).Infof("THIS IS NOT A REGULAR CLIENT. SKIPPING...")
-		return next.Server(ctx).Request(ctx, request)
-	}
-	dstAddrs := request.GetConnection().GetContext().GetIpContext().GetDstIpAddrs()
 	srcAddrs := request.GetConnection().GetContext().GetIpContext().GetSrcIpAddrs()
-	if !n.areAddressesValid(srcAddrs) || !n.areAddressesValid(dstAddrs) {
+	dstAddrs := request.GetConnection().GetContext().GetIpContext().GetDstIpAddrs()
+
+	if !n.areAddressesValid(srcAddrs) && !n.areAddressesValid(dstAddrs) {
 		request.Connection.Context.IpContext = &networkservice.IPContext{}
 	}
 	return next.Server(ctx).Request(ctx, request)

--- a/pkg/ipam/strictipam/server.go
+++ b/pkg/ipam/strictipam/server.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Cisco and its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package strictipam provides a networkservice.NetworkService Server chain element for building an IPAM server that prevents IP context configuration out of the settings scope
+package strictipam
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/ipam"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/ippool"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+type strictIPAMServer struct {
+	ipPool *ippool.IPPool
+	m      sync.Mutex
+}
+
+// NewServer - returns a new ipam networkservice.NetworkServiceServer that validates the incoming IP context parameters and resets them based on the validation result.
+func NewServer(ctx context.Context, prefixCh <-chan *ipam.PrefixResponse) networkservice.NetworkServiceServer {
+	var ipPool = ippool.New(net.IPv4len)
+
+	s := &strictIPAMServer{ipPool: ipPool}
+	go func() {
+		for prefix := range prefixCh {
+			s.m.Lock()
+			s.ipPool = ippool.NewWithNetString(prefix.Prefix)
+			s.m.Unlock()
+		}
+	}()
+
+	return s
+}
+
+func (n *strictIPAMServer) areAddressesValid(addresses []string) bool {
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	for _, addr := range addresses {
+		if !n.ipPool.ContainsNetString(addr) {
+			return false
+		}
+	}
+	return true
+}
+
+func (n *strictIPAMServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	if strings.HasPrefix(request.Connection.Path.PathSegments[0].Name, "nse") {
+		log.FromContext(ctx).Infof("THIS IS NOT A REGULAR CLIENT. SKIPPING...")
+		return next.Server(ctx).Request(ctx, request)
+	}
+	dstAddrs := request.GetConnection().GetContext().GetIpContext().GetDstIpAddrs()
+	srcAddrs := request.GetConnection().GetContext().GetIpContext().GetSrcIpAddrs()
+	if !n.areAddressesValid(srcAddrs) || !n.areAddressesValid(dstAddrs) {
+		request.Connection.Context.IpContext = &networkservice.IPContext{}
+	}
+	return next.Server(ctx).Request(ctx, request)
+}
+
+func (n *strictIPAMServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	return next.Server(ctx).Close(ctx, conn)
+}

--- a/pkg/networkservice/chains/nsmgr/vl3_test.go
+++ b/pkg/networkservice/chains/nsmgr/vl3_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
-	"github.com/networkservicemesh/sdk/pkg/ipam/strictipam"
+	"github.com/networkservicemesh/sdk/pkg/ipam/strictvl3ipam"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/dnscontext/vl3dns"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/connectioncontext/ipcontext/vl3"
@@ -546,7 +546,7 @@ func Test_NSC_ConnectsTo_vl3NSE_With_Invalid_IpContext(t *testing.T) {
 		ctx,
 		nseReg,
 		sandbox.GenerateTestToken,
-		strictipam.NewServer(ctx, strictIpamPrefixCh),
+		strictvl3ipam.NewServer(ctx, strictIpamPrefixCh),
 		vl3.NewServer(ctx, serverPrefixCh),
 	)
 

--- a/pkg/networkservice/chains/nsmgr/vl3_test.go
+++ b/pkg/networkservice/chains/nsmgr/vl3_test.go
@@ -536,8 +536,8 @@ func Test_NSC_ConnectsTo_vl3NSE_With_Invalid_IpContext(t *testing.T) {
 	defer close(serverPrefixCh)
 	defer close(strictIpamPrefixCh)
 
-	prefix1 := "10.0.0.1/24"
-	prefix2 := "10.10.0.1/24"
+	prefix1 := "10.0.0.0/24"
+	prefix2 := "10.10.0.0/24"
 
 	serverPrefixCh <- &ipam.PrefixResponse{Prefix: prefix1}
 	strictIpamPrefixCh <- &ipam.PrefixResponse{Prefix: prefix1}
@@ -561,6 +561,7 @@ func Test_NSC_ConnectsTo_vl3NSE_With_Invalid_IpContext(t *testing.T) {
 	serverPrefixCh <- &ipam.PrefixResponse{Prefix: prefix2}
 	strictIpamPrefixCh <- &ipam.PrefixResponse{Prefix: prefix2}
 
+	req.Connection = conn
 	conn, err = nsc.Request(ctx, req)
 	require.NoError(t, err)
 
@@ -571,6 +572,11 @@ func Test_NSC_ConnectsTo_vl3NSE_With_Invalid_IpContext(t *testing.T) {
 func checkIPContext(ipContext *networkservice.IPContext, prefix string) bool {
 	pool := ippool.NewWithNetString(prefix)
 	for _, addr := range ipContext.SrcIpAddrs {
+		if !pool.ContainsNetString(addr) {
+			return false
+		}
+	}
+	for _, addr := range ipContext.DstIpAddrs {
 		if !pool.ContainsNetString(addr) {
 			return false
 		}


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Added a new chain element that resets client's IPContext configuration if its dst and src addresses are from another vl3 subnetwork

## Issue link
https://github.com/networkservicemesh/cmd-nse-vl3-vpp/issues/289


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
