### PR TITLE
Generate random kernel interface names

### DIFF
--- a/pkg/networkservice/common/mechanisms/kernel/client.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
@@ -92,7 +91,7 @@ func (k *kernelMechanismClient) manageMechanismPreferences(request *networkservi
 	return nil
 }
 
-func (k *kernelMechanismClient) updateMechanism(mechanism *kernel.Mechanism) error {
+func (k *kernelMechanismClient) updateMechanism(mechanism *kernelmech.Mechanism) error {
 	if mechanism.GetInterfaceName() == "" {
 		if k.interfaceName != "" {
 			mechanism.SetInterfaceName(k.interfaceName)

--- a/pkg/networkservice/common/mechanisms/kernel/client.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client.go
@@ -28,44 +28,37 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/nanoid"
 )
 
 type kernelMechanismClient struct {
-	interfaceName string
+	interfaceName          string
+	interfaceNameGenerator func(int) (string, error)
 }
 
 // NewClient - returns client that sets kernel preferred mechanism
 func NewClient(opts ...Option) networkservice.NetworkServiceClient {
-	o := &options{}
+	o := &options{
+		interfaceNameGenerator: nanoid.New(),
+	}
 	for _, opt := range opts {
 		opt(o)
 	}
 	return &kernelMechanismClient{
-		interfaceName: o.interfaceName,
+		interfaceName:          o.interfaceName,
+		interfaceNameGenerator: o.interfaceNameGenerator,
 	}
 }
 
 func (k *kernelMechanismClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
-	updated, err := k.updateMechanismPreferences(request)
-	if err != nil {
+	if err := k.manageMechanismPreferences(request); err != nil {
 		return nil, errors.Wrap(err, "Failed to update mechanism preferences")
 	}
-	if !updated {
-		mechanism := kernelmech.ToMechanism(kernelmech.New(netNSURL))
-		if k.interfaceName != "" {
-			mechanism.SetInterfaceName(k.interfaceName)
-		} else {
-			ifname, err := generateInterfaceName()
-			if err != nil {
-				return nil, errors.Wrap(err, "Failed to generate kernel interface name")
-			}
-			mechanism.SetInterfaceName(ifname)
-		}
-		request.MechanismPreferences = append(request.GetMechanismPreferences(), mechanism.Mechanism)
-	}
+
 	return next.Client(ctx).Request(ctx, request, opts...)
 }
 
@@ -74,27 +67,43 @@ func (k *kernelMechanismClient) Close(ctx context.Context, conn *networkservice.
 }
 
 // updateMechanismPreferences returns true if MechanismPreferences has updated
-func (k *kernelMechanismClient) updateMechanismPreferences(request *networkservice.NetworkServiceRequest) (bool, error) {
+func (k *kernelMechanismClient) manageMechanismPreferences(request *networkservice.NetworkServiceRequest) error {
 	var updated = false
-
 	for _, m := range request.GetRequestMechanismPreferences() {
 		if mechanism := kernelmech.ToMechanism(m); mechanism != nil {
-			if mechanism.GetInterfaceName() == "" {
-				if k.interfaceName != "" {
-					mechanism.SetInterfaceName(k.interfaceName)
-				} else {
-					ifname, err := generateInterfaceName()
-					if err != nil {
-						return false, errors.Wrap(err, "Failed to generate kernel interface name")
-					}
-					mechanism.SetInterfaceName(ifname)
-				}
+			if err := k.updateMechanism(mechanism); err != nil {
+				return err
 			}
 			mechanism.SetNetNSURL(netNSURL)
-
 			updated = true
 		}
 	}
 
-	return updated, nil
+	if updated {
+		return nil
+	}
+
+	mechanism := kernelmech.ToMechanism(kernelmech.New(netNSURL))
+	if err := k.updateMechanism(mechanism); err != nil {
+		return err
+	}
+
+	request.MechanismPreferences = append(request.GetMechanismPreferences(), mechanism.Mechanism)
+	return nil
+}
+
+func (k *kernelMechanismClient) updateMechanism(mechanism *kernel.Mechanism) error {
+	if mechanism.GetInterfaceName() == "" {
+		if k.interfaceName != "" {
+			mechanism.SetInterfaceName(k.interfaceName)
+		} else {
+			ifname, err := generateInterfaceName(k.interfaceNameGenerator)
+			if err != nil {
+				return errors.Wrap(err, "Failed to generate kernel interface name")
+			}
+			mechanism.SetInterfaceName(ifname)
+		}
+	}
+
+	return nil
 }

--- a/pkg/networkservice/common/mechanisms/kernel/client.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client.go
@@ -53,7 +53,7 @@ func (k *kernelMechanismClient) Request(ctx context.Context, request *networkser
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to update mechanism preferences")
 	}
-	if updated {
+	if !updated {
 		mechanism := kernelmech.ToMechanism(kernelmech.New(netNSURL))
 		if k.interfaceName != "" {
 			mechanism.SetInterfaceName(k.interfaceName)

--- a/pkg/networkservice/common/mechanisms/kernel/client.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client.go
@@ -51,7 +51,7 @@ func (k *kernelMechanismClient) Request(ctx context.Context, request *networkser
 		if k.interfaceName != "" {
 			mechanism.SetInterfaceName(k.interfaceName)
 		} else {
-			mechanism.SetInterfaceName(getNameFromConnection(request.GetConnection()))
+			mechanism.SetInterfaceName(generateInterfaceName())
 		}
 		request.MechanismPreferences = append(request.GetMechanismPreferences(), mechanism.Mechanism)
 	}
@@ -72,7 +72,7 @@ func (k *kernelMechanismClient) updateMechanismPreferences(request *networkservi
 				if k.interfaceName != "" {
 					mechanism.SetInterfaceName(k.interfaceName)
 				} else {
-					mechanism.SetInterfaceName(getNameFromConnection(request.GetConnection()))
+					mechanism.SetInterfaceName(generateInterfaceName())
 				}
 			}
 			mechanism.SetNetNSURL(netNSURL)

--- a/pkg/networkservice/common/mechanisms/kernel/client.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client.go
@@ -65,7 +65,7 @@ func (k *kernelMechanismClient) Close(ctx context.Context, conn *networkservice.
 	return next.Client(ctx).Close(ctx, conn, opts...)
 }
 
-// updateMechanismPreferences returns true if MechanismPreferences has updated
+// manageMechanismPreferences updates mechanism preferences. Adds kernel mechanism if they doesn't have one
 func (k *kernelMechanismClient) manageMechanismPreferences(request *networkservice.NetworkServiceRequest) error {
 	var updated = false
 	for _, m := range request.GetRequestMechanismPreferences() {

--- a/pkg/networkservice/common/mechanisms/kernel/client_test.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +30,8 @@ import (
 	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/nanoid"
 )
 
 var netNSURL = (&url.URL{Scheme: "file", Path: "/proc/thread-self/ns/net"}).String()
@@ -86,7 +90,7 @@ func TestKernelMechanismClient_ShouldSetRandomInteraceName(t *testing.T) {
 	require.Len(t, ifname, kernelmech.LinuxIfMaxLength)
 	require.True(t, strings.HasPrefix(ifname, "nsm"))
 	for i := 0; i < kernelmech.LinuxIfMaxLength; i++ {
-		require.Contains(t, kernel.Alphabet, ifname[i])
+		require.Contains(t, nanoid.DefaultAlphabet, ifname[i])
 	}
 	require.Equal(t, netNSURL, req.MechanismPreferences[0].Parameters[kernelmech.NetNSURL])
 }

--- a/pkg/networkservice/common/mechanisms/kernel/client_test.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client_test.go
@@ -20,11 +20,11 @@ package kernel_test
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"

--- a/pkg/networkservice/common/mechanisms/kernel/client_test.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client_test.go
@@ -90,7 +90,6 @@ func TestKernelMechanismClient_ShouldSetRandomInteraceName(t *testing.T) {
 	require.Len(t, ifname, kernelmech.LinuxIfMaxLength)
 	require.True(t, strings.HasPrefix(ifname, "nsm"))
 	for i := 0; i < kernelmech.LinuxIfMaxLength; i++ {
-		require.Contains(t, nanoid.DefaultAlphabet, ifname[i])
+		require.Contains(t, nanoid.DefaultAlphabet, string(ifname[i]))
 	}
-	require.Equal(t, netNSURL, req.MechanismPreferences[0].Parameters[kernelmech.NetNSURL])
 }

--- a/pkg/networkservice/common/mechanisms/kernel/client_test.go
+++ b/pkg/networkservice/common/mechanisms/kernel/client_test.go
@@ -19,6 +19,7 @@ package kernel_test
 import (
 	"context"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -70,5 +71,22 @@ func TestKernelMechanismClient_ShouldSetValidNetNSURL(t *testing.T) {
 
 	_, err := c.Request(context.Background(), req)
 	require.NoError(t, err)
+	require.Equal(t, netNSURL, req.MechanismPreferences[0].Parameters[kernelmech.NetNSURL])
+}
+
+func TestKernelMechanismClient_ShouldSetRandomInteraceName(t *testing.T) {
+	c := kernel.NewClient()
+	req := &networkservice.NetworkServiceRequest{}
+
+	_, err := c.Request(context.Background(), req)
+	require.NoError(t, err)
+
+	ifname := req.MechanismPreferences[0].Parameters[kernelmech.InterfaceNameKey]
+
+	require.Len(t, ifname, kernelmech.LinuxIfMaxLength)
+	require.True(t, strings.HasPrefix(ifname, "nsm"))
+	for i := 0; i < kernelmech.LinuxIfMaxLength; i++ {
+		require.Contains(t, kernel.Alphabet, ifname[i])
+	}
 	require.Equal(t, netNSURL, req.MechanismPreferences[0].Parameters[kernelmech.NetNSURL])
 }

--- a/pkg/networkservice/common/mechanisms/kernel/option.go
+++ b/pkg/networkservice/common/mechanisms/kernel/option.go
@@ -17,7 +17,8 @@
 package kernel
 
 type options struct {
-	interfaceName string
+	interfaceName          string
+	interfaceNameGenerator func(int) (string, error)
 }
 
 // Option is an option pattern for kernelMechanismClient/Server
@@ -27,5 +28,11 @@ type Option func(o *options)
 func WithInterfaceName(interfaceName string) Option {
 	return func(o *options) {
 		o.interfaceName = limitName(interfaceName)
+	}
+}
+
+func WithInterfaceNameGenerator(generator func(int) (string, error)) Option {
+	return func(o *options) {
+		o.interfaceNameGenerator = generator
 	}
 }

--- a/pkg/networkservice/common/mechanisms/kernel/option.go
+++ b/pkg/networkservice/common/mechanisms/kernel/option.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +33,7 @@ func WithInterfaceName(interfaceName string) Option {
 	}
 }
 
+// WithInterfaceNameGenerator sets a generator for generating random interface names
 func WithInterfaceNameGenerator(generator func(int) (string, error)) Option {
 	return func(o *options) {
 		o.interfaceNameGenerator = generator

--- a/pkg/networkservice/common/mechanisms/kernel/server.go
+++ b/pkg/networkservice/common/mechanisms/kernel/server.go
@@ -49,7 +49,7 @@ func (m *kernelMechanismServer) Request(ctx context.Context, request *networkser
 		if m.interfaceName != "" {
 			mechanism.SetInterfaceName(m.interfaceName)
 		} else {
-			mechanism.SetInterfaceName(getNameFromConnection(request.GetConnection()))
+			mechanism.SetInterfaceName(generateInterfaceName())
 		}
 	}
 	return next.Server(ctx).Request(ctx, request)

--- a/pkg/networkservice/common/mechanisms/kernel/server.go
+++ b/pkg/networkservice/common/mechanisms/kernel/server.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +23,7 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
@@ -49,7 +52,11 @@ func (m *kernelMechanismServer) Request(ctx context.Context, request *networkser
 		if m.interfaceName != "" {
 			mechanism.SetInterfaceName(m.interfaceName)
 		} else {
-			mechanism.SetInterfaceName(generateInterfaceName())
+			ifname, err := generateInterfaceName()
+			if err != nil {
+				return nil, errors.Wrap(err, "Failed to generate kernel interface name")
+			}
+			mechanism.SetInterfaceName(ifname)
 		}
 	}
 	return next.Server(ctx).Request(ctx, request)

--- a/pkg/networkservice/common/mechanisms/kernel/server_test.go
+++ b/pkg/networkservice/common/mechanisms/kernel/server_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2021 Doc.ai and/or its affiliates.
-//
 // Copyright (c) 2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -20,8 +18,6 @@ package kernel_test
 
 import (
 	"context"
-	"errors"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -35,9 +31,7 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/tools/nanoid"
 )
 
-var netNSURL = (&url.URL{Scheme: "file", Path: "/proc/thread-self/ns/net"}).String()
-
-func TestKernelMechanismClient_ShouldSetInterfaceName(t *testing.T) {
+func TestKernelMechanismServer_ShouldSetInterfaceName(t *testing.T) {
 	var expectedIfaceName string
 	for i := 0; i < kernelmech.LinuxIfMaxLength; i++ {
 		expectedIfaceName += "a"
@@ -53,19 +47,7 @@ func TestKernelMechanismClient_ShouldSetInterfaceName(t *testing.T) {
 	require.Equal(t, expectedIfaceName, req.MechanismPreferences[0].Parameters[kernelmech.InterfaceNameKey])
 }
 
-func TestKernelMechanismClient_ShouldNotDoublingMechanisms(t *testing.T) {
-	c := kernel.NewClient()
-
-	req := &networkservice.NetworkServiceRequest{}
-
-	for i := 0; i < 10; i++ {
-		_, err := c.Request(context.Background(), req)
-		require.NoError(t, err)
-		require.Len(t, req.MechanismPreferences, 1)
-	}
-}
-
-func TestKernelMechanismClient_ShouldSetValidNetNSURL(t *testing.T) {
+func TestKernelMechanismServer_ShouldSetValidNetNSURL(t *testing.T) {
 	c := kernel.NewClient()
 
 	req := &networkservice.NetworkServiceRequest{
@@ -79,7 +61,7 @@ func TestKernelMechanismClient_ShouldSetValidNetNSURL(t *testing.T) {
 	require.Equal(t, netNSURL, req.MechanismPreferences[0].Parameters[kernelmech.NetNSURL])
 }
 
-func TestKernelMechanismClient_ShouldSetRandomInteraceName(t *testing.T) {
+func TestKernelMechanismServer_ShouldSetRandomInteraceName(t *testing.T) {
 	c := kernel.NewClient()
 	req := &networkservice.NetworkServiceRequest{}
 
@@ -95,14 +77,7 @@ func TestKernelMechanismClient_ShouldSetRandomInteraceName(t *testing.T) {
 	}
 }
 
-type brokenByteGenerator struct {
-}
-
-func (g *brokenByteGenerator) Read(buffer []byte) (int, error) {
-	return 0, errors.New("failed to generate bytes")
-}
-
-func TestKernelMechanismClient_FailedToGenerateRandomName(t *testing.T) {
+func TestKernelMechanismServer_FailedToGenerateRandomName(t *testing.T) {
 	c := kernel.NewClient(kernel.WithInterfaceNameGenerator(nanoid.New(nanoid.WithRandomByteGenerator(&brokenByteGenerator{}))))
 	req := &networkservice.NetworkServiceRequest{}
 

--- a/pkg/networkservice/common/mechanisms/kernel/utils.go
+++ b/pkg/networkservice/common/mechanisms/kernel/utils.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,23 +19,29 @@
 package kernel
 
 import (
+	"crypto/rand"
 	"fmt"
+	"math"
+	"math/bits"
 	"net/url"
 
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
+)
+
+const (
+	// Alphabet is the alphabet for Nano ID.
+	Alphabet = "!\"#$&'()*+,-.012456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+	ifPrefix = "nsm"
 )
 
 var netNSURL = (&url.URL{Scheme: "file", Path: "/proc/thread-self/ns/net"}).String()
 
-// getNameFromConnection - returns a name computed from networkservice.Connection 'conn'
-func getNameFromConnection(conn *networkservice.Connection) string {
-	ns := conn.GetNetworkService()
-	nsMaxLength := kernelmech.LinuxIfMaxLength - 5
-	if len(ns) > nsMaxLength {
-		ns = ns[:nsMaxLength]
-	}
-	name := fmt.Sprintf("%s-%s", ns, conn.GetId())
+// generateInterfaceName - returns a random interface name with "nsm" prefix
+func generateInterfaceName() string {
+	ifIDLen := kernelmech.LinuxIfMaxLength - len(ifPrefix)
+	id, _ := GenerateRandomString(ifIDLen)
+	name := fmt.Sprintf("%s%s", ifPrefix, id)
+
 	return limitName(name)
 }
 
@@ -42,4 +50,40 @@ func limitName(name string) string {
 		return name[:kernelmech.LinuxIfMaxLength]
 	}
 	return name
+}
+
+func generateRandomBuffer(step int) ([]byte, error) {
+	buffer := make([]byte, step)
+	if _, err := rand.Read(buffer); err != nil {
+		return nil, err
+	}
+	return buffer, nil
+}
+
+// GenerateRandomString generates a random string based on size.
+func GenerateRandomString(size int) (string, error) {
+	mask := 2<<uint32(31-bits.LeadingZeros32(uint32(len(Alphabet)-1|1))) - 1
+	step := int(math.Ceil(1.6 * float64(mask*size) / float64(len(Alphabet))))
+
+	id := make([]byte, size)
+
+	for {
+		randomBuffer, err := generateRandomBuffer(step)
+		if err != nil {
+			return "", err
+		}
+
+		j := 0
+		for i := 0; i < step; i++ {
+			currentIndex := int(randomBuffer[i]) & mask
+
+			if currentIndex < len(Alphabet) {
+				id[j] = Alphabet[currentIndex]
+				j++
+				if j == size {
+					return string(id), nil
+				}
+			}
+		}
+	}
 }

--- a/pkg/networkservice/common/mechanisms/kernel/utils.go
+++ b/pkg/networkservice/common/mechanisms/kernel/utils.go
@@ -23,8 +23,6 @@ import (
 	"net/url"
 
 	kernelmech "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
-
-	"github.com/networkservicemesh/sdk/pkg/tools/nanoid"
 )
 
 const (
@@ -34,9 +32,10 @@ const (
 var netNSURL = (&url.URL{Scheme: "file", Path: "/proc/thread-self/ns/net"}).String()
 
 // generateInterfaceName - returns a random interface name with "nsm" prefix
-func generateInterfaceName() (string, error) {
+// to achieve a 1% chance of name collision, you need to generate approximately 68 billon names
+func generateInterfaceName(generator func(int) (string, error)) (string, error) {
 	ifIDLen := kernelmech.LinuxIfMaxLength - len(ifPrefix)
-	id, err := nanoid.RandomString(ifIDLen)
+	id, err := generator(ifIDLen)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/networkservice/common/mechanisms/kernel/utils_test.go
+++ b/pkg/networkservice/common/mechanisms/kernel/utils_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	idLen = 30
+)
+
+func TestNoCollisions(t *testing.T) {
+	used := make(map[string]bool)
+	for i := 0; i < 50*1000; i++ {
+		id, err := kernel.GenerateRandomString(idLen)
+		require.NoError(t, err)
+		_, ok := used[id]
+		require.False(t, ok, "Collision detected for id: %s", id)
+		used[id] = true
+	}
+}
+
+func TestFlatDistribution(t *testing.T) {
+	count := 100 * 1000
+
+	chars := make(map[rune]int)
+	for i := 0; i < count; i++ {
+		id, err := kernel.GenerateRandomString(idLen)
+		require.NoError(t, err, "Error generating nanoid")
+		for _, char := range id {
+			chars[char]++
+		}
+	}
+
+	require.Equal(t, len(chars), len(kernel.Alphabet), "Unexpected number of unique characters")
+
+	max := 0.0
+	min := math.MaxFloat64
+	for _, count := range chars {
+		distribution := float64(count*len(kernel.Alphabet)) / float64(count*idLen)
+		if distribution > max {
+			max = distribution
+		}
+		if distribution < min {
+			min = distribution
+		}
+	}
+
+	require.True(t, max-min <= 0.05, "Distribution is not flat")
+}

--- a/pkg/networkservice/common/mechanismtranslation/client_test.go
+++ b/pkg/networkservice/common/mechanismtranslation/client_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,13 +43,17 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 )
 
+const (
+	clientIfName = "nsm1"
+)
+
 func kernelMechanism() *networkservice.Mechanism {
 	request := &networkservice.NetworkServiceRequest{
 		Connection: &networkservice.Connection{
 			Id: "id",
 		},
 	}
-	_, _ = kernel.NewClient().Request(context.Background(), request)
+	_, _ = kernel.NewClient(kernel.WithInterfaceName(clientIfName)).Request(context.Background(), request)
 	return request.MechanismPreferences[0]
 }
 
@@ -58,7 +64,7 @@ func TestMechanismTranslationClient(t *testing.T) {
 		metadata.NewClient(),
 		mechanismtranslation.NewClient(),
 		capture,
-		kernel.NewClient(),
+		kernel.NewClient(kernel.WithInterfaceName(clientIfName)),
 		adapters.NewServerToClient(
 			mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 				kernelmech.MECHANISM: null.NewServer(),
@@ -130,7 +136,7 @@ func TestMechanismTranslationClient_CloseOnError(t *testing.T) {
 			}
 			count++
 		}),
-		kernel.NewClient(),
+		kernel.NewClient(kernel.WithInterfaceName(clientIfName)),
 		adapters.NewServerToClient(
 			mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 				kernelmech.MECHANISM: null.NewServer(),

--- a/pkg/tools/nanoid/generator.go
+++ b/pkg/tools/nanoid/generator.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package nanoid is a tiny, unique string ID generator. Original JavaScript implementation: https://github.com/ai/nanoid
+// Package nanoid is a tiny, unique string ID generator
 package nanoid
 
 import (
@@ -51,6 +51,7 @@ func generateRandomBuffer(step int) ([]byte, error) {
 }
 
 // RandomString generates a random string based on size.
+// Original JavaScript implementation: https://github.com/ai/nanoid/blob/main/README.md
 func RandomString(size int, opt ...Option) (string, error) {
 	opts := &generatorOpts{
 		alphabet: DefaultAlphabet,

--- a/pkg/tools/nanoid/generator.go
+++ b/pkg/tools/nanoid/generator.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package nanoid is a tiny, unique string ID generator
+// Package nanoid is a tiny, unique string ID generator. Original JavaScript implementation: https://github.com/ai/nanoid
 package nanoid
 
 import (

--- a/pkg/tools/nanoid/generator.go
+++ b/pkg/tools/nanoid/generator.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nanoid is a tiny, unique string ID generator
+package nanoid
+
+import (
+	"crypto/rand"
+	"math"
+	"math/bits"
+)
+
+const (
+	// DefaultAlphabet is the default alphabet for the generator which can be used to generate kernel interface names
+	DefaultAlphabet = "!\"#$&'()*+,-.012456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+)
+
+type generatorOpts struct {
+	alphabet string
+}
+
+// Option represents options for the string generator
+type Option func(o *generatorOpts)
+
+// WithAlphabet sets a custom alphabet for the  generator
+func WithAlphabet(alphabet string) Option {
+	return func(o *generatorOpts) {
+		o.alphabet = alphabet
+	}
+}
+
+func generateRandomBuffer(step int) ([]byte, error) {
+	buffer := make([]byte, step)
+	if _, err := rand.Read(buffer); err != nil {
+		return nil, err
+	}
+	return buffer, nil
+}
+
+// RandomString generates a random string based on size.
+func RandomString(size int, opt ...Option) (string, error) {
+	opts := &generatorOpts{
+		alphabet: DefaultAlphabet,
+	}
+
+	for _, o := range opt {
+		o(opts)
+	}
+
+	mask := 2<<uint32(31-bits.LeadingZeros32(uint32(len(opts.alphabet)-1|1))) - 1
+	step := int(math.Ceil(1.6 * float64(mask*size) / float64(len(opts.alphabet))))
+
+	id := make([]byte, size)
+
+	for {
+		randomBuffer, err := generateRandomBuffer(step)
+		if err != nil {
+			return "", err
+		}
+
+		j := 0
+		for i := 0; i < step; i++ {
+			currentIndex := int(randomBuffer[i]) & mask
+
+			if currentIndex < len(opts.alphabet) {
+				id[j] = opts.alphabet[currentIndex]
+				j++
+				if j == size {
+					return string(id), nil
+				}
+			}
+		}
+	}
+}

--- a/pkg/tools/nanoid/generator.go
+++ b/pkg/tools/nanoid/generator.go
@@ -37,13 +37,14 @@ type generatorOpts struct {
 // Option represents options for the string generator
 type Option func(o *generatorOpts)
 
-// WithAlphabet sets a custom alphabet for the  generator
+// WithAlphabet sets a custom alphabet for the generator
 func WithAlphabet(alphabet string) Option {
 	return func(o *generatorOpts) {
 		o.alphabet = alphabet
 	}
 }
 
+// WithRandomByteGenerator sets a generator for random bytes generation
 func WithRandomByteGenerator(generator io.Reader) Option {
 	return func(o *generatorOpts) {
 		o.randomByteGenerator = generator
@@ -58,6 +59,7 @@ func generateRandomBuffer(generator io.Reader, step int) ([]byte, error) {
 	return buffer, nil
 }
 
+// New creates a new nanoid generator with specified options
 func New(opt ...Option) func(int) (string, error) {
 	return func(size int) (string, error) {
 		return RandomString(size, opt...)

--- a/pkg/tools/nanoid/generator_test.go
+++ b/pkg/tools/nanoid/generator_test.go
@@ -14,14 +14,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kernel_test
+package nanoid_test
 
 import (
 	"math"
 	"testing"
 
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
 	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/nanoid"
 )
 
 const (
@@ -31,7 +32,7 @@ const (
 func TestNoCollisions(t *testing.T) {
 	used := make(map[string]bool)
 	for i := 0; i < 50*1000; i++ {
-		id, err := kernel.GenerateRandomString(idLen)
+		id, err := nanoid.RandomString(idLen)
 		require.NoError(t, err)
 		_, ok := used[id]
 		require.False(t, ok, "Collision detected for id: %s", id)
@@ -44,19 +45,19 @@ func TestFlatDistribution(t *testing.T) {
 
 	chars := make(map[rune]int)
 	for i := 0; i < count; i++ {
-		id, err := kernel.GenerateRandomString(idLen)
+		id, err := nanoid.RandomString(idLen)
 		require.NoError(t, err, "Error generating nanoid")
 		for _, char := range id {
 			chars[char]++
 		}
 	}
 
-	require.Equal(t, len(chars), len(kernel.Alphabet), "Unexpected number of unique characters")
+	require.Equal(t, len(chars), len(nanoid.DefaultAlphabet), "Unexpected number of unique characters")
 
 	max := 0.0
 	min := math.MaxFloat64
 	for _, count := range chars {
-		distribution := float64(count*len(kernel.Alphabet)) / float64(count*idLen)
+		distribution := float64(count*len(nanoid.DefaultAlphabet)) / float64(count*idLen)
 		if distribution > max {
 			max = distribution
 		}
@@ -66,4 +67,14 @@ func TestFlatDistribution(t *testing.T) {
 	}
 
 	require.True(t, max-min <= 0.05, "Distribution is not flat")
+}
+
+func TestCustomAlphabet(t *testing.T) {
+	alphabet := "abcd"
+	id, err := nanoid.RandomString(idLen, nanoid.WithAlphabet(alphabet))
+	require.NoError(t, err)
+
+	for _, c := range id {
+		require.Contains(t, alphabet, string(c))
+	}
 }


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Generate random kernel interface names of a form `nsm############` where `#` is a random character.

## Issue link
https://github.com/networkservicemesh/sdk/issues/1589

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
