### PR TITLE
Use an extended timeout in case of reselect requests

### DIFF
--- a/pkg/networkservice/common/begin/server_test.go
+++ b/pkg/networkservice/common/begin/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/begin"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
@@ -42,13 +43,18 @@ type waitServer struct {
 
 func (s *waitServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	time.Sleep(waitTime)
-	s.requestDone.Store(1)
+	s.requestDone.Add(1)
 	return next.Server(ctx).Request(ctx, request)
 }
 
 func (s *waitServer) Close(ctx context.Context, connection *networkservice.Connection) (*empty.Empty, error) {
-	time.Sleep(waitTime)
-	s.closeDone.Store(1)
+	afterCh := time.After(time.Second)
+	select {
+	case <-ctx.Done():
+		return &emptypb.Empty{}, nil
+	case <-afterCh:
+		s.closeDone.Add(1)
+	}
 	return next.Server(ctx).Close(ctx, connection)
 }
 
@@ -81,4 +87,39 @@ func TestBeginWorksWithSmallTimeout(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return waitSrv.closeDone.Load() == 1
 	}, waitTime*2, time.Millisecond*500)
+}
+
+func TestBeginHasExtendedTimeoutOnReselect(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+	requestCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
+	defer cancel()
+
+	waitSrv := &waitServer{}
+	server := next.NewNetworkServiceServer(
+		begin.NewServer(),
+		waitSrv,
+	)
+
+	request := testRequest("id")
+	request.Connection.State = networkservice.State_RESELECT_REQUESTED
+
+	_, err := server.Request(requestCtx, request)
+	require.EqualError(t, err, context.DeadlineExceeded.Error())
+	require.Equal(t, int32(0), waitSrv.requestDone.Load())
+	require.Eventually(t, func() bool {
+		return waitSrv.requestDone.Load() == 1
+	}, waitTime*2, time.Millisecond*500)
+
+	requestCtx, cancel = context.WithTimeout(context.Background(), time.Millisecond*200)
+	defer cancel()
+	request.Connection.State = networkservice.State_RESELECT_REQUESTED
+
+	_, err = server.Request(requestCtx, request)
+	require.EqualError(t, err, context.DeadlineExceeded.Error())
+	require.Equal(t, int32(0), waitSrv.closeDone.Load())
+	require.Eventually(t, func() bool {
+		return waitSrv.closeDone.Load() == 1 && waitSrv.requestDone.Load() == 2
+	}, waitTime*4, time.Millisecond*500)
 }


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
We don't use a context with extended timeout in case of `RESELECT_REQUESTED` Closes in `begin`. It leads to leaking interfaces.

## Issue link
https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/1133

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
