### PR TITLE
Increase dial timeout in nsmgr

### DIFF
--- a/pkg/networkservice/chains/nsmgr/server.go
+++ b/pkg/networkservice/chains/nsmgr/server.go
@@ -225,7 +225,7 @@ func NewServer(ctx context.Context, tokenGenerator token.GeneratorFunc, options 
 		authorizeNSERegistryServer:       registryauthorize.NewNetworkServiceEndpointRegistryServer(registryauthorize.Any()),
 		authorizeNSERegistryClient:       registryauthorize.NewNetworkServiceEndpointRegistryClient(registryauthorize.Any()),
 		defaultExpiration:                time.Minute,
-		dialTimeout:                      time.Millisecond * 300,
+		dialTimeout:                      time.Second * 15,
 		name:                             "nsmgr-" + uuid.New().String(),
 		forwarderServiceName:             "forwarder",
 	}


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Increase context timeout for grpc dial connections.

## Issue link
<!--- Please link to the issue here. -->
networkservicemesh/deployments-k8s/issues/13484

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [ ] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
