### PR TITLE
Rework a cache for NS/NSE registry

### DIFF
--- a/pkg/registry/common/querycache/ns_cache.go
+++ b/pkg/registry/common/querycache/ns_cache.go
@@ -33,7 +33,7 @@ type nsCache struct {
 	clockTime     clock.Clock
 }
 
-func newNSCache(ctx context.Context, opts ...Option) *nsCache {
+func newNSCache(ctx context.Context, opts ...NSCacheOption) *nsCache {
 	c := &nsCache{
 		expireTimeout: time.Minute,
 		clockTime:     clock.FromContext(ctx),

--- a/pkg/registry/common/querycache/ns_cache.go
+++ b/pkg/registry/common/querycache/ns_cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edwarnicke/genericsync"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
+
 	"github.com/networkservicemesh/sdk/pkg/tools/clock"
 )
 

--- a/pkg/registry/common/querycache/ns_client.go
+++ b/pkg/registry/common/querycache/ns_client.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package querycache adds possibility to cache Find queries
+package querycache
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/streamchannel"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+type queryCacheNSClient struct {
+	ctx   context.Context
+	cache *nsCache
+}
+
+// NewNetworkServiceClient creates new querycache NS registry client that caches all resolved NSs
+func NewNetworkServiceClient(ctx context.Context, opts ...Option) registry.NetworkServiceRegistryClient {
+	return &queryCacheNSClient{
+		ctx:   ctx,
+		cache: newNSCache(ctx, opts...),
+	}
+}
+
+func (q *queryCacheNSClient) Register(ctx context.Context, nse *registry.NetworkService, opts ...grpc.CallOption) (*registry.NetworkService, error) {
+	return next.NetworkServiceRegistryClient(ctx).Register(ctx, nse, opts...)
+}
+
+func (q *queryCacheNSClient) Find(ctx context.Context, query *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
+	log.FromContext(ctx).WithField("time", time.Now()).Infof("queryCacheNSClient forth")
+	if query.Watch {
+		return next.NetworkServiceRegistryClient(ctx).Find(ctx, query, opts...)
+	}
+
+	log.FromContext(ctx).WithField("time", time.Now()).Info("queryCacheNSClient search in cache")
+	if client, ok := q.findInCache(ctx, query); ok {
+		log.FromContext(ctx).Info("queryCacheNSClient found in cache")
+		return client, nil
+	}
+
+	log.FromContext(ctx).WithField("time", time.Now()).Info("queryCacheNSClient not found in cache")
+
+	client, err := next.NetworkServiceRegistryClient(ctx).Find(ctx, query, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	nses := registry.ReadNetworkServiceList(client)
+
+	resultCh := make(chan *registry.NetworkServiceResponse, len(nses))
+	for _, nse := range nses {
+		resultCh <- &registry.NetworkServiceResponse{NetworkService: nse}
+		q.storeInCache(ctx, nse.Clone(), opts...)
+	}
+	close(resultCh)
+
+	return streamchannel.NewNetworkServiceFindClient(ctx, resultCh), nil
+}
+
+func (q *queryCacheNSClient) findInCache(ctx context.Context, query *registry.NetworkServiceQuery) (registry.NetworkServiceRegistry_FindClient, bool) {
+	log.FromContext(ctx).WithField("time", time.Now()).Infof("queryCacheNSClient checking key: %v", query.NetworkService)
+	ns := q.cache.Load(ctx, query.NetworkService)
+	if ns == nil {
+		return nil, false
+	}
+
+	log.FromContext(ctx).WithField("time", time.Now()).Infof("found NS in cache: %v", ns)
+
+	resultCh := make(chan *registry.NetworkServiceResponse, 1)
+	resultCh <- &registry.NetworkServiceResponse{NetworkService: ns.Clone()}
+	close(resultCh)
+
+	return streamchannel.NewNetworkServiceFindClient(ctx, resultCh), true
+}
+
+func (q *queryCacheNSClient) storeInCache(ctx context.Context, ns *registry.NetworkService, opts ...grpc.CallOption) {
+	nsQuery := &registry.NetworkServiceQuery{
+		NetworkService: &registry.NetworkService{
+			Name: ns.Name,
+		},
+	}
+
+	findCtx, cancel := context.WithCancel(q.ctx)
+
+	entry, loaded := q.cache.LoadOrStore(ns, cancel)
+	if loaded {
+		cancel()
+		return
+	}
+
+	go func() {
+		defer entry.Cleanup()
+
+		nsQuery.Watch = true
+
+		stream, err := next.NetworkServiceRegistryClient(ctx).Find(findCtx, nsQuery, opts...)
+		if err != nil {
+			return
+		}
+
+		for nsResp, err := stream.Recv(); err == nil; nsResp, err = stream.Recv() {
+			if nsResp.NetworkService.Name != nsQuery.NetworkService.Name {
+				continue
+			}
+			if nsResp.Deleted {
+				break
+			}
+
+			entry.Update(nsResp.NetworkService)
+		}
+	}()
+}
+
+func (q *queryCacheNSClient) Unregister(ctx context.Context, in *registry.NetworkService, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.NetworkServiceRegistryClient(ctx).Unregister(ctx, in, opts...)
+}

--- a/pkg/registry/common/querycache/ns_client.go
+++ b/pkg/registry/common/querycache/ns_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/registry/common/querycache/ns_client_test.go
+++ b/pkg/registry/common/querycache/ns_client_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-Licens-Identifier: Apache-2.0
+//
+// Licensd under the Apache Licens, Version 2.0 (the "Licens");
+// you may not use this file except in compliance with the Licens.
+// You may obtain a copy of the Licens at:
+//
+//     http://www.apache.org/licenss/LICEns-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Licens is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Licens for the specific language governing permissions and
+// limitations under the Licens.
+
+package querycache_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk/pkg/registry/common/memory"
+	"github.com/networkservicemesh/sdk/pkg/registry/common/querycache"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
+	"github.com/networkservicemesh/sdk/pkg/registry/core/next"
+	"github.com/networkservicemesh/sdk/pkg/tools/clock"
+	"github.com/networkservicemesh/sdk/pkg/tools/clockmock"
+)
+
+const (
+	payload1 = "ethernet"
+	payload2 = "ip"
+)
+
+func testNSQuery(nsName string) *registry.NetworkServiceQuery {
+	return &registry.NetworkServiceQuery{
+		NetworkService: &registry.NetworkService{
+			Name: nsName,
+		},
+	}
+}
+
+func Test_QueryCacheClient_ShouldCacheNSs(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mem := memory.NewNetworkServiceRegistryServer()
+
+	failureClient := new(failureNSClient)
+	c := next.NewNetworkServiceRegistryClient(
+		querycache.NewNetworkServiceClient(ctx, querycache.WithNSExpireTimeout(expireTimeout)),
+		failureClient,
+		adapters.NetworkServiceServerToClient(mem),
+	)
+
+	reg, err := mem.Register(ctx, &registry.NetworkService{
+		Name:    name,
+		Payload: payload1,
+	})
+	require.NoError(t, err)
+
+	// Goroutines should be cleaned up on ns unregister
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	// 1. Find from memory
+	atomic.StoreInt32(&failureClient.shouldFail, 0)
+
+	stream, err := c.Find(ctx, testNSQuery(""))
+	require.NoError(t, err)
+	nsResp, err := stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, name, nsResp.NetworkService.Name)
+
+	// 2. Find from cache
+	atomic.StoreInt32(&failureClient.shouldFail, 1)
+
+	stream, err = c.Find(ctx, testNSQuery(name))
+	require.NoError(t, err)
+	nsResp, err = stream.Recv()
+	require.NoError(t, err)
+	require.Equal(t, name, nsResp.NetworkService.Name)
+
+	// 3. Update NS in memory
+	reg.Payload = payload2
+	reg, err = mem.Register(ctx, reg)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		if stream, err = c.Find(ctx, testNSQuery(name)); err != nil {
+			return false
+		}
+		if nsResp, err = stream.Recv(); err != nil {
+			return false
+		}
+		return name == nsResp.NetworkService.Name && payload2 == nsResp.NetworkService.Payload
+	}, testWait, testTick)
+
+	// 4. Delete ns from memory
+	_, err = mem.Unregister(ctx, reg)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, err = c.Find(ctx, testNSQuery(name))
+		return err != nil
+	}, testWait, testTick)
+}
+
+func Test_QueryCacheClient_ShouldCleanUpNSOnTimeout(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clockMock := clockmock.New(ctx)
+	ctx = clock.WithClock(ctx, clockMock)
+
+	mem := memory.NewNetworkServiceRegistryServer()
+
+	failureClient := new(failureNSClient)
+	c := next.NewNetworkServiceRegistryClient(
+		querycache.NewNetworkServiceClient(ctx, querycache.WithNSExpireTimeout(expireTimeout)),
+		failureClient,
+		adapters.NetworkServiceServerToClient(mem),
+	)
+
+	_, err := mem.Register(ctx, &registry.NetworkService{
+		Name: name,
+	})
+	require.NoError(t, err)
+
+	// Goroutines should be cleaned up on cache entry expiration
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	// 1. Find from memory
+	atomic.StoreInt32(&failureClient.shouldFail, 0)
+
+	stream, err := c.Find(ctx, testNSQuery(""))
+	require.NoError(t, err)
+
+	_, err = stream.Recv()
+	require.NoError(t, err)
+
+	// 2. Find from cache
+	atomic.StoreInt32(&failureClient.shouldFail, 1)
+
+	require.Eventually(t, func() bool {
+		if stream, err = c.Find(ctx, testNSQuery(name)); err == nil {
+			_, err = stream.Recv()
+		}
+		return err == nil
+	}, testWait, testTick)
+
+	// 3. Keep finding from cache to prevent expiration
+	for start := clockMock.Now(); clockMock.Since(start) < 2*expireTimeout; clockMock.Add(expireTimeout / 3) {
+		stream, err = c.Find(ctx, testNSQuery(name))
+		require.NoError(t, err)
+
+		_, err = stream.Recv()
+		require.NoError(t, err)
+	}
+
+	// 4. Wait for the expire to happen
+	clockMock.Add(expireTimeout)
+
+	_, err = c.Find(ctx, testNSQuery(name))
+	require.Errorf(t, err, "find error")
+}
+
+type failureNSClient struct {
+	shouldFail int32
+}
+
+func (c *failureNSClient) Register(ctx context.Context, ns *registry.NetworkService, opts ...grpc.CallOption) (*registry.NetworkService, error) {
+	return next.NetworkServiceRegistryClient(ctx).Register(ctx, ns, opts...)
+}
+
+func (c *failureNSClient) Find(ctx context.Context, query *registry.NetworkServiceQuery, opts ...grpc.CallOption) (registry.NetworkServiceRegistry_FindClient, error) {
+	if atomic.LoadInt32(&c.shouldFail) == 1 && !query.Watch {
+		return nil, errors.New("find error")
+	}
+	return next.NetworkServiceRegistryClient(ctx).Find(ctx, query, opts...)
+}
+
+func (c *failureNSClient) Unregister(ctx context.Context, ns *registry.NetworkService, opts ...grpc.CallOption) (*empty.Empty, error) {
+	return next.NetworkServiceRegistryClient(ctx).Unregister(ctx, ns, opts...)
+}

