### PR TITLE
Increase timeout for all sandbox heal tests

### DIFF
--- a/pkg/networkservice/chains/nsmgr/heal_test.go
+++ b/pkg/networkservice/chains/nsmgr/heal_test.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	tick       = 10 * time.Millisecond
-	timeout    = 10 * time.Second
+	timeout    = 15 * time.Second
 	labelKey   = "key"
 	labelValue = "value"
 )


### PR DESCRIPTION
## Description
It looks like some of the failing unit tests just don't have enough test timeout

## Issue
https://github.com/networkservicemesh/deployments-k8s/issues/12544