### PR TITLE
Include excludedPrefixes when checking if vl3.IPAM contains an ip net

### DIFF
--- a/pkg/networkservice/connectioncontext/ipcontext/vl3/ipam.go
+++ b/pkg/networkservice/connectioncontext/ipcontext/vl3/ipam.go
@@ -186,8 +186,10 @@ func (p *IPAM) ContainsNetString(ipNet string) bool {
 	p.Lock()
 	defer p.Unlock()
 
-	if p.self.String() == ipNet {
-		return true
+	for k := range p.excludedPrefixes {
+		if k == ipNet {
+			return true
+		}
 	}
 	return p.ipPool.ContainsNetString(ipNet)
 }

--- a/pkg/networkservice/connectioncontext/ipcontext/vl3/ipam.go
+++ b/pkg/networkservice/connectioncontext/ipcontext/vl3/ipam.go
@@ -185,5 +185,9 @@ func (p *IPAM) Reset(prefix string, excludePrefies ...string) error {
 func (p *IPAM) ContainsNetString(ipNet string) bool {
 	p.Lock()
 	defer p.Unlock()
+
+	if p.self.String() == ipNet {
+		return true
+	}
 	return p.ipPool.ContainsNetString(ipNet)
 }


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
vl3.IPAM has `excludedPrefixes` field. When calling `IPAM.ContainsNetString()` we also should check `excludedPrefixes` 

## Issue link
https://github.com/networkservicemesh/cmd-nse-vl3-vpp/issues/289

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