--- a/pkg/registry/common/querycache/ns_client_test.go
+++ b/pkg/registry/common/querycache/ns_client_test.go
@@ -1,18 +1,18 @@
-// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2024 Cisco and/or its affiliates.
 //
-// SPDX-Licens-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0
 //
-// Licensd under the Apache Licens, Version 2.0 (the "Licens");
-// you may not use this file except in compliance with the Licens.
-// You may obtain a copy of the Licens at:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
 //
-//     http://www.apache.org/licenss/LICEns-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the Licens is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the Licens for the specific language governing permissions and
-// limitations under the Licens.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package querycache_test
 

--- a/pkg/registry/common/querycache/nse_cache.go
+++ b/pkg/registry/common/querycache/nse_cache.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package querycache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/edwarnicke/genericsync"
+
+	"github.com/networkservicemesh/api/pkg/api/registry"
+	"github.com/networkservicemesh/sdk/pkg/tools/clock"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+type nseCache struct {
+	expireTimeout time.Duration
+	entries       genericsync.Map[string, *cacheEntry[registry.NetworkServiceEndpoint]]
+	clockTime     clock.Clock
+}
+
+func newNSECache(ctx context.Context, opts ...Option) *nseCache {
+	c := &nseCache{
+		expireTimeout: time.Minute,
+		clockTime:     clock.FromContext(ctx),
+	}
+
+	// for _, opt := range opts {
+	// 	opt(c)
+	// }
+
+	ticker := c.clockTime.Ticker(c.expireTimeout)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C():
+				c.entries.Range(func(_ string, e *cacheEntry[registry.NetworkServiceEndpoint]) bool {
+					e.lock.Lock()
+					defer e.lock.Unlock()
+
+					if c.clockTime.Until(e.expirationTime) < 0 {
+						e.cleanup()
+					}
+					return true
+				})
+			}
+		}
+	}()
+
+	return c
+}
+
+func (c *nseCache) LoadOrStore(value *registry.NetworkServiceEndpoint, cancel context.CancelFunc) (*cacheEntry[registry.NetworkServiceEndpoint], bool) {
+	var once sync.Once
+
+	entry, ok := c.entries.LoadOrStore(value.GetName(), &cacheEntry[registry.NetworkServiceEndpoint]{
+		value:          value,
+		expirationTime: c.clockTime.Now().Add(c.expireTimeout),
+		cleanup: func() {
+			once.Do(func() {
+				c.entries.Delete(value.GetName())
+				cancel()
+			})
+		}})
+
+	return entry, ok
+}
+
+func (c *nseCache) add(entry *cacheEntry[registry.NetworkServiceEndpoint], values []*registry.NetworkServiceEndpoint) []*registry.NetworkServiceEndpoint {
+	entry.lock.Lock()
+	defer entry.lock.Unlock()
+	if c.clockTime.Until(entry.expirationTime) < 0 {
+		entry.cleanup()
+	} else {
+		entry.expirationTime = c.clockTime.Now().Add(c.expireTimeout)
+		values = append(values, entry.value)
+	}
+
+	return values
+}
+
+// Checks if a is a subset of b
+func subset(a, b []string) bool {
+	set := make(map[string]struct{})
+	for _, value := range a {
+		set[value] = struct{}{}
+	}
+
+	for _, value := range b {
+		if _, found := set[value]; !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (c *nseCache) Load(ctx context.Context, query *registry.NetworkServiceEndpointQuery) []*registry.NetworkServiceEndpoint {
+	values := make([]*registry.NetworkServiceEndpoint, 0)
+
+	log.FromContext(ctx).WithField("time", time.Now()).Infof("query: %v\n", query)
+
+	if query.NetworkServiceEndpoint.Name != "" {
+		entry, ok := c.entries.Load(query.NetworkServiceEndpoint.Name)
+		if ok {
+			values = c.add(entry, values)
+		}
+		return values
+	}
+
+	log.FromContext(ctx).WithField("time", time.Now()).Infof("Range")
+	c.entries.Range(func(key string, entry *cacheEntry[registry.NetworkServiceEndpoint]) bool {
+		log.FromContext(ctx).WithField("time", time.Now()).Infof("key: %v\n", key)
+		log.FromContext(ctx).WithField("time", time.Now()).Infof("entry.value: %v\n", entry.value)
+		if subset(query.NetworkServiceEndpoint.NetworkServiceNames, entry.value.NetworkServiceNames) {
+			log.FromContext(ctx).WithField("time", time.Now()).Infof("adding entry to nses\n")
+			values = c.add(entry, values)
+		}
+		return true
+	})
+
+	log.FromContext(ctx).WithField("time", time.Now()).Infof("values: %v\n", values)
+
+	return values
+}

--- a/pkg/registry/common/querycache/nse_cache.go
+++ b/pkg/registry/common/querycache/nse_cache.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
-// Copyright (c) 2023 Cisco and/or its affiliates.
+// Copyright (c) 2023-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -26,6 +26,7 @@ import (
 	"github.com/edwarnicke/genericsync"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
+
 	"github.com/networkservicemesh/sdk/pkg/tools/clock"
 )
 

--- a/pkg/registry/common/querycache/nse_client.go
+++ b/pkg/registry/common/querycache/nse_client.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/registry/common/querycache/nse_client_test.go
+++ b/pkg/registry/common/querycache/nse_client_test.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/registry/common/querycache/nse_client_test.go
+++ b/pkg/registry/common/querycache/nse_client_test.go
@@ -64,7 +64,7 @@ func Test_QueryCacheClient_ShouldCacheNSEs(t *testing.T) {
 
 	failureClient := new(failureNSEClient)
 	c := next.NewNetworkServiceEndpointRegistryClient(
-		querycache.NewClient(ctx, querycache.WithExpireTimeout(expireTimeout)),
+		querycache.NewNetworkServiceEndpointClient(ctx, querycache.WithExpireTimeout(expireTimeout)),
 		failureClient,
 		adapters.NetworkServiceEndpointServerToClient(mem),
 	)
@@ -142,7 +142,7 @@ func Test_QueryCacheClient_ShouldCleanUpOnTimeout(t *testing.T) {
 
 	failureClient := new(failureNSEClient)
 	c := next.NewNetworkServiceEndpointRegistryClient(
-		querycache.NewClient(ctx, querycache.WithExpireTimeout(expireTimeout)),
+		querycache.NewNetworkServiceEndpointClient(ctx, querycache.WithExpireTimeout(expireTimeout)),
 		failureClient,
 		adapters.NetworkServiceEndpointServerToClient(mem),
 	)

--- a/pkg/registry/common/querycache/option.go
+++ b/pkg/registry/common/querycache/option.go
@@ -19,11 +19,11 @@ package querycache
 import "time"
 
 // Option is an option for cache
-type Option func(c *cache)
+type Option func(c *nsCache)
 
 // WithExpireTimeout sets cache expire timeout
 func WithExpireTimeout(expireTimeout time.Duration) Option {
-	return func(c *cache) {
+	return func(c *nsCache) {
 		c.expireTimeout = expireTimeout
 	}
 }

--- a/pkg/registry/common/querycache/option.go
+++ b/pkg/registry/common/querycache/option.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/registry/common/querycache/option.go
+++ b/pkg/registry/common/querycache/option.go
@@ -18,12 +18,22 @@ package querycache
 
 import "time"
 
-// Option is an option for cache
-type Option func(c *nsCache)
+// NSCacheOption is an option for NS cache
+type NSCacheOption func(c *nsCache)
 
-// WithExpireTimeout sets cache expire timeout
-func WithExpireTimeout(expireTimeout time.Duration) Option {
+// NSECacheOption is an option for NSE cache
+type NSECacheOption func(c *nseCache)
+
+// WithNSExpireTimeout sets NS cache expire timeout
+func WithNSExpireTimeout(expireTimeout time.Duration) NSCacheOption {
 	return func(c *nsCache) {
+		c.expireTimeout = expireTimeout
+	}
+}
+
+// WithNSEExpireTimeout sets NSE cache expire timeout
+func WithNSEExpireTimeout(expireTimeout time.Duration) NSECacheOption {
+	return func(c *nseCache) {
 		c.expireTimeout = expireTimeout
 	}
 }


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Add a simple cache that saves all responses from a registry in a map for some period of time.

## Issue link
https://github.com/networkservicemesh/sdk/issues/1666


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [x] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
