### PR TITLE
Run release workflow only when CI passes on release branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
       - completed
     workflows:
       - "ci"
+    branches:
+      - release/*
 jobs:
   print-debug-info:
     name: Print debug info for Release workflow


### PR DESCRIPTION
## Issue
https://github.com/networkservicemesh/.github/issues/67