### PR TITLE
Fix fd mem leaks in nsmgr and forwarder

### DIFF
--- a/pkg/networkservice/common/mechanisms/recvfd/client.go
+++ b/pkg/networkservice/common/mechanisms/recvfd/client.go
@@ -2,6 +2,8 @@
 //
 // Copyright (c) 2020-2023 Cisco and/or its affiliates.
 //
+// Copyright (c) 2024  Xored Software Inc and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +70,7 @@ func (r *recvFDClient) Request(ctx context.Context, request *networkservice.Netw
 	// Recv the FD and swap theInode to File in the Parameters for the returned connection mechanism
 	err = recvFDAndSwapInodeToFile(ctx, fileMap, conn.GetMechanism().GetParameters(), recv)
 	if err != nil {
+		closeFiles(conn, &r.fileMaps)
 		return nil, err
 	}
 

--- a/pkg/registry/common/recvfd/client.go
+++ b/pkg/registry/common/recvfd/client.go
@@ -2,6 +2,8 @@
 //
 // Copyright (c) 2023 Cisco and/or its affiliates.
 //
+// Copyright (c) 2024  Xored Software Inc and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,6 +101,9 @@ func (x *recvfdNSEFindClient) Recv() (*registry.NetworkServiceEndpointResponse, 
 
 		// Recv the FD and swap theInode to File in the Parameters for the returned connection mechanism
 		err = recvFDAndSwapInodeToUnix(x.Context(), fileMap, nseResp.GetNetworkServiceEndpoint(), x.transceiver)
+		if err != nil {
+			closeFiles(nseResp.GetNetworkServiceEndpoint(), x.fileMaps)
+		}
 	}
 	return nseResp, err
 }


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description

In case the request or registration was not successful, the FD leak. 
This PR fixes the problem.


## Issue link
Closes https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/1025
Closes https://github.com/networkservicemesh/cmd-nsmgr/issues/675


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
