### PR TITLE
Add an option to expose Prometheus metrics via http/s server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/networkservicemesh/api v1.13.1-0.20240424210452-d0df98851760
 	github.com/open-policy-agent/opa v0.44.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.17.0
 	github.com/r3labs/diff v1.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spiffe/go-spiffe/v2 v2.1.7
@@ -85,7 +86,6 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/openzipkin/zipkin-go v0.4.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect

--- a/pkg/tools/prometheus/prometheus.go
+++ b/pkg/tools/prometheus/prometheus.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 Nordix Foundation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package prometheus provides a set of utilities for assisting with Prometheus data
+package prometheus
+
+import (
+	"os"
+	"strconv"
+)
+
+const (
+	prometheusEnv = "PROMETHEUS"
+)
+
+// IsEnabled returns true if prometheus is enabled
+func IsEnabled() bool {
+	if v, err := strconv.ParseBool(os.Getenv(prometheusEnv)); err == nil {
+		return v
+	}
+	return false
+}

--- a/pkg/tools/prometheus/server.go
+++ b/pkg/tools/prometheus/server.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2024 Nordix Foundation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package prometheus provides a set of utilities for assisting with Prometheus data
+package prometheus
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+// ListenAndServe gathers the certificate and initiates the server to begin handling incoming requests
+func ListenAndServe(ctx context.Context, listenOn string, headerTimeout time.Duration, cancel context.CancelFunc) {
+	metricsServer := server{
+		ListenOn:      listenOn,
+		HeaderTimeout: headerTimeout,
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+	source, err := workloadapi.NewX509Source(ctx)
+	if err != nil {
+		log.FromContext(ctx).Fatalf("error getting x509 source: %v", err.Error())
+	}
+	tlsConfig.GetCertificate = tlsconfig.GetCertificate(source)
+	metricsServer.TLSConfig = tlsConfig
+
+	select {
+	case <-ctx.Done():
+		err = source.Close()
+		log.FromContext(ctx).Errorf("unable to close x509 source: %v", err.Error())
+	default:
+	}
+
+	go func() {
+		err := metricsServer.start(ctx)
+		if err != nil {
+			log.FromContext(ctx).Error(err.Error())
+			cancel()
+		}
+	}()
+}
+
+type server struct {
+	TLSConfig     *tls.Config
+	ListenOn      string
+	HeaderTimeout time.Duration
+}
+
+func (s *server) start(ctx context.Context) error {
+	log.FromContext(ctx).Info("Start metrics server on ", s.ListenOn)
+
+	server := &http.Server{
+		Addr:              s.ListenOn,
+		TLSConfig:         s.TLSConfig,
+		ReadHeaderTimeout: s.HeaderTimeout,
+	}
+
+	http.Handle("/metrics", promhttp.Handler())
+
+	serverCtx, cancel := context.WithCancel(ctx)
+	var ListenAndServeErr error
+
+	go func() {
+		ListenAndServeErr = server.ListenAndServeTLS("", "")
+		if ListenAndServeErr != nil {
+			cancel()
+		}
+	}()
+
+	<-serverCtx.Done()
+
+	if ListenAndServeErr != nil {
+		return errors.Errorf("failed to ListenAndServe on metrics server: %s", ListenAndServeErr)
+	}
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer shutdownCancel()
+
+	err := server.Shutdown(shutdownCtx)
+	if err != nil {
+		return errors.Errorf("failed to shutdown metrics server: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Added a new server that can be utilized to expose Prometheus metrics on via http or https.

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/sdk/issues/1652

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [X] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
