### PR TITLE
Remove `automerge is completed` trigger from Update dependent repositories workflow

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -4,14 +4,8 @@ on:
   push:
     branches:
       - main
-  workflow_run:
-    types:
-      - completed
-    workflows:
-      - 'automerge'
 jobs:
   update-dependent-repositories:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push' }}
     uses: networkservicemesh/.github/.github/workflows/update-dependent-repositories-gomod.yaml@main
     with:
       dependent_repositories: |


### PR DESCRIPTION
## Issue link
https://github.com/networkservicemesh/.github/issues/67

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [ ] Tested by integration testing
- [x] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [x] CI
