### PR TITLE
Use a context with exteded timeout on Requests in begin

### DIFF
--- a/pkg/networkservice/common/begin/options.go
+++ b/pkg/networkservice/common/begin/options.go
@@ -22,9 +22,9 @@ import (
 )
 
 type option struct {
-	cancelCtx    context.Context
-	reselect     bool
-	closeTimeout time.Duration
+	cancelCtx      context.Context
+	reselect       bool
+	contextTimeout time.Duration
 }
 
 // Option - event option
@@ -44,9 +44,9 @@ func WithReselect() Option {
 	}
 }
 
-// WithCloseTimeout - set a custom timeout for a context in begin.Close
-func WithCloseTimeout(timeout time.Duration) Option {
+// WithContextTimeout - set a custom timeout for a context in begin.Close
+func WithContextTimeout(timeout time.Duration) Option {
 	return func(o *option) {
-		o.closeTimeout = timeout
+		o.contextTimeout = timeout
 	}
 }

--- a/pkg/networkservice/common/begin/server.go
+++ b/pkg/networkservice/common/begin/server.go
@@ -101,8 +101,12 @@ func (b *beginServer) Request(ctx context.Context, request *networkservice.Netwo
 			eventFactoryCtxCancel()
 		}
 
+		closeCtx, cancel := context.WithTimeout(context.Background(), b.closeTimeout)
+		defer cancel()
+
 		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
-		conn, err = next.Server(withEventFactoryCtx).Request(withEventFactoryCtx, request)
+		closeCtx = extend.WithValuesFromContext(closeCtx, withEventFactoryCtx)
+		conn, err = next.Server(closeCtx).Request(closeCtx, request)
 		if err != nil {
 			if eventFactoryServer.state != established {
 				eventFactoryServer.state = closed

--- a/pkg/networkservice/common/begin/server.go
+++ b/pkg/networkservice/common/begin/server.go
@@ -33,15 +33,15 @@ import (
 
 type beginServer struct {
 	genericsync.Map[string, *eventFactoryServer]
-	closeTimeout time.Duration
+	contextTimeout time.Duration
 }
 
 // NewServer - creates a new begin chain element
 func NewServer(opts ...Option) networkservice.NetworkServiceServer {
 	o := &option{
-		cancelCtx:    context.Background(),
-		reselect:     false,
-		closeTimeout: time.Minute,
+		cancelCtx:      context.Background(),
+		reselect:       false,
+		contextTimeout: time.Minute,
 	}
 
 	for _, opt := range opts {
@@ -49,7 +49,7 @@ func NewServer(opts ...Option) networkservice.NetworkServiceServer {
 	}
 
 	return &beginServer{
-		closeTimeout: o.closeTimeout,
+		contextTimeout: o.contextTimeout,
 	}
 }
 
@@ -68,7 +68,7 @@ func (b *beginServer) Request(ctx context.Context, request *networkservice.Netwo
 	eventFactoryServer, _ := b.LoadOrStore(request.GetConnection().GetId(),
 		newEventFactoryServer(
 			ctx,
-			b.closeTimeout,
+			b.contextTimeout,
 			func() {
 				b.Delete(request.GetRequestConnection().GetId())
 			},
@@ -101,12 +101,11 @@ func (b *beginServer) Request(ctx context.Context, request *networkservice.Netwo
 			eventFactoryCtxCancel()
 		}
 
-		closeCtx, cancel := context.WithTimeout(context.Background(), b.closeTimeout)
+		extendedCtx, cancel := context.WithTimeout(context.Background(), b.contextTimeout)
+		extendedCtx = extend.WithValuesFromContext(extendedCtx, withEventFactory(ctx, eventFactoryServer))
 		defer cancel()
 
-		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
-		closeCtx = extend.WithValuesFromContext(closeCtx, withEventFactoryCtx)
-		conn, err = next.Server(closeCtx).Request(closeCtx, request)
+		conn, err = next.Server(extendedCtx).Request(extendedCtx, request)
 		if err != nil {
 			if eventFactoryServer.state != established {
 				eventFactoryServer.state = closed
@@ -151,14 +150,13 @@ func (b *beginServer) Close(ctx context.Context, conn *networkservice.Connection
 		if currentServerClient != eventFactoryServer {
 			return
 		}
-		closeCtx, cancel := context.WithTimeout(context.Background(), b.closeTimeout)
+		extendedCtx, cancel := context.WithTimeout(context.Background(), b.contextTimeout)
+		extendedCtx = extend.WithValuesFromContext(extendedCtx, withEventFactory(ctx, eventFactoryServer))
 		defer cancel()
 
 		// Always close with the last valid EventFactory we got
 		conn = eventFactoryServer.request.Connection
-		withEventFactoryCtx := withEventFactory(ctx, eventFactoryServer)
-		closeCtx = extend.WithValuesFromContext(closeCtx, withEventFactoryCtx)
-		_, err = next.Server(closeCtx).Close(closeCtx, conn)
+		_, err = next.Server(extendedCtx).Close(extendedCtx, conn)
 		eventFactoryServer.afterCloseFunc()
 	}):
 		return &emptypb.Empty{}, err

--- a/pkg/networkservice/common/begin/server.go
+++ b/pkg/networkservice/common/begin/server.go
@@ -88,7 +88,7 @@ func (b *beginServer) Request(ctx context.Context, request *networkservice.Netwo
 			eventFactoryServer.request != nil && eventFactoryServer.request.Connection != nil {
 			log.FromContext(ctx).Info("Closing connection due to RESELECT_REQUESTED state")
 
-			closeCtx, cancel := context.WithTimeout(context.Background(), b.closeTimeout)
+			closeCtx, cancel := context.WithTimeout(context.Background(), b.contextTimeout)
 			defer cancel()
 
 			eventFactoryCtx, eventFactoryCtxCancel := eventFactoryServer.ctxFunc()

--- a/pkg/networkservice/common/begin/server_test.go
+++ b/pkg/networkservice/common/begin/server_test.go
@@ -42,8 +42,13 @@ type waitServer struct {
 }
 
 func (s *waitServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
-	time.Sleep(waitTime)
-	s.requestDone.Add(1)
+	afterCh := time.After(time.Second)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-afterCh:
+		s.requestDone.Add(1)
+	}
 	return next.Server(ctx).Request(ctx, request)
 }
 

--- a/pkg/networkservice/common/begin/server_test.go
+++ b/pkg/networkservice/common/begin/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/begin"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
@@ -42,13 +43,18 @@ type waitServer struct {
 
 func (s *waitServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	time.Sleep(waitTime)
-	s.requestDone.Store(1)
+	s.requestDone.Add(1)
 	return next.Server(ctx).Request(ctx, request)
 }
 
 func (s *waitServer) Close(ctx context.Context, connection *networkservice.Connection) (*empty.Empty, error) {
-	time.Sleep(waitTime)
-	s.closeDone.Store(1)
+	afterCh := time.After(time.Second)
+	select {
+	case <-ctx.Done():
+		return &emptypb.Empty{}, nil
+	case <-afterCh:
+		s.closeDone.Add(1)
+	}
 	return next.Server(ctx).Close(ctx, connection)
 }
 
@@ -81,4 +87,39 @@ func TestBeginWorksWithSmallTimeout(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return waitSrv.closeDone.Load() == 1
 	}, waitTime*2, time.Millisecond*500)
+}
+
+func TestBeginHasExtendedTimeoutOnReselect(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+	requestCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
+	defer cancel()
+
+	waitSrv := &waitServer{}
+	server := next.NewNetworkServiceServer(
+		begin.NewServer(),
+		waitSrv,
+	)
+
+	request := testRequest("id")
+	request.Connection.State = networkservice.State_RESELECT_REQUESTED
+
+	_, err := server.Request(requestCtx, request)
+	require.EqualError(t, err, context.DeadlineExceeded.Error())
+	require.Equal(t, int32(0), waitSrv.requestDone.Load())
+	require.Eventually(t, func() bool {
+		return waitSrv.requestDone.Load() == 1
+	}, waitTime*2, time.Millisecond*500)
+
+	requestCtx, cancel = context.WithTimeout(context.Background(), time.Millisecond*200)
+	defer cancel()
+	request.Connection.State = networkservice.State_RESELECT_REQUESTED
+
+	_, err = server.Request(requestCtx, request)
+	require.EqualError(t, err, context.DeadlineExceeded.Error())
+	require.Equal(t, int32(0), waitSrv.closeDone.Load())
+	require.Eventually(t, func() bool {
+		return waitSrv.closeDone.Load() == 1 && waitSrv.requestDone.Load() == 2
+	}, waitTime*4, time.Millisecond*500)
 }

--- a/pkg/networkservice/common/dial/client.go
+++ b/pkg/networkservice/common/dial/client.go
@@ -72,8 +72,12 @@ func (d *dialClient) Request(ctx context.Context, request *networkservice.Networ
 		return next.Client(ctx).Request(ctx, request, opts...)
 	}
 
+	di.mu.Lock()
+	dialClientURL := di.clientURL
+	di.mu.Unlock()
+
 	// If our existing dialer has a different URL close down the chain
-	if di.clientURL != nil && di.clientURL.String() != clientURL.String() {
+	if dialClientURL != nil && dialClientURL.String() != clientURL.String() {
 		closeCtx, closeCancel := closeContextFunc()
 		defer closeCancel()
 		err := di.Dial(closeCtx, di.clientURL)

--- a/pkg/networkservice/common/dial/client.go
+++ b/pkg/networkservice/common/dial/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 Cisco and/or its affiliates.
+// Copyright (c) 2021-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/networkservice/common/dial/dialer.go
+++ b/pkg/networkservice/common/dial/dialer.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/url"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -37,6 +38,7 @@ type dialer struct {
 	*grpc.ClientConn
 	dialOptions []grpc.DialOption
 	dialTimeout time.Duration
+	mu          sync.Mutex
 }
 
 func newDialer(ctx context.Context, dialTimeout time.Duration, dialOptions ...grpc.DialOption) *dialer {
@@ -56,8 +58,10 @@ func (di *dialer) Dial(ctx context.Context, clientURL *url.URL) error {
 		di.cleanupCancel()
 	}
 
+	di.mu.Lock()
 	// Set the clientURL
 	di.clientURL = clientURL
+	di.mu.Unlock()
 
 	// Setup dialTimeout if needed
 	dialCtx := ctx

--- a/pkg/networkservice/common/dial/dialer.go
+++ b/pkg/networkservice/common/dial/dialer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Cisco and/or its affiliates.
+// Copyright (c) 2021-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
These changes should fix leaking interfaces on requests in case of small timeout. 

## Issue link
https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/1133

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
