### PR TITLE
Fix kernel interface name generation

### DIFF
--- a/pkg/networkservice/common/mechanisms/kernel/server.go
+++ b/pkg/networkservice/common/mechanisms/kernel/server.go
@@ -54,14 +54,16 @@ func NewServer(opts ...Option) networkservice.NetworkServiceServer {
 func (m *kernelMechanismServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	if mechanism := kernelmech.ToMechanism(request.GetConnection().GetMechanism()); mechanism != nil {
 		mechanism.SetNetNSURL(netNSURL)
-		if m.interfaceName != "" {
-			mechanism.SetInterfaceName(m.interfaceName)
-		} else {
-			ifname, err := generateInterfaceName(m.interfaceNameGenerator)
-			if err != nil {
-				return nil, errors.Wrap(err, "Failed to generate kernel interface name")
+		if mechanism.GetInterfaceName() == "" {
+			if m.interfaceName != "" {
+				mechanism.SetInterfaceName(m.interfaceName)
+			} else {
+				ifname, err := generateInterfaceName(m.interfaceNameGenerator)
+				if err != nil {
+					return nil, errors.Wrap(err, "Failed to generate kernel interface name")
+				}
+				mechanism.SetInterfaceName(ifname)
 			}
-			mechanism.SetInterfaceName(ifname)
 		}
 	}
 	return next.Server(ctx).Request(ctx, request)


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
We need to generate the interface name only if the mechanism doesn't have one.

## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Modified unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
